### PR TITLE
Repo maintenance: auto-assign, branch cleanup, rebase, Docker Hub sync

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,9 @@ updates:
       interval: "weekly"
     commit-message:
       prefix: "ci"
+    assignees:
+      - "csmarshall"
+    open-pull-requests-limit: 99
 
   # Docker
   - package-ecosystem: "docker"
@@ -15,3 +18,6 @@ updates:
       interval: "weekly"
     commit-message:
       prefix: "docker"
+    assignees:
+      - "csmarshall"
+    open-pull-requests-limit: 99

--- a/.github/workflows/dependabot-rebase.yml
+++ b/.github/workflows/dependabot-rebase.yml
@@ -1,0 +1,41 @@
+name: Dependabot Rebase
+
+on:
+  schedule:
+    # Run weekly on Mondays at 09:00 UTC
+    - cron: "0 9 * * 1"
+  workflow_dispatch:
+
+jobs:
+  rebase:
+    name: Rebase Dependabot PRs
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      contents: write
+    steps:
+      - name: Rebase open Dependabot PRs
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const pulls = await github.rest.pulls.list({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+            });
+
+            const dependabotPRs = pulls.data.filter(
+              pr => pr.user.login === 'dependabot[bot]'
+            );
+
+            for (const pr of dependabotPRs) {
+              console.log(`Requesting rebase for PR #${pr.number}: ${pr.title}`);
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: pr.number,
+                body: '@dependabot rebase',
+              });
+            }
+
+            console.log(`Rebased ${dependabotPRs.length} Dependabot PRs`);

--- a/.github/workflows/dockerhub-readme.yml
+++ b/.github/workflows/dockerhub-readme.yml
@@ -1,0 +1,19 @@
+name: Docker Hub README Sync
+
+on:
+  workflow_dispatch:
+
+jobs:
+  sync:
+    name: Sync README to Docker Hub
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Update Docker Hub description
+        uses: peter-evans/dockerhub-description@v4
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          repository: ${{ secrets.DOCKERHUB_USERNAME }}/gluetun-monitor
+          readme-filepath: ./README.md

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,6 +63,14 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
+      - name: Update Docker Hub description
+        uses: peter-evans/dockerhub-description@v4
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+          repository: ${{ secrets.DOCKERHUB_USERNAME }}/gluetun-monitor
+          readme-filepath: ./README.md
+
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,7 +67,7 @@ jobs:
         uses: peter-evans/dockerhub-description@v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
           repository: ${{ secrets.DOCKERHUB_USERNAME }}/gluetun-monitor
           readme-filepath: ./README.md
 


### PR DESCRIPTION
## Summary

Housekeeping improvements for repo management:

- **Dependabot auto-assign:** PRs now auto-assign to @csmarshall
- **Open PR limit:** Increased from default 5 to 99 so Dependabot doesn't skip updates
- **Auto-delete branches:** Enabled on repo (already applied via API)
- **Dependabot rebase workaround:** Weekly workflow comments `@dependabot rebase` on stale PRs to work around GitHub's 30-day automatic rebase timeout
- **Docker Hub README sync:** Pushes `README.md` to Docker Hub description on each release via `peter-evans/dockerhub-description`, using existing `DOCKERHUB_TOKEN`
- **Standalone README sync workflow:** Manual dispatch to test Docker Hub sync without cutting a release

## Notes

- The rebase workflow can also be triggered manually via `workflow_dispatch`
- After merging, trigger the `Docker Hub README Sync` workflow manually to verify the token works for description updates. If it fails, we'll need a `DOCKERHUB_PASSWORD` secret with a full-access token

## Test plan

- [ ] CI passes
- [ ] After merge: trigger `Docker Hub README Sync` workflow to verify token works
- [ ] Verify Dependabot assigns next PR to csmarshall