### PR TITLE
Auto-assign PRs to csmarshall + add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,4 @@
+# Default reviewer for every pull request.
+# GitHub will not request review from the PR author, so this only applies to
+# contributor PRs — your own PRs need the auto-assign workflow instead.
+* @csmarshall

--- a/.github/workflows/auto-assign.yml
+++ b/.github/workflows/auto-assign.yml
@@ -1,0 +1,35 @@
+name: Auto-assign PRs
+
+on:
+  pull_request:
+    types: [opened, reopened]
+
+jobs:
+  assign:
+    name: Assign csmarshall
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      issues: write
+    steps:
+      - name: Add csmarshall as assignee
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const assignee = 'csmarshall';
+
+            // Skip if already assigned (e.g. dependabot PRs already assign via dependabot.yml)
+            const existing = context.payload.pull_request.assignees || [];
+            if (existing.some(a => a.login === assignee)) {
+              console.log(`PR #${context.issue.number} already assigned to ${assignee}`);
+              return;
+            }
+
+            await github.rest.issues.addAssignees({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              assignees: [assignee],
+            });
+
+            console.log(`Assigned PR #${context.issue.number} to ${assignee}`);


### PR DESCRIPTION
## Summary
- `.github/CODEOWNERS` with `* @csmarshall` — GitHub auto-requests review on contributor PRs (no effect on your own PRs, GitHub blocks self-review-request).
- `.github/workflows/auto-assign.yml` — on every `opened`/`reopened` PR, assigns `csmarshall` if not already an assignee. Covers your own PRs and contributor PRs; no-ops on Dependabot PRs which `dependabot.yml` already handles.

## Test plan
- [ ] Workflow runs against this PR itself once merged (or use a fresh PR after merge to confirm)
- [ ] CODEOWNERS request shows on the next contributor PR