### PR TITLE
v2.0.0: Python reimplementation with dependent-aware health + self-healing (#20)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,16 @@
 version: 2
 updates:
+  # Python (the v2 package + dev tooling, via pyproject.toml)
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "deps"
+    assignees:
+      - "csmarshall"
+    open-pull-requests-limit: 99
+
   # GitHub Actions
   - package-ecosystem: "github-actions"
     directory: "/"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,11 @@ jobs:
       - name: Mypy (strict types)
         run: mypy gluetun_monitor
 
+      - name: pip-audit (dependency CVEs)
+        run: |
+          pip install pip-audit
+          pip-audit
+
       - name: Pytest (incl. differential vs. legacy bash)
         # Floor is set below the current ~99% so a real regression fails the build
         # without flaking on trivial churn.
@@ -139,4 +144,23 @@ jobs:
           # Cleanup
           docker stop test-monitor-proxy test-socket-proxy || true
           docker rm test-monitor-proxy test-socket-proxy || true
+
+      - name: Test PUID/PGID drops privileges and chowns /logs
+        run: |
+          # Default (no PUID) runs as root = drop-in; setting PUID/PGID opts into
+          # non-root: the entrypoint chowns the /logs mount to that uid and drops.
+          echo "https://www.google.com" > sites.conf
+          mkdir -p puidlogs
+          docker run --rm \
+            -v $(pwd)/sites.conf:/config/sites.conf:ro \
+            -v $(pwd)/puidlogs:/logs \
+            -e DOCKER_HOST=tcp://127.0.0.1:1 \
+            -e GLUETUN_CONTAINER=nonexistent \
+            -e PUID=1000 -e PGID=1000 \
+            gluetun-monitor:test > puid.log 2>&1 || true
+
+          # Banner still prints (it started)...
+          grep -q "Gluetun Monitor starting" puid.log
+          # ...and the entrypoint chowned the mount to PUID before dropping.
+          test "$(stat -c %u ./puidlogs)" = "1000"
           docker network rm test-docker-proxy || true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,8 +7,31 @@ on:
     branches: [main]
 
 jobs:
+  python:
+    name: Python (lint, types, tests)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+
+      - name: Install package + dev tooling
+        run: pip install -e '.[dev]'
+
+      - name: Ruff (lint)
+        run: ruff check gluetun_monitor tests
+
+      - name: Mypy (strict types)
+        run: mypy gluetun_monitor
+
+      - name: Pytest (incl. differential vs. legacy bash)
+        run: pytest --cov=gluetun_monitor --cov-report=term-missing
+
   shellcheck:
-    name: Shellcheck
+    name: Shellcheck (legacy script)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -18,8 +41,8 @@ jobs:
           scandir: '.'
           format: tty
 
-  test:
-    name: Tests
+  bats:
+    name: Bats (legacy regression)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -29,7 +52,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y bats
 
-      - name: Run unit tests
+      - name: Run legacy bats tests
         run: bats tests/
 
   build:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,9 @@ jobs:
         run: mypy gluetun_monitor
 
       - name: Pytest (incl. differential vs. legacy bash)
-        run: pytest --cov=gluetun_monitor --cov-report=term-missing
+        # Floor is set below the current ~99% so a real regression fails the build
+        # without flaking on trivial churn.
+        run: pytest --cov=gluetun_monitor --cov-report=term-missing --cov-fail-under=95
 
   shellcheck:
     name: Shellcheck (legacy script)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,11 +46,14 @@ jobs:
           images: |
             ghcr.io/${{ github.repository }}
             docker.io/${{ secrets.DOCKERHUB_USERNAME }}/${{ env.IMAGE_NAME }}
+          # latest=auto: `:latest` follows non-prerelease semver tags only. The EOL
+          # v1 branch sets latest=false so old-major patches never claim `:latest`.
+          flavor: |
+            latest=auto
           tags: |
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}
-            type=raw,value=latest
 
       - name: Build and push
         uses: docker/build-push-action@v7

--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,18 @@ session-state.md
 
 # Local experiment/repro scripts (kept as reference, not committed)
 issue*.sh
+
+# Python
+__pycache__/
+*.py[cod]
+.venv/
+venv/
+*.egg-info/
+build/
+dist/
+.pytest_cache/
+.mypy_cache/
+.ruff_cache/
+.coverage
+.coverage.*
+htmlcov/

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,10 @@ docker-compose.yml
 # Local overrides
 docker-compose.override.yml
 
+# Personal local backups of the live compose (may contain real names)
+docker-compose.yml.*-backup
+*.bak
+
 # Editor files
 *.swp
 *.swo

--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ session-state.md
 
 # Local experiment/repro scripts (kept as reference, not committed)
 issue*.sh
+build-smoketest.sh
 
 # Python
 __pycache__/

--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ session-state.md
 # Local experiment/repro scripts (kept as reference, not committed)
 issue*.sh
 build-smoketest.sh
+rebuild-and-validate.sh
 
 # Python
 __pycache__/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [2.0.0] - 2026-05-28
+## [2.0.0] - 2026-06-03
 
 ### Changed
 - **Reimplemented in Python** (docker-py SDK) — see

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   is not auto-recreated — an orphan whose parent is gone can't be confirmed as a
   gluetun dependent (Tenet 1).
 
+### Fixed
+- **Per-dependent viability no longer false-fails on busybox-wget dependents.**
+  The probe classified results by GNU wget's exit codes (0/6/8 = responded), but
+  dependent containers commonly run **busybox wget** (linuxserver/Alpine images),
+  which returns exit 1 for any HTTP error response — so a harmless 404/403 from a
+  dependent was misread as a failure (and could trigger a spurious restart).
+  Classification is now HTTP-response-first and, for dependents, keys on **DNS
+  resolution** only: any HTTP response or a resolved-but-unreached site counts as
+  viable; only a real DNS-resolution failure does not (dependents share gluetun's
+  netns, so DNS is the sole per-container fault — strands are caught by the
+  interface check). Failures now log wget's actual reason instead of a bare
+  "Generic error".
+
 ### Changed (behavior)
 - **Configuration is now validated; bad config is fatal (exit non-zero) instead
   of guessed around.** A malformed env value (bad int/bool/`LOG_LEVEL`), no

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -132,13 +132,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   rather than silently passing.
 
 ### Security & robustness
-- **Runs as a non-root user** (default uid/gid 1000 — the typical first host user)
-  in the image. The real privilege is the Docker API it talks to, not its
-  in-container uid — but there's no reason to run as root. A `/logs` owned by uid
-  1000 is writable as-is; otherwise override `user:` to match (or `chown` the dir).
-  If it isn't writable the monitor still runs and logs to stdout. The direct-socket
-  compose variant adds `group_add` for the host `docker` group (the socket-proxy
-  path needs nothing).
+- **Optional non-root via `PUID`/`PGID`** (LinuxServer.io-style). Set them and the
+  entrypoint chowns `/logs` and drops privileges to that uid/gid — no manual chown.
+  Unset, the container runs as **root, exactly like v1**, so the upgrade stays
+  drop-in (running non-root is recommended, not required). The real privilege is
+  the Docker API it talks to, not its in-container uid. (Direct socket mount +
+  non-root: use Docker's `user:` + `group_add` — the privilege drop resets
+  supplementary groups; the socket-proxy path needs nothing.)
 - **Site entries can no longer be turned into command-line options.** A
   `sites.conf` / `SITES` entry like `--directory-prefix=/etc` was appended bare to
   `wget`/`getent`/`ping`; GNU wget would parse it as a flag (and could write files

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   with `sites.conf`, for config-via-env parity with the other knobs. Either
   source works; at least one site total is required. `sites.conf` is re-read each
   loop (live-editable); `SITES` is fixed at startup.
+- **`EXCLUDE_CONTAINERS` env var** — comma-separated denylist of containers to
+  never manage. Filters auto-discovery and subtracts from an explicit list. On
+  overlap with `DEPENDENT_CONTAINERS`, exclude wins with a warning ("first, do no
+  harm"); an exclude name matching nothing warns (likely typo).
 
 ### Changed (behavior)
 - **Configuration is now validated; bad config is fatal (exit non-zero) instead

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,9 +66,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   90). Knobs: `ADVISORY_WINDOW`, `ADVISORY_MIN_RESTARTS`, `ADVISORY_DOMINANCE`,
   `STATS_RETENTION_DAYS`.
 - **Per-dependent interface check is now shown at DEBUG** — each dependent logs
-  its L3 route check (`interface=live [eth0,lo,tun0]` / `stranded [lo]` /
-  `unknown`) alongside the DNS viability result, so "can it route out" is visible
-  every loop.
+  its L3 route check (`interface check: live [eth0,lo,tun0]` / `stranded [lo]` /
+  `unknown`) *before* its DNS/connect viability line, so "can it route out" is
+  visible every loop. Every test line is tagged with the container's role +
+  name — `[gateway:<gluetun>]` (site tests, run through the tunnel) or
+  `[dependent:<name>]` — and the viability label is honest about depth
+  (`resolved + connected (HTTP 200)` vs `resolved (DNS lookup only)`).
+- **Log files are rotated** so the watchdog can't fill its own disk: the `/logs`
+  file is size-capped (`LOG_MAX_BYTES` ≈10 MB × `LOG_BACKUP_COUNT` 5; `0`
+  disables). The compose example also caps the Docker/stderr stream
+  (`logging: max-size/max-file`), which Docker does *not* rotate on its own.
 
 ### Fixed
 - **Per-dependent viability no longer false-fails on busybox-wget dependents.**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,8 +59,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   gluetun restarts the monitor logs a once-per-episode **flaky-site advisory**
   ("X of the last Y restarts were this site over the last <window> — review it").
   By design it still applies the cheap restart fix and escalates to a human rather
-  than auto-suppressing the site. Knobs: `ADVISORY_WINDOW`, `ADVISORY_MIN_RESTARTS`,
-  `ADVISORY_DOMINANCE`, `STATS_SAVE_EVERY`.
+  than auto-suppressing the site. Per-site metrics also include the **longest
+  failure streak** (worst consecutive run of failed polls). The file is written
+  every loop, crash/power-loss-safely (temp file + fsync + atomic rename), and a
+  site removed from `sites.conf` is pruned after `STATS_RETENTION_DAYS` (default
+  90). Knobs: `ADVISORY_WINDOW`, `ADVISORY_MIN_RESTARTS`, `ADVISORY_DOMINANCE`,
+  `STATS_RETENTION_DAYS`.
+- **Per-dependent interface check is now shown at DEBUG** — each dependent logs
+  its L3 route check (`interface=live [eth0,lo,tun0]` / `stranded [lo]` /
+  `unknown`) alongside the DNS viability result, so "can it route out" is visible
+  every loop.
 
 ### Fixed
 - **Per-dependent viability no longer false-fails on busybox-wget dependents.**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,7 +61,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ("X of the last Y restarts were this site over the last <window> — review it").
   By design it still applies the cheap restart fix and escalates to a human rather
   than auto-suppressing the site. Per-site metrics also include the **longest
-  failure streak** (worst consecutive run of failed polls). The file is written
+  failure streak**, a **failure-reason breakdown** (dns/tls/timeout/connection/
+  http-error/other), **response-latency** of successful polls (avg/min/max +
+  **p50/p90/p99**), and **restart-effectiveness** (fraction of a site's restarts
+  that actually cleared it — a site-vs-VPN signal). The file is written
   every loop, crash/power-loss-safely (temp file + fsync + atomic rename), and a
   site removed from `sites.conf` is pruned after `STATS_RETENTION_DAYS` (default
   90). Knobs: `ADVISORY_WINDOW`, `ADVISORY_MIN_RESTARTS`, `ADVISORY_DOMINANCE`,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   restart-effectiveness) plus monitor-wide totals. Sortable (`--sort`), with a
   `--json` mode for jq/dashboards. Reads the same file via the same code the
   monitor uses, so the numbers always match; touches no Docker API.
+- **All-time latency percentiles** alongside the recent window. A per-site
+  bounded **histogram** (DDSketch-style, [ADR-0009](docs/adr/0009-all-time-latency-histogram.md))
+  records every successful poll's latency for the site's whole life — within 5%
+  relative error at a few dozen buckets/site — so you get a *lifetime* baseline,
+  not just the last 200 samples (the recent ring). Exact count/avg/min/max are
+  kept too. View it with `gluetun-monitor-stats --lifetime`; `--json` includes both
+  windows. Survives restarts (mergeable bucket counts) and is best-effort like the
+  rest of the sidecar.
 - **Concise, consistent per-loop log grammar.** Each line reads
   `[<role>:<name>] <dim> <verdict>: <target> (<detail>) [tool] [n/threshold → action]`.
   The dimension is `link` (the L3 interface/route check, shown *before* the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -111,12 +111,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   rather than silently passing.
 
 ### Security & robustness
-- **Runs as a non-root user** (uid 10001) in the image. The real privilege is the
-  Docker API it talks to, not its in-container uid — but there's no reason to run
-  as root. Make the `/logs` mount writable by it (e.g. `chown 10001:10001 ./logs`);
-  if it isn't, the monitor still runs and logs to stdout. The direct-socket compose
-  variant adds `group_add` for the host `docker` group (the socket-proxy path needs
-  nothing).
+- **Runs as a non-root user** (default uid/gid 1000 — the typical first host user)
+  in the image. The real privilege is the Docker API it talks to, not its
+  in-container uid — but there's no reason to run as root. A `/logs` owned by uid
+  1000 is writable as-is; otherwise override `user:` to match (or `chown` the dir).
+  If it isn't writable the monitor still runs and logs to stdout. The direct-socket
+  compose variant adds `group_add` for the host `docker` group (the socket-proxy
+  path needs nothing).
 - **Site entries can no longer be turned into command-line options.** A
   `sites.conf` / `SITES` entry like `--directory-prefix=/etc` was appended bare to
   `wget`/`getent`/`ping`; GNU wget would parse it as a flag (and could write files

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - New env vars: `DEPENDENT_CONTAINER_FAILURES` (default = `FAIL_THRESHOLD`),
   `MAX_PARALLEL_CHECKS` (default 6), `AUTO_RECREATE` (default on),
   `DNS_WAIT_TIMEOUT` (default 30), `LOG_LEVEL` (default `INFO`).
+- **`SITES` env var** — comma-separated test URLs, **unioned** (de-duplicated)
+  with `sites.conf`, for config-via-env parity with the other knobs. Either
+  source works; at least one site total is required. `sites.conf` is re-read each
+  loop (live-editable); `SITES` is fixed at startup.
+
+### Changed (behavior)
+- **Configuration is now validated; bad config is fatal (exit non-zero) instead
+  of guessed around.** A malformed env value (bad int/bool/`LOG_LEVEL`), no
+  testable sites (neither `sites.conf` nor `SITES`), or an explicit
+  `DEPENDENT_CONTAINERS` naming a container that doesn't exist, all cause the
+  monitor to refuse to start. v1 silently defaulted / warned-and-skipped / ran
+  green-while-testing-nothing; these are now loud, fatal misconfigurations. Sane
+  defaults still mean an *unset* var just uses its default — only a *set-but-bad*
+  value is fatal. (`DEPENDENT_CONTAINERS=auto` discovering zero is not an error.)
 
 ### Migration
 - Pull `:2` / `2.0.0`. Existing env / `sites.conf` / compose work unchanged. To

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   netns, so DNS is the sole per-container fault — strands are caught by the
   interface check). Failures now log wget's actual reason instead of a bare
   "Generic error".
+- **Portable DNS validation via a getaddrinfo cascade** (`wget → getent → ping`)
+  so the check survives a dependent lacking any one tool, and resolves the way
+  the application does (nslookup/dig are excluded — they bypass nsswitch/libc and
+  can lie). When a container has *no* usable resolver tool (e.g. distroless), DNS
+  is reported **UNVALIDATED** — logged once, falling back to the interface check,
+  rather than silently passing.
 
 ### Changed (behavior)
 - **Configuration is now validated; bad config is fatal (exit non-zero) instead

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   recreate** (volumes preserved, including anonymous volumes). See ADR-0005.
 - New env vars: `DEPENDENT_CONTAINER_FAILURES` (default = `FAIL_THRESHOLD`),
   `MAX_PARALLEL_CHECKS` (default 6), `AUTO_RECREATE` (default on),
-  `DNS_WAIT_TIMEOUT` (default 30), `LOG_LEVEL` (default `INFO`).
+  `DNS_WAIT_TIMEOUT` (default 30), `LOG_LEVEL` (default `INFO`),
+  `DEPENDENT_VIABILITY` (default on; `0` = interface/strand check only, no L7
+  probe), `MAX_JITTER_MS` (default 0; opt-in per-dispatch jitter).
 - **`SITES` env var** — comma-separated test URLs, **unioned** (de-duplicated)
   with `sites.conf`, for config-via-env parity with the other knobs. Either
   source works; at least one site total is required. `sites.conf` is re-read each

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `MAX_PARALLEL_CHECKS` (default 6), `AUTO_RECREATE` (default on),
   `DNS_WAIT_TIMEOUT` (default 30), `LOG_LEVEL` (default `INFO`),
   `DEPENDENT_VIABILITY` (default on; `0` = interface/strand check only, no L7
-  probe), `MAX_JITTER_MS` (default 0; opt-in per-dispatch jitter).
+  probe), `MAX_JITTER_MS` (default 0; opt-in per-dispatch jitter),
+  `DRY_RUN` (default off; observe-only — detect + log intended actions but never
+  restart/recreate, for soak-testing alongside an active monitor).
 - **`SITES` env var** — comma-separated test URLs, **unioned** (de-duplicated)
   with `sites.conf`, for config-via-env parity with the other knobs. Either
   source works; at least one site total is required. `sites.conf` is re-read each

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `MAX_PARALLEL_CHECKS` (default 6), `AUTO_RECREATE` (default on),
   `DNS_WAIT_TIMEOUT` (default 30), `LOG_LEVEL` (default `INFO`),
   `DEPENDENT_VIABILITY` (default on; `0` = interface/strand check only, no L7
-  probe), `MAX_JITTER_MS` (default 0; opt-in per-dispatch jitter),
+  probe), `DEPENDENT_VIABILITY_SAMPLES` (default 1; sites each dependent tests per
+  loop — `N` or `-1` for all), `MAX_JITTER_MS` (default 0; opt-in per-dispatch jitter),
   `DRY_RUN` (default off; observe-only — detect + log intended actions but never
   restart/recreate, for soak-testing alongside an active monitor).
 - **`SITES` env var** — comma-separated test URLs, **unioned** (de-duplicated)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,7 +64,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   failure streak**, a **failure-reason breakdown** (dns/tls/timeout/connection/
   http-error/other), **response-latency** of successful polls (avg/min/max +
   **p50/p90/p99**), and **restart-effectiveness** (fraction of a site's restarts
-  that actually cleared it — a site-vs-VPN signal). The file is written
+  that actually cleared it — a site-vs-VPN signal). A top-level **`monitor`**
+  section records monitor-wide totals (version, uptime, total loops, accumulated
+  runtime, cumulative gluetun restarts / dependent remediations / advisories).
+  The file is written
   every loop, crash/power-loss-safely (temp file + fsync + atomic rename), and a
   site removed from `sites.conf` is pruned after `STATS_RETENTION_DAYS` (default
   90). Knobs: `ADVISORY_WINDOW`, `ADVISORY_MIN_RESTARTS`, `ADVISORY_DOMINANCE`,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   monitor started) is logged at WARN with a pointer to `DEPENDENT_CONTAINERS`. It
   is not auto-recreated — an orphan whose parent is gone can't be confirmed as a
   gluetun dependent (Tenet 1).
+- **Persistent per-site stats + flaky-site advisory** ([ADR-0008](docs/adr/0008-persistent-site-stats-and-advisory.md)).
+  A human-readable JSON sidecar (`STATS_FILE`, default `/logs/site-stats.json`,
+  best-effort, survives restarts) records per test site: total polls/failures
+  (→ rate), failure episodes + average episode length, gluetun restarts triggered,
+  and last-good/last-failure timestamps. When one site dominates the recent
+  gluetun restarts the monitor logs a once-per-episode **flaky-site advisory**
+  ("X of the last Y restarts were this site over the last <window> — review it").
+  By design it still applies the cheap restart fix and escalates to a human rather
+  than auto-suppressing the site. Knobs: `ADVISORY_WINDOW`, `ADVISORY_MIN_RESTARTS`,
+  `ADVISORY_DOMINANCE`, `STATS_SAVE_EVERY`.
 
 ### Fixed
 - **Per-dependent viability no longer false-fails on busybox-wget dependents.**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,39 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.0] - 2026-05-28
+
+### Changed
+- **Reimplemented in Python** (docker-py SDK) — see
+  [ADR-0007](docs/adr/0007-reimplement-in-python.md). The connectivity test is
+  unchanged in behavior (still `wget --spider` from inside gluetun's netns, same
+  exit-code map); the rewrite is about making the now-complex orchestration
+  testable. A characterization/differential suite pins the v1.x bash contract and
+  the Python port matches it green.
+- Image base is now `python:3.13-slim` (docker-py talks the Docker API directly;
+  the `docker` CLI is no longer needed in the image). The socket-proxy
+  permissions are unchanged (`CONTAINERS`/`POST`/`EXEC`).
+- DEBUG logs are now gated behind `LOG_LEVEL` (default `INFO`); the v1.x log
+  format is otherwise byte-for-byte preserved.
+
+### Added
+- **Dependent-aware health (issue #20).** The monitor no longer reports healthy
+  when dependents (`network_mode: service:gluetun`) are stranded loopback-only
+  after a gluetun restart/recreate. Each loop it interface-checks every dependent
+  and runs a per-dependent connectivity + DNS viability probe (one shuffled
+  resolvable name per dependent). See ADR-0004 / ADR-0006.
+- **Self-healing for stranded dependents.** Same-instance strand → `docker
+  restart`; gluetun recreated under it (id changed) → **non-destructive
+  recreate** (volumes preserved, including anonymous volumes). See ADR-0005.
+- New env vars: `DEPENDENT_CONTAINER_FAILURES` (default = `FAIL_THRESHOLD`),
+  `MAX_PARALLEL_CHECKS` (default 6), `AUTO_RECREATE` (default on),
+  `DNS_WAIT_TIMEOUT` (default 30), `LOG_LEVEL` (default `INFO`).
+
+### Migration
+- Pull `:2` / `2.0.0`. Existing env / `sites.conf` / compose work unchanged. To
+  roll back, repin the v1.x image (`:1` / `1.1.1`). The bash implementation
+  remains in the repo as the differential oracle and rollback anchor.
+
 ## [1.1.1] - 2026-05-16
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   probe), `DEPENDENT_VIABILITY_SAMPLES` (default 1; sites each dependent tests per
   loop — `N` or `-1` for all), `MAX_JITTER_MS` (default 0; opt-in per-dispatch jitter),
   `DRY_RUN` (default off; observe-only — detect + log intended actions but never
-  restart/recreate, for soak-testing alongside an active monitor).
+  restart/recreate, for soak-testing alongside an active monitor),
+  `WGET_TRIES` (default 1; attempts per `wget` probe), `LOG_MAX_BYTES` /
+  `LOG_BACKUP_COUNT` (log rotation), and `LOG_FILE` (log path; also always to stdout).
+- **One standardized `TIMEOUT` (and `WGET_TRIES`) across every probe** — the same
+  per-request timeout/retries now apply identically to gluetun's site tests, the
+  dependent-container viability `wget`, and the post-restart DNS-readiness probe
+  (which previously hard-coded a 5 s timeout). Set `TIMEOUT=10` once and it reaches
+  the `wget` run *inside* the dependents too.
 - **`SITES` env var** — comma-separated test URLs, **unioned** (de-duplicated)
   with `sites.conf`, for config-via-env parity with the other knobs. Either
   source works; at least one site total is required. `sites.conf` is re-read each
@@ -102,6 +109,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   can lie). When a container has *no* usable resolver tool (e.g. distroless), DNS
   is reported **UNVALIDATED** — logged once, falling back to the interface check,
   rather than silently passing.
+
+### Security & robustness
+- **Runs as a non-root user** (uid 10001) in the image. The real privilege is the
+  Docker API it talks to, not its in-container uid — but there's no reason to run
+  as root. Make the `/logs` mount writable by it (e.g. `chown 10001:10001 ./logs`);
+  if it isn't, the monitor still runs and logs to stdout. The direct-socket compose
+  variant adds `group_add` for the host `docker` group (the socket-proxy path needs
+  nothing).
+- **Site entries can no longer be turned into command-line options.** A
+  `sites.conf` / `SITES` entry like `--directory-prefix=/etc` was appended bare to
+  `wget`/`getent`/`ping`; GNU wget would parse it as a flag (and could write files
+  inside a probed container). Exec arg-lists now place a `--` end-of-options guard
+  before the URL/host, and parsing drops leading-dash / hostless entries with a
+  startup warning.
+- **Numeric config dials are range-validated.** Parseable-but-nonsensical values
+  are now fatal rather than silently creating bugs: `TIMEOUT=0` (infinite wget),
+  `WGET_TRIES=0`, `CHECK_INTERVAL=0` (busy loop), `FAIL_THRESHOLD=0`,
+  `ADVISORY_DOMINANCE>1` (never fires), `DEPENDENT_VIABILITY_SAMPLES=0`, etc.
+  Documented sentinels stay valid (`STATS_RETENTION_DAYS=0` = keep forever,
+  `LOG_MAX_BYTES=0` = no rotation, `DEPENDENT_VIABILITY_SAMPLES=-1` = all).
+- **Thread-safe site shuffle.** Dependents are probed in a thread pool; the
+  load-bearing per-dependent site shuffle now draws from the RNG under a lock, so
+  concurrent probes can't interleave and bias it.
+- **A corrupt stats sidecar can never crash startup** — any malformed shape
+  (wrong top-level/`sites`/`monitor` type, truncation, garbage) is tolerated and
+  the monitor starts fresh, honoring the best-effort contract.
 
 ### Changed (behavior)
 - **Configuration is now validated; bad config is fatal (exit non-zero) instead

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,13 +79,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   site removed from `sites.conf` is pruned after `STATS_RETENTION_DAYS` (default
   90). Knobs: `ADVISORY_WINDOW`, `ADVISORY_MIN_RESTARTS`, `ADVISORY_DOMINANCE`,
   `STATS_RETENTION_DAYS`.
-- **Per-dependent interface check is now shown at DEBUG** — each dependent logs
-  its L3 route check (`interface check: live [eth0,lo,tun0]` / `stranded [lo]` /
-  `unknown`) *before* its DNS/connect viability line, so "can it route out" is
-  visible every loop. Every test line is tagged with the container's role +
-  name — `[gateway:<gluetun>]` (site tests, run through the tunnel) or
-  `[dependent:<name>]` — and the viability label is honest about depth
-  (`resolved + connected (HTTP 200)` vs `resolved (DNS lookup only)`).
+- **`gluetun-monitor-stats` command** — a read-only operator command (shipped in
+  the image, `docker exec gluetun-monitor gluetun-monitor-stats`) that renders the
+  stats sidecar as a per-site matrix (latency percentiles, failure rate,
+  restart-effectiveness) plus monitor-wide totals. Sortable (`--sort`), with a
+  `--json` mode for jq/dashboards. Reads the same file via the same code the
+  monitor uses, so the numbers always match; touches no Docker API.
+- **Concise, consistent per-loop log grammar.** Each line reads
+  `[<role>:<name>] <dim> <verdict>: <target> (<detail>) [tool] [n/threshold → action]`.
+  The dimension is `link` (the L3 interface/route check, shown *before* the
+  connectivity test) or `reach` (DNS + connectivity), unifying the gateway site
+  test and the dependent viability test under one greppable verb; the verdict is
+  `ok` / `fail` / `stranded` / `?`. Healthy lines omit the failure counter (a
+  failing one shows e.g. `[2/2 → restart]`), and the detail is the bare proof
+  (`HTTP 200`, `bad address`) rather than a redundant restatement. Every line is
+  tagged with the container's role + name — `[gateway:<gluetun>]` (site tests, run
+  through the tunnel) or `[dependent:<name>]`.
+- **Log files are rotated** so the watchdog can't fill its own disk: the `/logs`
+  file is size-capped (`LOG_MAX_BYTES` ≈10 MB × `LOG_BACKUP_COUNT` 5; `0`
+  disables). The compose example also caps the Docker/stderr stream
+  (`logging: max-size/max-file`), which Docker does *not* rotate on its own.
 - **Log files are rotated** so the watchdog can't fill its own disk: the `/logs`
   file is size-capped (`LOG_MAX_BYTES` ≈10 MB × `LOG_BACKUP_COUNT` 5; `0`
   disables). The compose example also caps the Docker/stderr stream

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   never manage. Filters auto-discovery and subtracts from an explicit list. On
   overlap with `DEPENDENT_CONTAINERS`, exclude wins with a warning ("first, do no
   harm"); an exclude name matching nothing warns (likely typo).
+- **Startup warning for stranded orphans** — a running container whose netns
+  parent no longer exists (likely a dependent recreate-stranded before the
+  monitor started) is logged at WARN with a pointer to `DEPENDENT_CONTAINERS`. It
+  is not auto-recreated — an orphan whose parent is gone can't be confirmed as a
+  gluetun dependent (Tenet 1).
 
 ### Changed (behavior)
 - **Configuration is now validated; bad config is fatal (exit non-zero) instead

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,9 +61,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   value is fatal. (`DEPENDENT_CONTAINERS=auto` discovering zero is not an error.)
 
 ### Migration
-- Pull `:2` / `2.0.0`. Existing env / `sites.conf` / compose work unchanged. To
-  roll back, repin the v1.x image (`:1` / `1.1.1`). The bash implementation
-  remains in the repo as the differential oracle and rollback anchor.
+- **v1 (the bash implementation, image `:1`) is end-of-life; move to v2.** The
+  upgrade is a drop-in config change: same env vars/defaults, same
+  `sites.conf`/`logs` paths, same socket-proxy permissions
+  (`CONTAINERS`/`POST`/`EXEC`). In the common case you change only the image tag.
+- Recommended tag for production is **`:2`** (all v2.x patches, no surprise
+  major); `:latest` floats; `:1` stays as the rollback anchor (one-step rollback:
+  repin `:1`).
+- Two behavior changes to expect: (1) v2 **heals dependents by default**
+  (restart/recreate, volumes preserved) — set `AUTO_RECREATE=0` and/or
+  `DEPENDENT_VIABILITY=0` to stay conservative; (2) **bad config is now fatal** —
+  an empty `sites.conf`, a malformed env value, or an explicit
+  `DEPENDENT_CONTAINERS` naming a missing container will refuse to start with a
+  clear error (v1 tolerated these silently).
 
 ## [1.1.1] - 2026-05-16
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,118 +1,85 @@
 # Contributing to gluetun-monitor
 
-Thank you for your interest in contributing! This document provides guidelines and information for contributors.
+Thanks for your interest in contributing! As of v2, gluetun-monitor is a **Python
+package** (`gluetun_monitor`); the original Bash script (`gluetun-monitor.sh`) is
+retained only as a differential test oracle (see below).
 
-## Getting Started
+## Getting started
 
-1. Fork the repository
-2. Clone your fork locally
-3. Copy example configs:
+1. Fork and clone the repo.
+2. Copy the example configs:
    ```bash
    cp docker-compose.yml.example docker-compose.yml
    cp sites.conf.example sites.conf
    ```
-4. Make your changes
-5. Test your changes
-6. Submit a pull request
+3. Set up the Python toolchain:
+   ```bash
+   python -m venv .venv && . .venv/bin/activate
+   pip install -e '.[dev]'
+   ```
+4. Make your change with tests, run the gate (below), open a PR.
 
-## Development Setup
+Python **3.13** is the target (`requires-python`/`target-version`).
 
-### Prerequisites
-
-- Docker and Docker Compose
-- Bash 4.0+
-- [shellcheck](https://github.com/koalaman/shellcheck) for linting
-- [bats](https://github.com/bats-core/bats-core) for testing (optional, runs in CI)
-
-### Running Locally
+## The gate — run this before every PR
 
 ```bash
-# Build and run
-docker compose build
-docker compose up -d
-
-# View logs
-docker logs -f gluetun-monitor
+ruff check gluetun_monitor tests     # lint + import order (line length 100)
+mypy gluetun_monitor                 # types — strict
+pytest                               # tests, incl. the differential suite vs. bash
+pytest --cov=gluetun_monitor --cov-report=term-missing --cov-fail-under=95
 ```
 
-### Running Tests
+CI runs exactly these (plus a Docker build, an integration smoke test, and
+`pip-audit` for dependency CVEs) on every PR. All must pass. Coverage is
+**branch** coverage with a **95% floor** — new code needs tests.
 
-```bash
-# Run shellcheck
-shellcheck gluetun-monitor.sh
+## Code style (PEP 8 + types)
 
-# Run bats tests (requires bats installed)
-bats tests/
-```
+- **PEP 8 via ruff** (line length 100). The enabled rule sets are in
+  `pyproject.toml` (`[tool.ruff.lint]`): pycodestyle/pyflakes, isort, bugbear,
+  pyupgrade, comprehensions, simplify, return, pathlib, Ruff. Let ruff format your
+  imports (`known-first-party = ["gluetun_monitor"]`).
+- **Type hints everywhere**, checked by `mypy --strict` (with `warn_unreachable`
+  and `warn_redundant_casts`). No untyped defs.
+- **Docstrings explain _why_, not just _what_** — the non-obvious reasoning,
+  trade-offs, and tenet/ADR references. Self-documenting names; comment only
+  non-obvious logic. Remove dead code.
+- No bare `except`; degrade deliberately and say why (the monitor must never let
+  one bad loop kill it — Tenet 7).
 
-## Code Style
+## Tests
 
-### Shell Script Guidelines
+- Tests live in `tests/`, use **pytest**, and run **without a Docker daemon**: a
+  `FakeDockerClient` is injected at the `DockerClient` seam (`tests/fakes.py`), so
+  you script container state and `exec` results in-memory and assert on *what the
+  monitor decided to do*.
+- Each test module opens with a short **what/why docstring**. New behavior needs a
+  test; a bug fix needs a regression test. Assert the negative too (e.g. that a
+  line is *not* logged at INFO) — that's how log-level/contract behavior is pinned.
+- Markers (`pyproject.toml`): `integration` (needs a live daemon — excluded by
+  default) and `differential` (runs the **legacy bash functions** and asserts the
+  Python port matches — the no-regressions gate from
+  [ADR-0007](docs/adr/0007-reimplement-in-python.md)).
+- The legacy `gluetun-monitor.sh` is **kept as the differential oracle**, so it
+  still has `shellcheck` + `bats` CI jobs — if you touch it, keep those green.
 
-- Use `#!/bin/bash` shebang
-- Enable strict mode: `set -euo pipefail`
-- Declare variables with `local` in functions
-- Separate declaration and assignment for command substitution:
-  ```bash
-  # Good
-  local result
-  result=$(some_command)
+## Commit messages & PRs
 
-  # Bad (masks return value)
-  local result=$(some_command)
-  ```
-- Quote all variables: `"$variable"` not `$variable`
-- Use `[[` instead of `[` for conditionals
-- Run shellcheck before committing
+- Imperative mood, first line < 72 chars, reference issues (`Fixes #123`).
+- Update `CHANGELOG.md` under `[Unreleased]` when you change behavior.
+- Update the relevant docs; for a **significant or hard-to-reverse design
+  decision**, add an ADR under `docs/adr/` (see `docs/adr/README.md` for the bar —
+  routine choices belong in code/docs, not an ADR).
+- A PR should leave the gate green and coverage at/above the floor.
 
-### Commit Messages
+See [DEVELOPMENT.md](DEVELOPMENT.md) for architecture and deeper internals.
 
-- Use present tense ("Add feature" not "Added feature")
-- Use imperative mood ("Move cursor to..." not "Moves cursor to...")
-- Keep the first line under 72 characters
-- Reference issues when applicable: "Fix #123"
+## Reporting issues & feature requests
 
-## Pull Request Process
-
-1. Ensure shellcheck passes with no errors
-2. Update documentation if you're changing behavior
-3. Add tests for new functionality
-4. Update CHANGELOG.md under "Unreleased"
-5. Request review from maintainers
-
-## Testing Guidelines
-
-### What to Test
-
-- New functions should have unit tests
-- Bug fixes should include a regression test
-- Integration tests for Docker-related changes
-
-### Test Structure
-
-Tests use [bats](https://github.com/bats-core/bats-core):
-
-```bash
-@test "description of what is being tested" {
-    result=$(function_to_test)
-    [ "$result" = "expected" ]
-}
-```
-
-## Reporting Issues
-
-- Use the issue templates provided
-- Include relevant logs (sanitize sensitive info)
-- Specify your environment (Docker version, OS, etc.)
-- Check existing issues before creating a new one
-
-## Feature Requests
-
-- Open an issue using the feature request template
-- Describe the problem you're trying to solve
-- Propose a solution if you have one
-- Be open to discussion and alternatives
+Use the issue templates. Include sanitized logs and your environment (Docker
+version, OS). Check existing issues first.
 
 ## License
 
-By contributing, you agree that your contributions will be licensed under the MIT License.
+By contributing, you agree your contributions are licensed under the MIT License.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,14 +34,21 @@ CI runs exactly these (plus a Docker build, an integration smoke test, and
 `pip-audit` for dependency CVEs) on every PR. All must pass. Coverage is
 **branch** coverage with a **95% floor** — new code needs tests.
 
-## Code style (PEP 8 + types)
+## Code style — the standards we follow
 
-- **PEP 8 via ruff** (line length 100). The enabled rule sets are in
-  `pyproject.toml` (`[tool.ruff.lint]`): pycodestyle/pyflakes, isort, bugbear,
-  pyupgrade, comprehensions, simplify, return, pathlib, Ruff. Let ruff format your
-  imports (`known-first-party = ["gluetun_monitor"]`).
-- **Type hints everywhere**, checked by `mypy --strict` (with `warn_unreachable`
-  and `warn_redundant_casts`). No untyped defs.
+| Standard | What | Enforced by |
+|---|---|---|
+| **PEP 8** | style | ruff (E/W) — **line length 120** (wide-screen, not an 80s terminal) |
+| **PEP 257** | docstring conventions | ruff `D` (pydocstyle) — *presence* on every public module/class/method/function, plus formatting |
+| **PEP 484** | type hints | `mypy --strict` (+ `warn_unreachable`, `warn_redundant_casts`) — no untyped defs |
+| **PEP 517/518/621** | packaging | `pyproject.toml` |
+
+- The enabled ruff rule sets live in `pyproject.toml` (`[tool.ruff.lint]`):
+  pycodestyle/pyflakes, isort, bugbear, pyupgrade, comprehensions, simplify,
+  return, pathlib, **pydocstyle**, Ruff. We deliberately **exempt three** pydocstyle
+  rules (documented inline): `D107` (`__init__` — class docstring covers it),
+  `D205` (blank line after summary), `D401` (imperative mood) — our docstrings are
+  already clear and we don't reflow them for those.
 - **Docstrings explain _why_, not just _what_** — the non-obvious reasoning,
   trade-offs, and tenet/ADR references. Self-documenting names; comment only
   non-obvious logic. Remove dead code.

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,164 +1,105 @@
 # Development Notes
 
-This document provides context for future development and AI assistance.
+Context for working on gluetun-monitor. The **why** behind the architecture
+lives in [`docs/`](docs/): start with [`docs/TENETS.md`](docs/TENETS.md), then
+the ADRs ([`docs/adr/`](docs/adr/)) and the per-loop state machine in
+[ADR-0006](docs/adr/0006-per-dependent-viability-testing.md). This file covers
+the **how**: layout, toolchain, and testing.
 
-## Problem Statement
+## v2 at a glance
 
-When using Gluetun as a VPN gateway for other containers (via `network_mode: container:gluetun`), there are several operational challenges:
+v2 (ADR-0007) is a Python package, `gluetun_monitor`. It does everything v1.x did
+and adds dependent-aware health + self-healing (issue #20). The legacy
+`gluetun-monitor.sh` remains in the tree as the **differential oracle** and
+rollback anchor (`:1` image) — not for further feature work.
 
-1. **VPN endpoint failures** - Some VPN servers may become slow, blocked, or unresponsive
-2. **Dependent container restarts** - When Gluetun restarts, containers using its network lose connectivity and often need to be restarted
-3. **Manual intervention** - Without monitoring, users must manually detect issues and restart services
-4. **Lack of visibility** - No logging of which VPN endpoints work or fail
+The single most important design idea: **all Docker access goes through one
+seam** (`docker_client.DockerClient`, implemented over docker-py). Tests inject a
+`FakeDockerClient`, so the entire monitor — including the destructive-adjacent
+recreate path — is exercised without a live daemon.
 
-## Solution Design
-
-### Architecture
-
-```
-┌─────────────────────┐
-│   gluetun-monitor   │
-│   (this container)  │
-└──────────┬──────────┘
-           │ Docker Socket
-           ▼
-┌─────────────────────┐     ┌─────────────────────┐
-│      Gluetun        │◄────│  Dependent Containers│
-│   (VPN gateway)     │     │  (network_mode:      │
-└─────────────────────┘     │   container:gluetun) │
-                            └─────────────────────┘
-```
-
-### Key Design Decisions
-
-#### 1. Parallel Site Testing
-- **Problem:** Sequential testing takes `num_sites × timeout` seconds
-- **Solution:** Launch all site tests as background jobs, wait for all to complete
-- **Implementation:** Uses bash background jobs (`&`) and `wait`
-- **Result:** Total test time = single timeout, regardless of site count
-
-#### 2. Auto-Discovery of Dependent Containers
-- **Problem:** Hard-coding container names is brittle and requires manual updates
-- **Solution:** Query Docker API to find containers with matching `NetworkMode`
-- **Implementation:** `docker inspect --format='{{.HostConfig.NetworkMode}}'`
-- **Timing:** Discovery runs at startup (for logging) and immediately before each restart operation
-
-#### 3. Consecutive Failure Threshold
-- **Problem:** Transient network blips could cause unnecessary restarts
-- **Solution:** Require N consecutive failures before triggering restart
-- **Implementation:** Per-site failure counters, reset on success or after restart
-
-#### 4. Memory-Safe Site Testing
-- **Problem:** Large HTTP responses could consume memory
-- **Solution:** Use `wget --spider` (headers only) with output discarded
-- **Implementation:** `wget --spider ... >/dev/null 2>&1`
-
-#### 5. Smart Failure Detection
-- **Problem:** HTTP 4xx/5xx errors don't indicate VPN failure - the site responded
-- **Solution:** Only treat actual connectivity failures as failures
-- **Implementation:** Check wget exit codes:
-  - Exit 0, 6, 8 → PASS (site responded, VPN working)
-  - Exit 4, 5, others → FAIL (connectivity issue)
-- **Rationale:** A 403 Forbidden means the VPN tunnel works; DNS resolved and TCP connected
-
-#### 6. DNS Stabilization Wait
-- **Problem:** Gluetun may report "healthy" before DNS is fully operational
-- **Solution:** After health check passes, verify DNS actually works
-- **Implementation:** `nslookup google.com` + `wget https://1.1.1.1` before proceeding
-- **Timeout:** 30 seconds with 2-second polling
-
-#### 7. VPN Endpoint Logging
-- **Problem:** Need visibility into which endpoints fail/succeed
-- **Solution:** Parse Gluetun logs for server, country, city, IP information
-- **Implementation:** Grep patterns for known Gluetun log formats
-
-## Code Structure
+## Package layout
 
 ```
-gluetun-monitor.sh
-├── Configuration variables (lines 8-18)
-├── log() - Timestamped logging (to stderr and log file)
-├── log_endpoint_info() - Extract VPN details from Gluetun logs
-├── get_gluetun_health() - Query container health status
-├── discover_dependent_containers() - Find containers using Gluetun's network
-├── get_dependent_containers() - Wrapper for auto/manual mode
-├── wait_for_gluetun_healthy() - Poll until healthy or timeout
-├── wait_for_dns_ready() - Verify DNS works after restart
-├── decode_wget_exit_code() - Human-readable wget error messages
-├── test_site_async() - Background job for single site test
-├── test_all_sites() - Parallel test orchestration
-├── restart_gluetun() - Restart with logging
-├── restart_dependent_containers() - Discover and restart dependents
-├── handle_failure() - Recovery orchestration with connectivity verification
-├── check_prerequisites() - Startup validation
-└── main() - Main loop
+gluetun_monitor/
+├── __main__.py       # python -m gluetun_monitor
+├── cli.py            # main(): config + logger + client, prereqs, run loop
+├── config.py         # Config dataclass, from_env() (the env-var contract)
+├── logging_setup.py  # stdlib logging, formatted to the v1.x line format
+├── docker_client.py  # the seam: DockerClient Protocol + DockerPyClient + ContainerInfo
+├── sites.py          # sites.conf parsing, trim, resolvable-vs-IP classification
+├── connectivity.py   # probe_site() — wget --spider, the v1.x exit-code map (0/6/8 pass)
+├── endpoint.py       # parse gluetun logs for IP/location/server (issue #17 safe)
+├── dependents.py     # discovery, interface check, restart-vs-recreate decision
+├── recreate.py       # build_create_body() (pure) + recreate_dependent() — ADR-0005
+├── recovery.py       # gluetun restart waits + dependent remediation/verify
+├── state.py          # consecutive-failure Counter + enums
+└── monitor.py        # Monitor: the per-loop state machine (ADR-0006 nodes 1-22)
 ```
 
-## Testing Considerations
-
-### Manual Testing
+## Toolchain
 
 ```bash
-# Test site connectivity through Gluetun
-docker exec gluetun wget --spider --timeout=10 https://google.com
+python -m venv .venv && . .venv/bin/activate
+pip install -e '.[dev]'
 
-# Check container network mode
-docker inspect --format='{{.HostConfig.NetworkMode}}' <container>
-
-# View Gluetun logs for endpoint info
-docker logs gluetun 2>&1 | grep -E "server|country|city|public IP"
+ruff check gluetun_monitor tests   # lint (replaces shellcheck for the Python)
+mypy gluetun_monitor               # types — strict
+pytest                             # unit + differential
+pytest --cov=gluetun_monitor --cov-report=term-missing
 ```
 
-### Simulating Failures
+CI runs all three on every PR (`.github/workflows/ci.yml`), plus shellcheck and
+the legacy bats suite against `gluetun-monitor.sh`, plus a Docker build +
+container-start integration check.
+
+## Testing strategy
+
+- **Unit tests** (`tests/test_*.py`) — each module against the `FakeDockerClient`
+  (`tests/fakes.py`). State mutation in the monitor is single-threaded, so these
+  are deterministic; the shuffle RNG is injected (`random.Random(0)`).
+- **Recreate tests** (`tests/test_recreate.py`) — the highest-risk logic. The
+  field-stripping and the **anonymous-volume data-preservation** guarantee are
+  pinned because `build_create_body` is a pure function.
+- **Characterization / differential** (`tests/test_characterization.py`, marked
+  `differential`) — executes the *actual* legacy bash functions and asserts the
+  Python port matches (`trim`, `decode_wget_exit_code`, env defaults). This is
+  the no-regressions gate from ADR-0007. Run just these with
+  `pytest -m differential`.
+
+### Manual / live testing
 
 ```bash
-# Block outbound traffic in Gluetun (requires exec into container)
-docker exec gluetun iptables -A OUTPUT -j DROP
+# Connectivity through gluetun (what probe_site does):
+docker exec gluetun wget --spider -S --timeout=10 --tries=1 -q https://google.com; echo $?
 
-# Or restart Gluetun to force new endpoint
-docker restart gluetun
+# A dependent's interface check (what the interface check does):
+docker exec <dependent> ls /sys/class/net      # only "lo" => stranded
+
+# A dependent's NetworkMode target vs gluetun's id (the recreate selector):
+docker inspect --format='{{.HostConfig.NetworkMode}}' <dependent>
+docker inspect --format='{{.Id}}' gluetun
 ```
 
-## Potential Enhancements
+### Simulating the #20 strand
 
-### Not Yet Implemented
+```bash
+docker restart gluetun     # same id -> dependents stranded, recover via restart
+docker compose up -d --force-recreate gluetun   # new id -> recover via recreate
+```
 
-1. **Metrics/Prometheus endpoint** - Export check results as metrics
-2. **Webhook notifications** - Alert on failures/recoveries
-3. **Endpoint blocklist** - Remember and avoid problematic endpoints
-4. **Graceful dependent restart** - SIGTERM with timeout before SIGKILL
-5. **Health endpoint** - HTTP endpoint for external monitoring
-6. **Configuration hot-reload** - Reload sites.conf without restart
+## Conventions
 
-### Considered and Rejected
+- `mypy --strict` and `ruff` must stay green; keep public functions typed +
+  docstring'd.
+- New env vars: add to `Config`, document in `README.md`, and (if it changes the
+  contract) extend the characterization suite.
+- Docker behavior is added to the `DockerClient` Protocol **and** the
+  `FakeDockerClient`, never reached for directly — that keeps everything testable.
+- Significant/hard-to-reverse decisions get an ADR; tunable heuristics go in
+  `TENETS.md` or the code (see [`docs/adr/README.md`](docs/adr/README.md)).
 
-1. **Using curl instead of wget** - wget is available in Gluetun's Alpine image
-2. **Running tests from monitor container** - Need to test through VPN, requires exec into Gluetun
-3. **Docker Compose integration** - Would limit to single-compose deployments
+## Backlog
 
-## Compatibility Notes
-
-- **Gluetun versions:** Tested with qmcgaw/gluetun, log parsing patterns may need adjustment for other versions
-- **Docker API:** Uses Docker CLI, should work with any Docker version supporting `docker inspect`
-- **Shell:** Requires bash (not sh) for associative arrays and other bashisms
-
-## Log Levels
-
-| Level | Usage |
-|-------|-------|
-| `INFO` | Normal operations (startup, restarts, discoveries) |
-| `WARN` | Non-critical issues (single failure, unhealthy status, threshold reached) |
-| `ERROR` | Critical issues (threshold exceeded, restart failed) |
-| `DEBUG` | Detailed info (individual site results, timing, health checks) |
-| `CHECK` | Check cycle start/end markers |
-| `ENDPOINT` | VPN endpoint information (startup, failing, new) |
-
-## Contributing
-
-When modifying this project:
-
-1. Maintain bash compatibility (no external dependencies beyond docker CLI)
-2. Keep memory usage minimal (no storing response bodies)
-3. Preserve parallel testing behavior
-4. Update README.md for any new configuration options
-5. Test with multiple VPN providers if possible
+The notification layer and socket-proxy hardening are tracked in
+[`docs/ROADMAP.md`](docs/ROADMAP.md).

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,16 @@
 # longer needed in the image.
 FROM python:3.13-slim
 
-# Create directories the monitor reads/writes.
-RUN mkdir -p /app /config /logs
+# Create a non-root user to run as (defense in depth — the real privilege is the
+# Docker API the monitor talks to, not its in-container uid, but there's no reason
+# to run as root). /config and /logs are owned by it so the read-only sites mount
+# and the writable log/stats dir both work. NOTE: with the *direct* socket mount
+# (the docker-compose alternative), /var/run/docker.sock is root:docker — a
+# non-root process needs that group; the recommended socket-proxy path over
+# DOCKER_HOST=tcp:// needs no special permission and works as-is.
+RUN useradd --system --uid 10001 --create-home --home-dir /home/monitor monitor \
+    && mkdir -p /app /config /logs \
+    && chown -R monitor:monitor /app /config /logs
 
 WORKDIR /app
 
@@ -12,6 +20,8 @@ WORKDIR /app
 COPY pyproject.toml README.md LICENSE /app/
 COPY gluetun_monitor /app/gluetun_monitor
 RUN pip install --no-cache-dir .
+
+USER monitor
 
 # Default environment (matches the v1.x contract; v2 adds the dependent knobs).
 ENV CONFIG_FILE=/config/sites.conf \

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,20 +3,13 @@
 # longer needed in the image.
 FROM python:3.13-slim
 
-# Create a non-root user to run as (defense in depth — the real privilege is the
-# Docker API the monitor talks to, not its in-container uid, but there's no reason
-# to run as root). Default uid/gid is 1000 — the first real user on a typical
-# single-user host — so a bind-mounted /logs owned by that user is writable with
-# no chown. If your /logs is owned by a different uid, override at runtime with
-# `user: "<uid>:<gid>"` in compose. /config and /logs are owned by it so the
-# read-only sites mount and the writable log/stats dir both work. NOTE: with the
-# *direct* socket mount (the docker-compose alternative), /var/run/docker.sock is
-# root:docker — a non-root process needs that group; the recommended socket-proxy
-# path over DOCKER_HOST=tcp:// needs no special permission and works as-is.
-RUN groupadd --gid 1000 monitor \
-    && useradd --uid 1000 --gid 1000 --create-home --home-dir /home/monitor monitor \
-    && mkdir -p /app /config /logs \
-    && chown -R 1000:1000 /app /config /logs
+# gosu lets the entrypoint drop privileges to PUID:PGID when the operator opts in
+# (LSIO-style). With no PUID/PGID the container runs as root — a drop-in match for
+# v1, with no host-side chown. Running non-root is recommended; see the README.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends gosu \
+    && rm -rf /var/lib/apt/lists/* \
+    && mkdir -p /app /config /logs
 
 WORKDIR /app
 
@@ -25,7 +18,8 @@ COPY pyproject.toml README.md LICENSE /app/
 COPY gluetun_monitor /app/gluetun_monitor
 RUN pip install --no-cache-dir .
 
-USER monitor
+COPY docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
+RUN chmod +x /usr/local/bin/docker-entrypoint.sh
 
 # Default environment (matches the v1.x contract; v2 adds the dependent knobs).
 ENV CONFIG_FILE=/config/sites.conf \
@@ -41,5 +35,6 @@ ENV CONFIG_FILE=/config/sites.conf \
     AUTO_RECREATE=1 \
     LOG_LEVEL=INFO
 
-# Run as the installed console script.
+# The entrypoint optionally drops to PUID:PGID, then runs the console script.
+ENTRYPOINT ["docker-entrypoint.sh"]
 CMD ["gluetun-monitor"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,26 +1,31 @@
-FROM docker:29-cli
+# gluetun-monitor v2 — Python (ADR-0007). docker-py talks the Docker API
+# directly (honoring DOCKER_HOST / the socket proxy), so the docker CLI is no
+# longer needed in the image.
+FROM python:3.13-slim
 
-# Install bash and other utilities
-RUN apk add --no-cache bash coreutils grep tzdata
-
-# Create directories
+# Create directories the monitor reads/writes.
 RUN mkdir -p /app /config /logs
-
-# Copy the monitor script
-COPY gluetun-monitor.sh /app/gluetun-monitor.sh
-RUN chmod +x /app/gluetun-monitor.sh
-
-# Default environment variables
-ENV CONFIG_FILE=/config/sites.conf
-ENV LOG_FILE=/logs/gluetun-monitor.log
-ENV CHECK_INTERVAL=30
-ENV TIMEOUT=10
-ENV FAIL_THRESHOLD=2
-ENV GLUETUN_CONTAINER=gluetun
-ENV DEPENDENT_CONTAINERS=auto
-ENV HEALTHY_WAIT_TIMEOUT=120
-ENV DISCOVERY_INTERVAL=300
 
 WORKDIR /app
 
-CMD ["/app/gluetun-monitor.sh"]
+# Install the package first (its own layer) for build-cache friendliness.
+COPY pyproject.toml README.md LICENSE /app/
+COPY gluetun_monitor /app/gluetun_monitor
+RUN pip install --no-cache-dir .
+
+# Default environment (matches the v1.x contract; v2 adds the dependent knobs).
+ENV CONFIG_FILE=/config/sites.conf \
+    LOG_FILE=/logs/gluetun-monitor.log \
+    CHECK_INTERVAL=30 \
+    TIMEOUT=10 \
+    FAIL_THRESHOLD=2 \
+    GLUETUN_CONTAINER=gluetun \
+    DEPENDENT_CONTAINERS=auto \
+    HEALTHY_WAIT_TIMEOUT=120 \
+    DEPENDENT_CONTAINER_FAILURES=2 \
+    MAX_PARALLEL_CHECKS=6 \
+    AUTO_RECREATE=1 \
+    LOG_LEVEL=INFO
+
+# Run as the installed console script.
+CMD ["gluetun-monitor"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,14 +5,18 @@ FROM python:3.13-slim
 
 # Create a non-root user to run as (defense in depth — the real privilege is the
 # Docker API the monitor talks to, not its in-container uid, but there's no reason
-# to run as root). /config and /logs are owned by it so the read-only sites mount
-# and the writable log/stats dir both work. NOTE: with the *direct* socket mount
-# (the docker-compose alternative), /var/run/docker.sock is root:docker — a
-# non-root process needs that group; the recommended socket-proxy path over
-# DOCKER_HOST=tcp:// needs no special permission and works as-is.
-RUN useradd --system --uid 10001 --create-home --home-dir /home/monitor monitor \
+# to run as root). Default uid/gid is 1000 — the first real user on a typical
+# single-user host — so a bind-mounted /logs owned by that user is writable with
+# no chown. If your /logs is owned by a different uid, override at runtime with
+# `user: "<uid>:<gid>"` in compose. /config and /logs are owned by it so the
+# read-only sites mount and the writable log/stats dir both work. NOTE: with the
+# *direct* socket mount (the docker-compose alternative), /var/run/docker.sock is
+# root:docker — a non-root process needs that group; the recommended socket-proxy
+# path over DOCKER_HOST=tcp:// needs no special permission and works as-is.
+RUN groupadd --gid 1000 monitor \
+    && useradd --uid 1000 --gid 1000 --create-home --home-dir /home/monitor monitor \
     && mkdir -p /app /config /logs \
-    && chown -R monitor:monitor /app /config /logs
+    && chown -R 1000:1000 /app /config /logs
 
 WORKDIR /app
 

--- a/README.md
+++ b/README.md
@@ -89,8 +89,9 @@ boots cleanly against a socket proxy as part of testing.
 - **`:2`** — **recommended for production**: you get every v2.x patch and never a
   surprise future major.
 - `:2.0.0` — fully pinned to one release (reproducible; you update deliberately).
-- `:latest` — always the newest release; **will** eventually roll to a future v3
-  major, so don't use it for unattended updates of a container-restarting watchdog.
+- `:latest` — always the newest **stable** release (excludes pre-releases, and an
+  EOL v1 patch can't drag it back); **will** eventually roll to a future v3 major,
+  so don't use it for unattended updates of a container-restarting watchdog.
 - **`:1`** — frozen v1, kept only as a **rollback anchor**; unsupported (EOL).
 
 **Two behavior changes to know about** (the config interface is compatible, but

--- a/README.md
+++ b/README.md
@@ -75,6 +75,38 @@ The full per-loop state machine (22 nodes) is in
 [ADR-0006](docs/adr/0006-per-dependent-viability-testing.md); the
 restart-vs-recreate decision is [ADR-0004](docs/adr/0004-dependent-aware-health.md).
 
+## Upgrading from v1 (v1 is end-of-life)
+
+**v1 (the original bash implementation, image tag `:1`) is end-of-life.** v2 is
+the supported line — please move to it. The upgrade is a **drop-in config
+change**: v2 reads the **same env vars** (same names and defaults), the same
+`/config/sites.conf` and `/logs` paths, and needs the **same socket-proxy
+permissions** (`CONTAINERS` / `POST` / `EXEC`). In the common case you change
+only the image tag and it keeps working — we validate that the v1 env surface
+boots cleanly against a socket proxy as part of testing.
+
+**Image tags:**
+- **`:2`** — recommended for production: you get every v2.x patch and never a
+  surprise future major.
+- **`:latest`** — always the newest release (note: it *will* eventually roll to a
+  future v3 major).
+- **`:1`** — frozen v1, kept only as a **rollback anchor**; unsupported.
+
+**Two behavior changes to know about** (the config interface is compatible, but
+v2 does more):
+1. **It now heals dependents by default** (the #20 fix): a stranded dependent is
+   restarted (same gluetun id) or **recreated** (id changed — volumes preserved;
+   see [data safety](#what-it-will-and-wont-do-and-why-your-data-is-safe)). To
+   stay close to v1's behavior, set `AUTO_RECREATE=0` (alert instead of recreate)
+   and/or `DEPENDENT_VIABILITY=0` (interface/strand check only, no L7 probing).
+2. **Config is validated; bad config is now fatal.** v2 refuses to start on a
+   few things v1 tolerated silently — an empty `sites.conf`, a malformed env
+   value, or an explicit `DEPENDENT_CONTAINERS` naming a container that doesn't
+   exist. If startup fails after the upgrade, the error message says exactly what
+   to fix (see [Configuration is validated](#configuration-is-validated--sane-defaults-but-bad-config-is-fatal)).
+
+**Rollback** is one step: repin the image to `:1`.
+
 ## Quick Start
 
 ### 1. Pull the image

--- a/README.md
+++ b/README.md
@@ -98,8 +98,9 @@ v2 does more):
 1. **It now heals dependents by default** (the #20 fix): a stranded dependent is
    restarted (same gluetun id) or **recreated** (id changed — volumes preserved;
    see [data safety](#what-it-will-and-wont-do-and-why-your-data-is-safe)). To
-   stay close to v1's behavior, set `AUTO_RECREATE=0` (alert instead of recreate)
-   and/or `DEPENDENT_VIABILITY=0` (interface/strand check only, no L7 probing).
+   stay close to v1's behavior, set `AUTO_RECREATE=0` (log a loud alert line
+   instead of recreating) and/or `DEPENDENT_VIABILITY=0` (interface/strand check
+   only, no L7 probing).
 2. **Config is validated; bad config is now fatal.** v2 refuses to start on a
    few things v1 tolerated silently — an empty `sites.conf`, a malformed env
    value, or an explicit `DEPENDENT_CONTAINERS` naming a container that doesn't
@@ -164,6 +165,7 @@ docker compose up -d
 
 | Variable | Default | Description |
 |----------|---------|-------------|
+| `PUID` / `PGID` | *(unset → root)* | Run non-root (recommended): the entrypoint chowns `/logs` and drops to this uid/gid (LSIO-style). Unset = runs as root (drop-in). See [Running as non-root](#running-as-non-root-recommended) |
 | `DOCKER_HOST` | *(unset)* | Docker daemon endpoint. Set to `tcp://docker-socket-proxy:2375` when using a socket proxy |
 | `GLUETUN_CONTAINER` | `gluetun` | Name of the Gluetun container to monitor (must exist, else fatal) |
 | `CONFIG_FILE` | `/config/sites.conf` | Path to the sites file (re-read each loop → live-editable) |
@@ -440,7 +442,10 @@ owned by the daemon, not the container, so:
 | "Reconstruction might drop a setting" | The genuine residual risk: a recreate copies the container's config + mounts, and a fidelity bug could drop a *non-volume* setting. Mitigations: it **verifies** after recreating, `AUTO_RECREATE=0` disables recreate entirely, and `EXCLUDE_CONTAINERS` protects specific containers. |
 
 ### Your controls
-- **`AUTO_RECREATE=0`** — never recreate; alert instead (restart-only recovery).
+- **`AUTO_RECREATE=0`** — never recreate; log a loud alert line instead
+  (restart-only recovery). ("alert" here, and the flaky-site "advisory" below,
+  mean a **log line** — there is no external notification yet; that's on the
+  [roadmap](docs/ROADMAP.md).)
 - **`EXCLUDE_CONTAINERS=...`** — a denylist of containers to never touch.
 - **Socket proxy** (default) — cap the Docker API surface the monitor can use.
 
@@ -589,6 +594,8 @@ services:
       - docker-socket-proxy
     environment:
       - TZ=UTC
+      - PUID=1000                      # run non-root (recommended); unset = root (drop-in)
+      - PGID=1000
       - DOCKER_HOST=tcp://docker-socket-proxy:2375
       - GLUETUN_CONTAINER=gluetun
       - DEPENDENT_CONTAINERS=auto      # auto-discovery (default)
@@ -707,26 +714,33 @@ watchdog never fills the disk:
 At `LOG_LEVEL=DEBUG` the per-site/per-dependent lines are verbose (good for
 soak-testing); `INFO` is much quieter for steady-state.
 
-### Running as non-root
+### Running as non-root (recommended)
 
-The image runs as a non-root user, default **uid/gid 1000** (the first real user
-on a typical single-user host). The real privilege the monitor holds is the Docker
-API, not its in-container uid — running unprivileged is just defense in depth.
-Three things follow:
+By default the container runs as **root** — a drop-in match for v1, with nothing to
+configure. Running it **non-root is recommended** (defense in depth), and it uses
+the same `PUID`/`PGID` knob the rest of your stack (the LinuxServer.io `*arr`
+images) already does:
 
-- **`/logs` must be writable by the runtime uid.** If your host user is `1000`
-  (the common case — check with `id`), a `./logs` you created is already owned by
-  it and just works. If it isn't writable the monitor still runs and logs to
-  `docker logs`; it just can't persist the file log or the site-stats sidecar.
-- **Different uid?** Override at runtime to match whoever owns `/logs` —
-  `user: "${UID}:${GID}"` (or e.g. `user: "1000:1000"`) in the compose service.
-  No image rebuild needed.
-- **Upgrading from v1** (which ran as root)? Your existing `./logs` files are
-  root-owned — `sudo chown -R 1000:1000 ./logs` (or to whatever uid you run as).
-- **Direct socket mount** (instead of the recommended socket proxy)? A non-root
-  process can't read the root:docker-owned `/var/run/docker.sock` by default — add
-  the host `docker` group via `group_add` (see the compose example). The
-  socket-proxy path talks TCP and needs none of this.
+```yaml
+services:
+  gluetun-monitor:
+    environment:
+      - PUID=1000   # your host user's uid — run `id` to find it
+      - PGID=1000   # your host user's gid
+```
+
+When `PUID`/`PGID` are set, the entrypoint chowns the `/logs` mount to that user
+and drops privileges to it — **no manual chown**. Unset, it stays root and behaves
+exactly like v1 (so the upgrade is drop-in; non-root is opt-in). Either way the
+monitor's real privilege is the Docker API it talks to, not its in-container uid.
+
+> **Direct socket mount** (instead of the recommended socket proxy) **+ non-root:**
+> a non-root process can't read the root:docker-owned `/var/run/docker.sock`. With
+> the socket **proxy** (the default) this is a non-issue — it's reached over TCP.
+> If you insist on the direct mount *and* non-root, use Docker's native
+> `user: "<uid>:<gid>"` together with `group_add: ["<docker-gid>"]` instead of
+> `PUID`/`PGID` (the privilege-drop resets supplementary groups, so `group_add`
+> only composes with `user:`), or simply leave it as root there.
 
 ## Requirements
 

--- a/README.md
+++ b/README.md
@@ -177,6 +177,7 @@ docker compose up -d
 | `DEPENDENT_CONTAINER_FAILURES` | *(= `FAIL_THRESHOLD`)* | Consecutive per-dependent viability failures before remediating that dependent |
 | `MAX_PARALLEL_CHECKS` | `6` | Cap on concurrent `docker exec` probes across dependents per loop |
 | `DEPENDENT_VIABILITY` | `1` | Per-dependent L7 DNS/connectivity probe. `0` = interface/strand check only (no URL fetch); the interface check is always on |
+| `DEPENDENT_VIABILITY_SAMPLES` | `1` | Sites each dependent tests per loop: `1` (one shuffled), `N` (N distinct), or `-1` (all). >1 is largely redundant (dependents share gluetun's netns), at `N` execs/dependent/loop |
 | `MAX_JITTER_MS` | `0` | Optional per-dispatch jitter (ms) to spread the dependent probe burst. `0` = off (the concurrency cap already bounds it) |
 | `DRY_RUN` | `0` | Observe-only: run all detection/probing but **take no action** — log `[DRY-RUN] would …` instead of restarting/recreating. For soak-testing alongside an active monitor |
 | `STATS_FILE` | `/logs/site-stats.json` | Where persistent per-site stats are written (best-effort, atomic; survives restarts). See [Site stats & flaky-site advisory](#site-stats--flaky-site-advisory) |

--- a/README.md
+++ b/README.md
@@ -179,7 +179,8 @@ docker compose up -d
 | `DEPENDENT_VIABILITY` | `1` | Per-dependent L7 DNS/connectivity probe. `0` = interface/strand check only (no URL fetch); the interface check is always on |
 | `MAX_JITTER_MS` | `0` | Optional per-dispatch jitter (ms) to spread the dependent probe burst. `0` = off (the concurrency cap already bounds it) |
 | `DRY_RUN` | `0` | Observe-only: run all detection/probing but **take no action** — log `[DRY-RUN] would …` instead of restarting/recreating. For soak-testing alongside an active monitor |
-| `STATS_FILE` | `/logs/site-stats.json` | Where persistent per-site stats are written (best-effort; survives restarts). See [Site stats & flaky-site advisory](#site-stats--flaky-site-advisory) |
+| `STATS_FILE` | `/logs/site-stats.json` | Where persistent per-site stats are written (best-effort, atomic; survives restarts). See [Site stats & flaky-site advisory](#site-stats--flaky-site-advisory) |
+| `STATS_RETENTION_DAYS` | `90` | Drop a site's stats if it hasn't been tested (e.g. removed from `sites.conf`) for this many days; `0` keeps them forever |
 | `ADVISORY_WINDOW` | `86400` | Window (seconds) for the flaky-site advisory |
 | `ADVISORY_MIN_RESTARTS` | `5` | Minimum gluetun restarts in the window before an advisory can fire |
 | `ADVISORY_DOMINANCE` | `0.5` | Fraction of those restarts one site must cause to be flagged flaky |
@@ -416,9 +417,12 @@ it keeps a **persistent, rear-looking record** of how each site behaves and
 It writes a human-readable JSON sidecar (`STATS_FILE`, default
 `/logs/site-stats.json`) with, per site: total polls, total failures (→ failure
 rate), failure **episodes** and the average episode length in polls (how long it
-typically stays down when it breaks), how many gluetun restarts it triggered, and
-last-good / last-failure timestamps. The file survives monitor restarts; it's
-best-effort (a missing/unwritable/corrupt file never blocks the monitor).
+typically stays down when it breaks), the **longest** such streak, how many
+gluetun restarts it triggered, and first-seen / last-good / last-failure
+timestamps. It's written **every loop, crash- and power-loss-safely** (temp file
++ fsync + atomic rename), survives monitor restarts, and is best-effort (a
+missing/unwritable/corrupt file never blocks the monitor). A site removed from
+`sites.conf` is kept for `STATS_RETENTION_DAYS` (default 90) then pruned.
 
 When one site dominates the recent restarts, the monitor logs a **flaky-site
 advisory** (once, not per loop):

--- a/README.md
+++ b/README.md
@@ -191,6 +191,7 @@ docker compose up -d
 | `LOG_LEVEL` | `INFO` | `DEBUG` to include per-site/per-dependent detail lines |
 | `LOG_MAX_BYTES` | `10485760` | Rotate the `/logs` file at this size (≈10 MB); `0` disables rotation |
 | `LOG_BACKUP_COUNT` | `5` | How many rotated log backups to keep (≈60 MB total at defaults) |
+| `LOG_FILE` | `/logs/gluetun-monitor.log` | Path to the log file inside the `/logs` mount. Logs always go to stdout (`docker logs`) too; if this path isn't writable the monitor degrades to stdout-only rather than failing |
 | `TZ` | `UTC` | Timezone for log timestamps |
 
 ### Configuration is validated — sane defaults, but bad config is fatal
@@ -665,6 +666,21 @@ watchdog never fills the disk:
 
 At `LOG_LEVEL=DEBUG` the per-site/per-dependent lines are verbose (good for
 soak-testing); `INFO` is much quieter for steady-state.
+
+### Running as non-root
+
+The image runs as a non-root user (uid **10001**). The real privilege the monitor
+holds is the Docker API, not its in-container uid — running unprivileged is just
+defense in depth. Two things follow:
+
+- **Make `/logs` writable by it** — e.g. `mkdir -p ./logs && sudo chown 10001:10001
+  ./logs`. If it isn't writable the monitor still runs and logs to `docker logs`;
+  it just can't persist the file log or the site-stats sidecar. (Upgrading from v1,
+  which ran as root? Your existing `./logs` is probably root-owned — chown it.)
+- **Direct socket mount** (instead of the recommended socket proxy)? A non-root
+  process can't read the root:docker-owned `/var/run/docker.sock` by default — add
+  the host `docker` group via `group_add` (see the compose example). The
+  socket-proxy path talks TCP and needs none of this.
 
 ## Requirements
 

--- a/README.md
+++ b/README.md
@@ -143,6 +143,8 @@ docker compose up -d
 | `HEALTHY_WAIT_TIMEOUT` | `120` | Max seconds to wait for Gluetun to become healthy after restart |
 | `DEPENDENT_CONTAINER_FAILURES` | *(= `FAIL_THRESHOLD`)* | Consecutive per-dependent viability failures before remediating that dependent |
 | `MAX_PARALLEL_CHECKS` | `6` | Cap on concurrent `docker exec` probes across dependents per loop |
+| `DEPENDENT_VIABILITY` | `1` | Per-dependent L7 DNS/connectivity probe. `0` = interface/strand check only (no URL fetch); the interface check is always on |
+| `MAX_JITTER_MS` | `0` | Optional per-dispatch jitter (ms) to spread the dependent probe burst. `0` = off (the concurrency cap already bounds it) |
 | `AUTO_RECREATE` | `1` | Recreate a dependent stranded by a Gluetun recreate (id changed). Set `0` to disable → such a dependent is reported FAILED instead |
 | `DNS_WAIT_TIMEOUT` | `30` | Max seconds to wait for Gluetun DNS to stabilize after a restart |
 | `LOG_LEVEL` | `INFO` | `DEBUG` to include per-site/per-dependent detail lines |

--- a/README.md
+++ b/README.md
@@ -12,7 +12,15 @@
   <a href="https://buymeacoffee.com/cs_marshall"><img src="https://img.shields.io/badge/Buy%20Me%20a%20Coffee-ffdd00?logo=buy-me-a-coffee&logoColor=black" alt="Buy Me a Coffee"></a>
 </p>
 
-A lightweight Docker container that monitors VPN connectivity through [Gluetun](https://github.com/qdm12/gluetun) and automatically recovers from connection failures by restarting Gluetun and its dependent containers.
+A lightweight Docker container that monitors VPN connectivity through [Gluetun](https://github.com/qdm12/gluetun) and automatically recovers from connection failures — restarting Gluetun **and** healing dependent containers that get stranded when Gluetun's network namespace is rebuilt.
+
+> **v2.0.0** is a Python reimplementation that adds **dependent-aware health**:
+> the monitor now measures each dependent directly instead of inferring stack
+> health from the gateway, and self-heals a dependent that is stranded
+> loopback-only after a Gluetun restart/recreate (issue #20). Behavior and
+> configuration are backward compatible; see the [CHANGELOG](CHANGELOG.md) and
+> [ADR-0007](docs/adr/0007-reimplement-in-python.md). The design record lives in
+> [`docs/`](docs/) (tenets + ADRs + the per-loop state machine).
 
 ## Links
 
@@ -34,28 +42,38 @@ docker pull ghcr.io/csmarshall/gluetun-monitor:latest
 
 - **Multi-site health checking** - Tests connectivity to multiple endpoints simultaneously
 - **Parallel testing** - All sites tested concurrently for fast detection (bounded by single timeout)
-- **Auto-discovery** - Automatically finds containers using Gluetun's network
-- **Automatic recovery** - Restarts Gluetun and dependent containers on failure
+- **Dependent-aware health (#20)** - Measures each dependent directly (interface check + a per-container DNS/connectivity probe) instead of trusting the gateway; stops reporting healthy when a dependent is stranded
+- **Self-healing dependents** - Restarts a dependent that shares Gluetun's current namespace; **non-destructively recreates** (volumes preserved) one stranded by a Gluetun *recreate* (new container id)
+- **Auto-discovery** - Automatically finds containers using Gluetun's network, and remembers them across cycles so a dependent isn't lost when Gluetun's id changes
+- **Automatic recovery** - Restarts Gluetun on connectivity failure and re-verifies before touching dependents
 - **Endpoint logging** - Logs VPN server details (server, country, city, IP) on failures and recoveries
-- **Change detection** - Logs when dependent containers are added or removed
-- **Configurable thresholds** - Consecutive failure count before triggering restart
-- **Low resource usage** - Uses `wget --spider` (headers only, no body download)
+- **Configurable thresholds** - Consecutive failure counts, independently tunable for Gluetun and for dependents
+- **Low resource usage** - Uses `wget --spider` (headers only, no body download), bounded dependent fan-out
 
 ## How It Works
 
 ```
 ┌─────────────────────────────────────────────────────────────────┐
-│                       Gluetun Monitor                           │
+│                       Gluetun Monitor (each loop)               │
 ├─────────────────────────────────────────────────────────────────┤
-│  1. Test sites through Gluetun's network (parallel)             │
-│  2. If failures exceed threshold:                               │
-│     a. Log current VPN endpoint info                            │
-│     b. Restart Gluetun                                          │
-│     c. Wait for Gluetun to become healthy                       │
-│     d. Log new VPN endpoint info                                │
-│     e. Auto-discover and restart dependent containers           │
+│  1. Test sites through Gluetun's network (the root signal)      │
+│  2. If site failures exceed FAIL_THRESHOLD:                     │
+│       restart Gluetun, wait healthy + DNS, re-verify the set    │
+│       (only proceed if the tunnel is actually restored)         │
+│  3. For each dependent (every loop — the #20 fix):              │
+│       a. Interface check: stranded loopback-only?               │
+│       b. Else probe one shuffled name (DNS + connectivity)      │
+│       c. On confirmed failure, remediate:                       │
+│            • shares Gluetun's current id → docker restart       │
+│            • Gluetun recreated (id moved) → recreate (volumes    │
+│              preserved); disabled/denied → report FAILED        │
+│       d. Verify (running + non-loopback interface)              │
 └─────────────────────────────────────────────────────────────────┘
 ```
+
+The full per-loop state machine (22 nodes) is in
+[ADR-0006](docs/adr/0006-per-dependent-viability-testing.md); the
+restart-vs-recreate decision is [ADR-0004](docs/adr/0004-dependent-aware-health.md).
 
 ## Quick Start
 
@@ -106,8 +124,13 @@ docker compose up -d
 | `DEPENDENT_CONTAINERS` | `auto` | `auto` to discover dynamically, or comma-separated list |
 | `CHECK_INTERVAL` | `30` | Seconds between health checks |
 | `TIMEOUT` | `10` | Seconds to wait for each site test |
-| `FAIL_THRESHOLD` | `2` | Consecutive failures before triggering restart |
+| `FAIL_THRESHOLD` | `2` | Consecutive site failures before restarting Gluetun |
 | `HEALTHY_WAIT_TIMEOUT` | `120` | Max seconds to wait for Gluetun to become healthy after restart |
+| `DEPENDENT_CONTAINER_FAILURES` | *(= `FAIL_THRESHOLD`)* | Consecutive per-dependent viability failures before remediating that dependent |
+| `MAX_PARALLEL_CHECKS` | `6` | Cap on concurrent `docker exec` probes across dependents per loop |
+| `AUTO_RECREATE` | `1` | Recreate a dependent stranded by a Gluetun recreate (id changed). Set `0` to disable → such a dependent is reported FAILED instead |
+| `DNS_WAIT_TIMEOUT` | `30` | Max seconds to wait for Gluetun DNS to stabilize after a restart |
+| `LOG_LEVEL` | `INFO` | `DEBUG` to include per-site/per-dependent detail lines |
 | `TZ` | `UTC` | Timezone for log timestamps |
 
 ### Variable Details
@@ -188,6 +211,51 @@ environment:
   - DEPENDENT_CONTAINERS=container1,container2,container3
 ```
 
+## Dependent-Aware Health (issue #20)
+
+Dependents that use `network_mode: "service:gluetun"` (or `container:gluetun`)
+share Gluetun's **network namespace**, and that share is bound to a specific
+container **instance**. When Gluetun is restarted or recreated (e.g. a Watchtower
+image update), those dependents are left **stranded loopback-only** — `Running`,
+but with only the `lo` interface and no route to the internet. Because v1.x
+tested connectivity *only from inside Gluetun*, every check passed and the
+monitor reported healthy while the stack was broken.
+
+v2 closes that blind spot by measuring each dependent directly, every loop:
+
+1. **Interface check** — `ls /sys/class/net` inside the dependent. Only `lo` ⇒
+   stranded (a hard failure; re-checked once because it won't self-heal).
+2. **Viability probe** — for a live dependent, one **shuffled** resolvable name
+   from your `sites.conf` is fetched *from inside that container*, proving its own
+   DNS + connectivity. A different name each loop means
+   `DEPENDENT_CONTAINER_FAILURES` consecutive failures = "this container can't
+   reach N *different* names" (a container fault), not "one URL was down". If
+   `sites.conf` has only IP literals, the monitor warns that dependent DNS can't
+   be validated and falls back to a connectivity-only IP probe.
+3. **Remediation** — keyed on the dependent's `NetworkMode` target vs Gluetun's
+   current container id:
+   - **same id** (incl. the monitor's own Gluetun restart) → `docker restart` the
+     dependent — it rejoins the rebuilt namespace. Cheap, no new permissions.
+   - **id changed** (Gluetun was replaced) → **recreate** the dependent.
+     `NetworkMode` is immutable, so there is no in-place fix. The recreate is
+     **non-destructive**: all mounts — named, bind, and **anonymous** volumes —
+     are carried forward by source and the old container is removed *without*
+     `-v`, so only the ephemeral writable layer is lost.
+   - recreate **disabled** (`AUTO_RECREATE=0`) or denied → the dependent is
+     reported **FAILED** loudly rather than papered over.
+
+A dependent that fails counts up per-container and resets on any passing loop —
+counters are in-memory with no backoff (recovery is cheap and non-destructive, so
+the monitor simply re-acts each cycle). distroless/scratch dependents with no
+shell can't be exec-probed and fall back to the inspect-based signals.
+
+> **Note on discovery + recreate:** a dependent stranded by a Gluetun *recreate*
+> still points at the dead old id, so auto-discovery (which matches Gluetun's
+> *current* id/name) no longer recognizes it. A running monitor remembers
+> dependents across cycles and handles this automatically. If you start the
+> monitor *after* such a strand already exists, name the dependents explicitly
+> via `DEPENDENT_CONTAINERS` so they're tracked from the first loop.
+
 ## Docker Compose Example
 
 ### Minimal Configuration (with socket proxy)
@@ -261,8 +329,14 @@ services:
       - DEPENDENT_CONTAINERS=auto      # auto-discovery (default)
       - CHECK_INTERVAL=30              # seconds between checks
       - TIMEOUT=10                     # seconds per site test
-      - FAIL_THRESHOLD=2               # consecutive failures to trigger restart
+      - FAIL_THRESHOLD=2               # consecutive site failures to restart gluetun
       - HEALTHY_WAIT_TIMEOUT=120       # seconds to wait for healthy status
+      # --- v2 dependent-aware knobs (all optional) ---
+      - DEPENDENT_CONTAINER_FAILURES=2 # consecutive per-dependent failures to remediate (default = FAIL_THRESHOLD)
+      - MAX_PARALLEL_CHECKS=6          # cap on concurrent dependent probes
+      - AUTO_RECREATE=1                # recreate a dependent stranded by a gluetun recreate (0 to disable)
+      - DNS_WAIT_TIMEOUT=30            # seconds to wait for gluetun DNS after restart
+      - LOG_LEVEL=INFO                 # DEBUG for per-site/per-dependent detail
     volumes:
       - ./sites.conf:/config/sites.conf:ro
       - ./logs:/logs
@@ -300,7 +374,7 @@ Note: This gives the container full read access to the Docker API. The socket pr
 ### Startup
 ```
 [2025-01-15 10:00:00] [INFO] Gluetun Monitor starting...
-[2025-01-15 10:00:00] [INFO] Config: CHECK_INTERVAL=30s, TIMEOUT=10s, FAIL_THRESHOLD=2
+[2025-01-15 10:00:00] [INFO] Config: CHECK_INTERVAL=30s, TIMEOUT=10s, FAIL_THRESHOLD=2, DEPENDENT_CONTAINER_FAILURES=2, AUTO_RECREATE=1
 [2025-01-15 10:00:00] [INFO] Monitoring container: gluetun
 [2025-01-15 10:00:00] [INFO] Prerequisites check passed
 [2025-01-15 10:00:00] [INFO] Docker connection: socket proxy (tcp://docker-socket-proxy:2375)
@@ -308,23 +382,26 @@ Note: This gives the container full read access to the Docker API. The socket pr
 [2025-01-15 10:00:00] [ENDPOINT] Status: STARTUP | IP: 203.x.x.x | Country: United States | City: New York | VPN Server: us123.vpn.com | Reason: Monitor starting
 ```
 
-### Failure and Recovery
+### Gluetun connectivity failure + recovery
 ```
 [2025-01-15 10:10:00] [WARN] Site https://example.com failed 2 consecutive times - THRESHOLD REACHED - Network failure (DNS or connection)
 [2025-01-15 10:10:00] [ERROR] Failed sites (exceeded threshold): https://example.com
 [2025-01-15 10:10:00] [WARN] Health check failed, initiating recovery...
 [2025-01-15 10:10:00] [ENDPOINT] Status: FAILING | IP: 203.x.x.x | Country: United States | City: New York | VPN Server: us123.vpn.com | Reason: Site connectivity test failed
-[2025-01-15 10:10:05] [INFO] Restarting gluetun-nordvpn-wg to force new endpoint...
-[2025-01-15 10:10:35] [INFO] gluetun-nordvpn-wg is healthy after 30s
+[2025-01-15 10:10:05] [INFO] Restarting gluetun to force new endpoint...
+[2025-01-15 10:10:35] [INFO] gluetun is healthy after 30s
+[2025-01-15 10:10:38] [INFO] DNS and connectivity verified after 3s
 [2025-01-15 10:10:40] [ENDPOINT] Status: NEW | IP: 89.x.x.x | Country: Germany | City: Frankfurt | VPN Server: de456.vpn.com | Reason: After restart
-[2025-01-15 10:10:40] [INFO] Discovering and restarting dependent containers...
-[2025-01-15 10:10:41] [INFO] Discovered dependent containers: app1,app2
-[2025-01-15 10:10:42] [INFO] Restarting app1...
-[2025-01-15 10:10:44] [INFO] app1 restarted successfully
-[2025-01-15 10:10:46] [INFO] Restarting app2...
-[2025-01-15 10:10:48] [INFO] app2 restarted successfully
-[2025-01-15 10:10:48] [INFO] Dependent container restart complete
-[2025-01-15 10:10:48] [INFO] Recovery complete
+[2025-01-15 10:10:40] [INFO] Connectivity verified after restart
+```
+
+### Dependent stranded by a Gluetun recreate (self-healed)
+```
+[2025-01-15 11:00:00] [WARN] Remediating dependent qbittorrent: stranded loopback-only
+[2025-01-15 11:00:00] [WARN] qbittorrent netns target moved (gluetun recreated) — recreate required
+[2025-01-15 11:00:00] [WARN] Recreating qbittorrent (re-homing netns onto gluetun 9f3c1a2b4d5e)
+[2025-01-15 11:00:02] [INFO] qbittorrent recreated as 7a1b2c3d4e5f and started
+[2025-01-15 11:00:04] [INFO] qbittorrent verified healthy after remediation
 ```
 
 ## Requirements
@@ -400,7 +477,10 @@ docker inspect --format='{{.HostConfig.NetworkMode}}' <container_id>
 ### When Discovery Runs
 
 - **At startup** - For logging which containers will be managed
-- **Before each restart** - To catch any containers added since startup
+- **Every loop** - So newly added containers are picked up promptly, and so a
+  dependent is re-checked each cycle. Discovered containers are also remembered
+  across cycles, so a dependent isn't lost when Gluetun's container id changes
+  (see [Dependent-Aware Health](#dependent-aware-health-issue-20)).
 
 This approach means no configuration is needed - containers are discovered dynamically based on their actual Docker configuration.
 
@@ -412,9 +492,9 @@ The recommended deployment uses a [Docker socket proxy](https://github.com/Tecna
 
 | Proxy Setting | Required For |
 |---------------|-------------|
-| `CONTAINERS=1` | Listing, inspecting, and reading logs of containers |
-| `POST=1` | Restarting containers (also enables other POST operations like stop/kill on any container) |
-| `EXEC=1` | Running connectivity tests inside the Gluetun container |
+| `CONTAINERS=1` | Listing, inspecting, and reading logs of containers; creating the replacement when recreating a stranded dependent |
+| `POST=1` | Restarting, removing, and starting containers (the recreate path rides on the same `POST` flag — no new permission) |
+| `EXEC=1` | Running connectivity/interface probes inside Gluetun and the dependents |
 
 The proxy and gluetun-monitor communicate over an isolated Docker network (`docker-proxy`). Only the proxy container has access to the Docker socket.
 
@@ -436,6 +516,27 @@ Or manually:
 ```bash
 docker build -t gluetun-monitor .
 ```
+
+## Development
+
+v2 is a Python package (`gluetun_monitor`). The whole monitor is unit-testable
+without a Docker daemon — a fake client is injected at the Docker seam.
+
+```bash
+python -m venv .venv && . .venv/bin/activate
+pip install -e '.[dev]'
+
+ruff check gluetun_monitor tests     # lint
+mypy gluetun_monitor                 # types (strict)
+pytest                               # tests (incl. the differential suite vs. bash)
+pytest --cov=gluetun_monitor         # with coverage
+```
+
+The legacy `gluetun-monitor.sh` is retained as the **differential oracle**: the
+`differential`-marked tests execute its actual functions and assert the Python
+port matches (the no-regressions gate from
+[ADR-0007](docs/adr/0007-reimplement-in-python.md)). See
+[DEVELOPMENT.md](DEVELOPMENT.md) for more.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -486,6 +486,30 @@ no restart needed). Tune with `ADVISORY_WINDOW`, `ADVISORY_MIN_RESTARTS`, and
 > applying the cheap restart fix and escalates to you. (A future automatic
 > back-off is possible; it would be opt-in.)
 
+### Viewing the stats: `gluetun-monitor-stats`
+
+The image ships a read-only command that renders the sidecar as a per-site matrix
+(it reads the same file the monitor writes, using the same code, so the numbers
+always match). It touches no Docker API and never mutates state — safe to run any
+time:
+
+```console
+$ docker exec gluetun-monitor gluetun-monitor-stats
+monitor v2.0.0  loops=205  runtime=2.0h  gluetun_restarts=0  remediations=0  advisories=0
+tracking since 2026-06-02 14:24
+
+site                     polls  fails  rate%   avg   p50   p90   p99   max  eff%  last_fail
+-----------------------  -----  -----  -----  ----  ----  ----  ----  ----  ----  ---------
+https://thepiratebay.org   319      0   0.00  2255  2191  2527  2679  3136   n/a  —
+https://www.google.com     319      0   0.00   716   631   911  1238  1274   n/a  —
+...
+latency in ms; eff% = restart-effectiveness (n/a = no restarts triggered)
+```
+
+Sites are sorted by `p90` (worst tail first) by default; `--sort` accepts
+`p90|p99|avg|max|p50|rate|polls|name`. Add `--json` to emit the same data for
+`jq`/dashboards, and `--file PATH` if your `STATS_FILE` lives elsewhere.
+
 ## Docker Compose Example
 
 ### Minimal Configuration (with socket proxy)

--- a/README.md
+++ b/README.md
@@ -298,18 +298,14 @@ retry meaningfully helps.
 
 ### Site Test Success/Failure Logic
 
-The monitor distinguishes between **connectivity failures** (VPN broken) and **site errors** (VPN working, site returned an error):
+The monitor distinguishes between **connectivity failures** (VPN broken) and **site errors** (VPN working, site returned an error). The decision is **HTTP-response-first**, not exit-code-based:
 
-| wget Exit Code | Meaning | Treated As | Rationale |
-|----------------|---------|------------|-----------|
-| 0 | Success (HTTP 2xx/3xx) | **PASS** | Site responded successfully |
-| 6 | Authentication required | **PASS** | Site responded (VPN working) |
-| 8 | Server error (HTTP 4xx/5xx) | **PASS** | Site responded (VPN working) |
-| 4 | Network failure | **FAIL** | DNS or connection failed |
-| 5 | SSL verification failure | **FAIL** | Possible MITM or connectivity issue |
-| 1-3, 7 | Other errors | **FAIL** | Various connectivity issues |
+- **Any HTTP response = PASS** — including 401/403/404/5xx. A status line proves DNS resolved, the connection traversed the tunnel, and a server answered, so the tunnel is up regardless of *what* the server said (Tenet 3 — a broken tunnel is not a sad website).
+- **Only a failure to get any HTTP response = FAIL** — DNS failure, connection refused, TLS error, or timeout.
 
-**Key insight:** If a site returns HTTP 403 Forbidden or 503 Service Unavailable, the VPN is working - the site just doesn't like the request. Only actual network/DNS failures indicate a VPN problem.
+This is also why it's correct across wget implementations: gluetun ships **GNU wget** (HTTP errors → exit 6/8), but dependent containers commonly run **busybox wget** (exit 1 for *any* HTTP error). Keying on "did we get an HTTP status?" rather than on the exit code means a busybox dependent's harmless 404 is read as a PASS, not a spurious failure. The wget exit code is used only as a **fallback** when no HTTP status line was captured at all (GNU's `0/6/8` = "responded").
+
+**Key insight:** If a site returns HTTP 403 Forbidden or 503 Service Unavailable, the VPN is working — the site just doesn't like the request. Only actual network/DNS/TLS/timeout failures indicate a VPN problem.
 
 #### `FAIL_THRESHOLD`
 Number of **consecutive** failures for a site before triggering a restart. This prevents restarts from transient network blips.

--- a/README.md
+++ b/README.md
@@ -107,6 +107,18 @@ https://1.1.1.1
 # Add sites you need to reach through VPN
 ```
 
+Alternatively (or in addition), you can provide sites entirely via the **`SITES`**
+environment variable — handy if you'd rather not mount a file:
+
+```yaml
+environment:
+  - SITES=https://www.google.com,https://cloudflare.com
+```
+
+The two sources are **unioned** (file + env, de-duplicated). At least one site is
+required — see [Configuration](#configuration). The monitor must reach a real
+endpoint set to do its job, so it refuses to start with none.
+
 ### 4. Deploy
 
 ```bash
@@ -120,8 +132,10 @@ docker compose up -d
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `DOCKER_HOST` | *(unset)* | Docker daemon endpoint. Set to `tcp://docker-socket-proxy:2375` when using a socket proxy |
-| `GLUETUN_CONTAINER` | `gluetun` | Name of the Gluetun container to monitor |
-| `DEPENDENT_CONTAINERS` | `auto` | `auto` to discover dynamically, or comma-separated list |
+| `GLUETUN_CONTAINER` | `gluetun` | Name of the Gluetun container to monitor (must exist, else fatal) |
+| `CONFIG_FILE` | `/config/sites.conf` | Path to the sites file (re-read each loop → live-editable) |
+| `SITES` | *(unset)* | Comma-separated test URLs, **unioned** with the sites file. Set at startup (not live-reloaded) |
+| `DEPENDENT_CONTAINERS` | `auto` | `auto` to discover dynamically, or comma-separated list (every named container must exist, else fatal) |
 | `CHECK_INTERVAL` | `30` | Seconds between health checks |
 | `TIMEOUT` | `10` | Seconds to wait for each site test |
 | `FAIL_THRESHOLD` | `2` | Consecutive site failures before restarting Gluetun |
@@ -133,7 +147,37 @@ docker compose up -d
 | `LOG_LEVEL` | `INFO` | `DEBUG` to include per-site/per-dependent detail lines |
 | `TZ` | `UTC` | Timezone for log timestamps |
 
+### Configuration is validated — sane defaults, but bad config is fatal
+
+The design goal is **good results with zero extra config**: with a container named
+`gluetun` and a site to test, everything else has a sane default. But to protect
+the wider system, the monitor **refuses to start** (exits non-zero) rather than
+*guess* around misconfiguration:
+
+- **Malformed env value** (a non-integer `CHECK_INTERVAL`, an unrecognized
+  `AUTO_RECREATE`, an invalid `LOG_LEVEL`, …) → fatal. An *unset* variable is just
+  its default; a *set-but-unparseable* one is an error we won't paper over.
+- **No testable sites** (no `sites.conf` *and* no `SITES`, or both empty) → fatal.
+  A monitor that tests nothing would report fake-green forever.
+- **`GLUETUN_CONTAINER` doesn't exist** → fatal (nothing to monitor).
+- **Explicit `DEPENDENT_CONTAINERS` names a container that doesn't exist** → fatal.
+  You told us exactly what to manage; we won't silently drop or guess around a
+  name we can't find (it could mean acting on the wrong container). `auto` finding
+  zero is fine — that's gluetun-only monitoring, a valid setup.
+
 ### Variable Details
+
+#### Sites — `CONFIG_FILE` + `SITES`
+Test URLs come from two **unioned** sources (de-duplicated):
+- **`CONFIG_FILE`** (default `/config/sites.conf`) — one URL per line, `#` comments
+  allowed. **Re-read every loop**, so adding/removing a URL takes effect on the
+  next check with no restart.
+- **`SITES`** — a comma-separated list in the environment, for config-via-env
+  parity with the other knobs (no file mount needed). Fixed at process start —
+  changing it requires a container restart.
+
+Provide either, or both. At least one URL total is required or the monitor won't
+start (see above).
 
 #### `DOCKER_HOST`
 When unset, the Docker CLI connects via the local socket (`/var/run/docker.sock`). Set this to `tcp://<proxy-host>:2375` to connect through a [Docker socket proxy](#docker-socket-proxy) instead of mounting the socket directly. See the [Docker Socket Proxy](#docker-socket-proxy) section for setup details.
@@ -146,19 +190,17 @@ The name of your Gluetun container as shown in `docker ps`. This is the containe
 - Used to extract VPN endpoint information from logs
 
 #### `DEPENDENT_CONTAINERS`
-Controls which containers are restarted after Gluetun recovers:
-- `auto` - Automatically discovers containers using `network_mode: "container:<GLUETUN_CONTAINER>"`
-- `container1,container2` - Comma-separated list of container names to restart
-
-Auto-discovery queries the Docker API to inspect each running container's `NetworkMode` setting.
+Controls which dependents are watched and healed:
+- `auto` - Automatically discovers containers using `network_mode: "container:<GLUETUN_CONTAINER>"` (queries the Docker API for each running container's `NetworkMode`). Discovering zero is fine — gluetun-only monitoring.
+- `container1,container2` - Comma-separated list of container names. **Every name must exist at startup or the monitor exits** — an explicit list is a contract, and we won't guess around a missing name. If your dependents start alongside the monitor, order startup (`depends_on:`) so they exist first, or use `auto`.
 
 #### `CHECK_INTERVAL`
-Time in seconds between health check cycles. Each cycle tests all configured sites in parallel.
+Time in seconds between health check cycles.
 
-**Note:** The actual interval is `CHECK_INTERVAL` + up to `TIMEOUT` seconds (for parallel site tests).
+**Note:** sites are tested concurrently, bounded by `MAX_PARALLEL_CHECKS` (default 6). With ≤6 sites a cycle's tests finish within one `TIMEOUT`; with more, they run in batches, so a cycle can take up to `ceil(sites / MAX_PARALLEL_CHECKS) × TIMEOUT`.
 
 #### `TIMEOUT`
-Maximum seconds to wait for each site to respond. Since tests run in parallel, this is the maximum time for the entire test batch, not per-site.
+Maximum seconds to wait for each site to respond. Tests run concurrently (up to `MAX_PARALLEL_CHECKS` at a time), so this bounds each batch rather than each individual site.
 
 Uses `wget --spider` which only fetches headers (no response body downloaded).
 

--- a/README.md
+++ b/README.md
@@ -618,12 +618,17 @@ gluetun container (through the tunnel); each dependent logs its interface/route
 check, then its viability result.
 ```
 [2025-01-15 10:00:00] [CHECK] Start
-[2025-01-15 10:00:02] [DEBUG] [gateway:gluetun] site https://www.google.com: ok (769ms)
-[2025-01-15 10:00:02] [DEBUG] [gateway:gluetun] site https://cloudflare.com: ok (1768ms)
-[2025-01-15 10:00:04] [DEBUG] [dependent:qbittorrent] interface check: live [eth0,lo,tun0]
-[2025-01-15 10:00:04] [DEBUG] [dependent:qbittorrent] viability: https://cloudflare.com: resolved + connected (HTTP 200) [wget] [fails 0]
+[2025-01-15 10:00:02] [DEBUG] [gateway:gluetun] reach ok: https://www.google.com (HTTP 200, 769ms)
+[2025-01-15 10:00:02] [DEBUG] [gateway:gluetun] reach ok: https://cloudflare.com (HTTP 200, 1768ms)
+[2025-01-15 10:00:04] [DEBUG] [dependent:qbittorrent] link live: eth0,lo,tun0
+[2025-01-15 10:00:04] [DEBUG] [dependent:qbittorrent] reach ok: cloudflare.com (HTTP 200) [wget]
 [2025-01-15 10:00:04] [CHECK] End - Sleeping 30s
 ```
+
+Each line reads `[<role>:<name>] <dim> <verdict>: <target> (<detail>)`. The
+dimension is `link` (the L3 interface/route check) or `reach` (DNS + connectivity);
+the verdict is `ok` / `fail` / `stranded` / `?` (couldn't verify). A healthy line
+omits the failure counter — a failing one shows `[2/2 → restart]`.
 
 Each test line is tagged `[gateway:<name>]` (the gluetun VPN container, where the
 site tests run — through the tunnel) or `[dependent:<name>]`, so you can tell at a
@@ -631,9 +636,9 @@ glance what kind of container a line is about (`grep gateway:` / `grep dependent
 
 ### Gluetun connectivity failure + recovery
 ```
-[2025-01-15 10:10:00] [WARN] [gateway:gluetun] site https://example.com: FAILED 2x consecutive - THRESHOLD REACHED - Network failure (DNS or connection)
-[2025-01-15 10:10:00] [ERROR] [gateway:gluetun] failed sites (exceeded threshold): https://example.com
-[2025-01-15 10:10:00] [WARN] Health check failed, initiating recovery...
+[2025-01-15 10:10:00] [WARN] [gateway:gluetun] reach fail: https://example.com (Network failure (DNS or connection)) [2/2 → restart]
+[2025-01-15 10:10:00] [ERROR] [gateway:gluetun] restart triggered by: https://example.com
+[2025-01-15 10:10:00] [WARN] Gluetun unhealthy → restarting
 [2025-01-15 10:10:00] [ENDPOINT] Status: FAILING | IP: 203.x.x.x | Country: United States | City: New York | VPN Server: us123.vpn.com | Reason: Site connectivity test failed
 [2025-01-15 10:10:05] [INFO] Restarting gluetun to force new endpoint...
 [2025-01-15 10:10:35] [INFO] gluetun is healthy after 30s
@@ -645,7 +650,7 @@ glance what kind of container a line is about (`grep gateway:` / `grep dependent
 ### Dependent stranded by a Gluetun recreate (self-healed)
 ```
 [2025-01-15 11:00:00] [WARN] Remediating dependent qbittorrent: stranded loopback-only
-[2025-01-15 11:00:00] [WARN] qbittorrent netns target moved (gluetun recreated) — recreate required
+[2025-01-15 11:00:00] [WARN] qbittorrent netns moved (gluetun recreated) → recreate
 [2025-01-15 11:00:00] [WARN] Recreating qbittorrent (re-homing netns onto gluetun 9f3c1a2b4d5e)
 [2025-01-15 11:00:02] [INFO] qbittorrent recreated as 7a1b2c3d4e5f and started
 [2025-01-15 11:00:04] [INFO] qbittorrent verified healthy after remediation

--- a/README.md
+++ b/README.md
@@ -171,7 +171,8 @@ docker compose up -d
 | `DEPENDENT_CONTAINERS` | `auto` | `auto` to discover dynamically, or comma-separated list (every named container must exist, else fatal) |
 | `EXCLUDE_CONTAINERS` | *(unset)* | Comma-separated container names to **never** manage (denylist). Filters auto-discovery and subtracts from an explicit list; exclude wins on overlap |
 | `CHECK_INTERVAL` | `30` | Seconds between health checks |
-| `TIMEOUT` | `10` | Seconds to wait for each site test |
+| `TIMEOUT` | `10` | Per-request network timeout, applied identically to every probe — `wget --timeout` (gluetun site tests **and** the dependent-container probes) and `ping -W` |
+| `WGET_TRIES` | `1` | Attempts per `wget` probe (the shuffle + consecutive-failure thresholds, not retries, are how noise is tolerated) |
 | `FAIL_THRESHOLD` | `2` | Consecutive site failures before restarting Gluetun |
 | `HEALTHY_WAIT_TIMEOUT` | `120` | Max seconds to wait for Gluetun to become healthy after restart |
 | `DEPENDENT_CONTAINER_FAILURES` | *(= `FAIL_THRESHOLD`)* | Consecutive per-dependent viability failures before remediating that dependent |
@@ -261,6 +262,38 @@ Time in seconds between health check cycles.
 Maximum seconds to wait for each site to respond. Tests run concurrently (up to `MAX_PARALLEL_CHECKS` at a time), so this bounds each batch rather than each individual site.
 
 Uses `wget --spider` which only fetches headers (no response body downloaded).
+
+### Timeouts & retries — one model, everywhere
+
+There is **one per-request timeout knob, `TIMEOUT`**, and it is applied identically
+to every network probe the monitor makes:
+
+| where | command | uses |
+|---|---|---|
+| gluetun site tests (through the tunnel) | `wget --spider --timeout=$TIMEOUT --tries=$WGET_TRIES` | `TIMEOUT`, `WGET_TRIES` |
+| dependent viability (inside each dependent) | the same `wget …` | `TIMEOUT`, `WGET_TRIES` |
+| DNS fallback (`ping`) | `ping -W $TIMEOUT` | `TIMEOUT` |
+| post-restart DNS-readiness probe | the same `wget …` | `TIMEOUT`, `WGET_TRIES` |
+
+So setting `TIMEOUT=10` **does** flow straight down to the `wget` run inside the
+dependent containers (busybox or GNU — both honor `--timeout`). `getent`/`nslookup`
+have no timeout flag and fall back to the container's resolver config (the cascade
+moves on if a tool is slow/absent).
+
+Don't confuse the **per-request** `TIMEOUT` with the **overall wait budgets** used
+only after a gluetun restart: `HEALTHY_WAIT_TIMEOUT` (wait for gluetun's
+healthcheck) and `DNS_WAIT_TIMEOUT` (poll for DNS to stabilize). Those are loops;
+`TIMEOUT` is each individual request inside them.
+
+**How the monitor "hunts" for a good result — and why `WGET_TRIES` defaults to 1.**
+Reliability comes from *breadth and repetition over time*, not from retrying a
+single request: gluetun tests the **whole site set** each loop and only acts after
+`FAIL_THRESHOLD` **consecutive** loops fail; each dependent tests **one shuffled
+site per loop** (so over loops it covers many names) and only acts after
+`DEPENDENT_CONTAINER_FAILURES` consecutive failures. That shuffle-and-threshold
+design already absorbs a flaky site, so a single fast attempt (`WGET_TRIES=1`) is
+the right default — raise it only if your links are lossy enough that one in-loop
+retry meaningfully helps.
 
 ### Site Test Success/Failure Logic
 

--- a/README.md
+++ b/README.md
@@ -178,6 +178,7 @@ docker compose up -d
 | `MAX_PARALLEL_CHECKS` | `6` | Cap on concurrent `docker exec` probes across dependents per loop |
 | `DEPENDENT_VIABILITY` | `1` | Per-dependent L7 DNS/connectivity probe. `0` = interface/strand check only (no URL fetch); the interface check is always on |
 | `MAX_JITTER_MS` | `0` | Optional per-dispatch jitter (ms) to spread the dependent probe burst. `0` = off (the concurrency cap already bounds it) |
+| `DRY_RUN` | `0` | Observe-only: run all detection/probing but **take no action** — log `[DRY-RUN] would …` instead of restarting/recreating. For soak-testing alongside an active monitor |
 | `AUTO_RECREATE` | `1` | Recreate a dependent stranded by a Gluetun recreate (id changed). Set `0` to disable → such a dependent is reported FAILED instead |
 | `DNS_WAIT_TIMEOUT` | `30` | Max seconds to wait for Gluetun DNS to stabilize after a restart |
 | `LOG_LEVEL` | `INFO` | `DEBUG` to include per-site/per-dependent detail lines |

--- a/README.md
+++ b/README.md
@@ -312,7 +312,11 @@ shell can't be exec-probed and fall back to the inspect-based signals.
 > *current* id/name) no longer recognizes it. A running monitor remembers
 > dependents across cycles and handles this automatically. If you start the
 > monitor *after* such a strand already exists, name the dependents explicitly
-> via `DEPENDENT_CONTAINERS` so they're tracked from the first loop.
+> via `DEPENDENT_CONTAINERS` so they're tracked from the first loop. At startup
+> the monitor logs a **WARN** naming any running container stranded on a
+> now-dead netns parent, so you know which ones to add — it won't auto-recreate
+> them, since an orphan whose parent is gone can't be confirmed as *this*
+> gluetun's dependent (first, do no harm).
 
 ## What it will and won't do (and why your data is safe)
 

--- a/README.md
+++ b/README.md
@@ -674,14 +674,20 @@ soak-testing); `INFO` is much quieter for steady-state.
 
 ### Running as non-root
 
-The image runs as a non-root user (uid **10001**). The real privilege the monitor
-holds is the Docker API, not its in-container uid — running unprivileged is just
-defense in depth. Two things follow:
+The image runs as a non-root user, default **uid/gid 1000** (the first real user
+on a typical single-user host). The real privilege the monitor holds is the Docker
+API, not its in-container uid — running unprivileged is just defense in depth.
+Three things follow:
 
-- **Make `/logs` writable by it** — e.g. `mkdir -p ./logs && sudo chown 10001:10001
-  ./logs`. If it isn't writable the monitor still runs and logs to `docker logs`;
-  it just can't persist the file log or the site-stats sidecar. (Upgrading from v1,
-  which ran as root? Your existing `./logs` is probably root-owned — chown it.)
+- **`/logs` must be writable by the runtime uid.** If your host user is `1000`
+  (the common case — check with `id`), a `./logs` you created is already owned by
+  it and just works. If it isn't writable the monitor still runs and logs to
+  `docker logs`; it just can't persist the file log or the site-stats sidecar.
+- **Different uid?** Override at runtime to match whoever owns `/logs` —
+  `user: "${UID}:${GID}"` (or e.g. `user: "1000:1000"`) in the compose service.
+  No image rebuild needed.
+- **Upgrading from v1** (which ran as root)? Your existing `./logs` files are
+  root-owned — `sudo chown -R 1000:1000 ./logs` (or to whatever uid you run as).
 - **Direct socket mount** (instead of the recommended socket proxy)? A non-root
   process can't read the root:docker-owned `/var/run/docker.sock` by default — add
   the host `docker` group via `group_add` (see the compose example). The

--- a/README.md
+++ b/README.md
@@ -312,6 +312,54 @@ shell can't be exec-probed and fall back to the inspect-based signals.
 > monitor *after* such a strand already exists, name the dependents explicitly
 > via `DEPENDENT_CONTAINERS` so they're tracked from the first loop.
 
+## What it will and won't do (and why your data is safe)
+
+gluetun-monitor is a watchdog that *restarts and recreates containers*, so it
+owes you a clear contract about exactly what it touches — and what it can't.
+
+### It WILL
+- Restart **gluetun** on a confirmed connectivity failure (to force a new endpoint).
+- Restart a **dependent** that shares gluetun's *current* network namespace.
+- **Recreate** a dependent stranded by a gluetun *recreate* (its netns id moved) —
+  non-destructively (see below). On by default; `AUTO_RECREATE=0` disables it.
+- Report a loud, explicit **FAILED** state when it can't heal — never fake-green.
+
+### It WON'T
+- Pull or build images, or change image tags/versions.
+- Edit your compose files, env, or container configuration.
+- **Delete volumes or data** (it never runs `docker rm -v`).
+- Touch containers that aren't gluetun dependents, or any you list in
+  `EXCLUDE_CONTAINERS`.
+- Act on targets you didn't choose — sites you didn't configure, or an orphan it
+  can't confidently attribute to gluetun (Tenet 1).
+- Start at all on malformed config — it fails loud instead of guessing.
+
+### Why your data is safe across a recreate
+A "recreate" replaces the container **object**, not its data. Docker volumes are
+owned by the daemon, not the container, so:
+
+- **Named volumes, bind mounts, and even anonymous volumes are carried forward** —
+  the monitor reads the old container's mounts and re-attaches the *same* volumes
+  by source on the new container, then removes the old container **without `-v`**.
+  No volume is ever deleted. (Mechanism + empirical data-loss test: [ADR-0005](docs/adr/0005-recreate-mechanism.md).)
+- The **only** thing lost is the container's ephemeral **writable layer** — files
+  written *inside* the container that aren't on a volume. That layer is ephemeral
+  by design (recreated from the image). Anything you care about lives on a volume,
+  and volumes survive.
+
+### What's actually at risk vs. what only sounds risky
+
+| Sounds alarming | The reality |
+|---|---|
+| "It *recreates* my container!" | New container **ID** and a **brief downtime** during the swap. Volume data is preserved. |
+| "A watchdog with Docker access" | Behind the default socket-proxy it's limited to container ops (list/inspect/logs/restart/exec/create/remove) — no image pull/build, no host access. |
+| "Reconstruction might drop a setting" | The genuine residual risk: a recreate copies the container's config + mounts, and a fidelity bug could drop a *non-volume* setting. Mitigations: it **verifies** after recreating, `AUTO_RECREATE=0` disables recreate entirely, and `EXCLUDE_CONTAINERS` protects specific containers. |
+
+### Your controls
+- **`AUTO_RECREATE=0`** — never recreate; alert instead (restart-only recovery).
+- **`EXCLUDE_CONTAINERS=...`** — a denylist of containers to never touch.
+- **Socket proxy** (default) — cap the Docker API surface the monitor can use.
+
 ## Docker Compose Example
 
 ### Minimal Configuration (with socket proxy)

--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@ docker compose up -d
 | `CONFIG_FILE` | `/config/sites.conf` | Path to the sites file (re-read each loop → live-editable) |
 | `SITES` | *(unset)* | Comma-separated test URLs, **unioned** with the sites file. Set at startup (not live-reloaded) |
 | `DEPENDENT_CONTAINERS` | `auto` | `auto` to discover dynamically, or comma-separated list (every named container must exist, else fatal) |
+| `EXCLUDE_CONTAINERS` | *(unset)* | Comma-separated container names to **never** manage (denylist). Filters auto-discovery and subtracts from an explicit list; exclude wins on overlap |
 | `CHECK_INTERVAL` | `30` | Seconds between health checks |
 | `TIMEOUT` | `10` | Seconds to wait for each site test |
 | `FAIL_THRESHOLD` | `2` | Consecutive site failures before restarting Gluetun |
@@ -193,6 +194,19 @@ The name of your Gluetun container as shown in `docker ps`. This is the containe
 Controls which dependents are watched and healed:
 - `auto` - Automatically discovers containers using `network_mode: "container:<GLUETUN_CONTAINER>"` (queries the Docker API for each running container's `NetworkMode`). Discovering zero is fine — gluetun-only monitoring.
 - `container1,container2` - Comma-separated list of container names. **Every name must exist at startup or the monitor exits** — an explicit list is a contract, and we won't guess around a missing name. If your dependents start alongside the monitor, order startup (`depends_on:`) so they exist first, or use `auto`.
+
+#### `EXCLUDE_CONTAINERS`
+A comma-separated **denylist** of containers the monitor must **never** manage —
+never interface-checked, viability-tested, restarted, or recreated. Most useful
+with `auto` ("discover everything *except* these") so you keep auto-discovery of
+new dependents while protecting specific ones. It also subtracts from an explicit
+`DEPENDENT_CONTAINERS` list.
+
+If a name appears in **both** `DEPENDENT_CONTAINERS` and `EXCLUDE_CONTAINERS`,
+**exclude wins** and the monitor warns — the contradiction resolves toward *not*
+touching the container ("first, do no harm") rather than failing. An exclude name
+that matches no container warns too (likely a typo — the container you meant to
+protect would otherwise still be managed).
 
 #### `CHECK_INTERVAL`
 Time in seconds between health check cycles.

--- a/README.md
+++ b/README.md
@@ -226,6 +226,12 @@ Test URLs come from two **unioned** sources (de-duplicated):
 Provide either, or both. At least one URL total is required or the monitor won't
 start (see above).
 
+Entries are sanity-checked: a URL with no host, or one that looks like a
+command-line flag (leading `-`, which could otherwise be parsed as an option by
+the in-container `wget`/`ping`), is **dropped with a startup warning** rather than
+probed. The probes also pass URLs/hosts after a `--` end-of-options separator, so
+a stray value can never be interpreted as a flag.
+
 #### `DOCKER_HOST`
 When unset, the Docker CLI connects via the local socket (`/var/run/docker.sock`). Set this to `tcp://<proxy-host>:2375` to connect through a [Docker socket proxy](#docker-socket-proxy) instead of mounting the socket directly. See the [Docker Socket Proxy](#docker-socket-proxy) section for setup details.
 

--- a/README.md
+++ b/README.md
@@ -179,6 +179,10 @@ docker compose up -d
 | `DEPENDENT_VIABILITY` | `1` | Per-dependent L7 DNS/connectivity probe. `0` = interface/strand check only (no URL fetch); the interface check is always on |
 | `MAX_JITTER_MS` | `0` | Optional per-dispatch jitter (ms) to spread the dependent probe burst. `0` = off (the concurrency cap already bounds it) |
 | `DRY_RUN` | `0` | Observe-only: run all detection/probing but **take no action** — log `[DRY-RUN] would …` instead of restarting/recreating. For soak-testing alongside an active monitor |
+| `STATS_FILE` | `/logs/site-stats.json` | Where persistent per-site stats are written (best-effort; survives restarts). See [Site stats & flaky-site advisory](#site-stats--flaky-site-advisory) |
+| `ADVISORY_WINDOW` | `86400` | Window (seconds) for the flaky-site advisory |
+| `ADVISORY_MIN_RESTARTS` | `5` | Minimum gluetun restarts in the window before an advisory can fire |
+| `ADVISORY_DOMINANCE` | `0.5` | Fraction of those restarts one site must cause to be flagged flaky |
 | `AUTO_RECREATE` | `1` | Recreate a dependent stranded by a Gluetun recreate (id changed). Set `0` to disable → such a dependent is reported FAILED instead |
 | `DNS_WAIT_TIMEOUT` | `30` | Max seconds to wait for Gluetun DNS to stabilize after a restart |
 | `LOG_LEVEL` | `INFO` | `DEBUG` to include per-site/per-dependent detail lines |
@@ -399,6 +403,38 @@ owned by the daemon, not the container, so:
 - **`AUTO_RECREATE=0`** — never recreate; alert instead (restart-only recovery).
 - **`EXCLUDE_CONTAINERS=...`** — a denylist of containers to never touch.
 - **Socket proxy** (default) — cap the Docker API surface the monitor can use.
+
+## Site stats & flaky-site advisory
+
+A single flaky **test site** (one that intermittently times out or SSL-errors)
+can trip `FAIL_THRESHOLD` and trigger a gluetun restart — even though the tunnel
+is fine (your other sites pass). Restarting *can* fix a genuinely blocked
+endpoint, so the monitor still tries it; but to stop you chasing the wrong thing,
+it keeps a **persistent, rear-looking record** of how each site behaves and
+**tells you** which one is the troublemaker.
+
+It writes a human-readable JSON sidecar (`STATS_FILE`, default
+`/logs/site-stats.json`) with, per site: total polls, total failures (→ failure
+rate), failure **episodes** and the average episode length in polls (how long it
+typically stays down when it breaks), how many gluetun restarts it triggered, and
+last-good / last-failure timestamps. The file survives monitor restarts; it's
+best-effort (a missing/unwritable/corrupt file never blocks the monitor).
+
+When one site dominates the recent restarts, the monitor logs a **flaky-site
+advisory** (once, not per loop):
+
+```
+[WARN] FLAKY SITE: https://dognzb.cr caused 17 of the last 22 gluetun restarts
+over the last 24h — it may be flaky; consider reviewing or removing it from sites.conf
+```
+
+That's the signal to prune that site from `sites.conf` (which is re-read live, so
+no restart needed). Tune with `ADVISORY_WINDOW`, `ADVISORY_MIN_RESTARTS`, and
+`ADVISORY_DOMINANCE`. See [ADR-0008](docs/adr/0008-persistent-site-stats-and-advisory.md).
+
+> **By design, the monitor does not auto-suppress a flaky site** — it keeps
+> applying the cheap restart fix and escalates to you. (A future automatic
+> back-off is possible; it would be opt-in.)
 
 ## Docker Compose Example
 

--- a/README.md
+++ b/README.md
@@ -431,6 +431,11 @@ and first-seen / last-good / last-failure timestamps. It's written **every loop,
 missing/unwritable/corrupt file never blocks the monitor). A site removed from
 `sites.conf` is kept for `STATS_RETENTION_DAYS` (default 90) then pruned.
 
+The file also has a top-level **`monitor`** section with monitor-wide totals:
+version, first-/last-started, current uptime, **total loops**, **total runtime**
+(accumulated, excluding downtime), and cumulative **gluetun restarts**,
+**dependent remediations**, and **advisories** raised.
+
 When one site dominates the recent restarts, the monitor logs a **flaky-site
 advisory** (once, not per loop):
 

--- a/README.md
+++ b/README.md
@@ -420,9 +420,13 @@ it keeps a **persistent, rear-looking record** of how each site behaves and
 It writes a human-readable JSON sidecar (`STATS_FILE`, default
 `/logs/site-stats.json`) with, per site: total polls, total failures (→ failure
 rate), failure **episodes** and the average episode length in polls (how long it
-typically stays down when it breaks), the **longest** such streak, how many
-gluetun restarts it triggered, and first-seen / last-good / last-failure
-timestamps. It's written **every loop, crash- and power-loss-safely** (temp file
+typically stays down when it breaks), the **longest** such streak, a
+**failure-reason breakdown** (dns / tls / timeout / connection / http-error /
+other), **response-latency** of successful polls (avg/min/max + **p50/p90/p99**, so
+you see median vs mean — a site getting slow often precedes it failing), how many
+gluetun restarts it triggered and the **restart-effectiveness** (fraction of those
+restarts that actually cleared it — a low number means it's the site, not the VPN),
+and first-seen / last-good / last-failure timestamps. It's written **every loop, crash- and power-loss-safely** (temp file
 + fsync + atomic rename), survives monitor restarts, and is best-effort (a
 missing/unwritable/corrupt file never blocks the monitor). A site removed from
 `sites.conf` is kept for `STATS_RETENTION_DAYS` (default 90) then pruned.

--- a/README.md
+++ b/README.md
@@ -32,10 +32,10 @@ A lightweight Docker container that monitors VPN connectivity through [Gluetun](
 **Pull the image:**
 ```bash
 # From Docker Hub
-docker pull chasmarshall/gluetun-monitor:latest
+docker pull chasmarshall/gluetun-monitor:2
 
 # From GitHub Container Registry
-docker pull ghcr.io/csmarshall/gluetun-monitor:latest
+docker pull ghcr.io/csmarshall/gluetun-monitor:2
 ```
 
 ## Features
@@ -85,12 +85,13 @@ permissions** (`CONTAINERS` / `POST` / `EXEC`). In the common case you change
 only the image tag and it keeps working — we validate that the v1 env surface
 boots cleanly against a socket proxy as part of testing.
 
-**Image tags:**
-- **`:2`** — recommended for production: you get every v2.x patch and never a
+**Image tags** (full policy: [docs/VERSIONING.md](docs/VERSIONING.md)):
+- **`:2`** — **recommended for production**: you get every v2.x patch and never a
   surprise future major.
-- **`:latest`** — always the newest release (note: it *will* eventually roll to a
-  future v3 major).
-- **`:1`** — frozen v1, kept only as a **rollback anchor**; unsupported.
+- `:2.0.0` — fully pinned to one release (reproducible; you update deliberately).
+- `:latest` — always the newest release; **will** eventually roll to a future v3
+  major, so don't use it for unattended updates of a container-restarting watchdog.
+- **`:1`** — frozen v1, kept only as a **rollback anchor**; unsupported (EOL).
 
 **Two behavior changes to know about** (the config interface is compatible, but
 v2 does more):
@@ -112,7 +113,7 @@ v2 does more):
 ### 1. Pull the image
 
 ```bash
-docker pull ghcr.io/csmarshall/gluetun-monitor:latest
+docker pull ghcr.io/csmarshall/gluetun-monitor:2
 ```
 
 ### 2. Copy example configs
@@ -418,8 +419,8 @@ services:
       - docker-proxy
 
   gluetun-monitor:
-    image: ghcr.io/csmarshall/gluetun-monitor:latest
-    # Or from Docker Hub: chasmarshall/gluetun-monitor:latest
+    image: ghcr.io/csmarshall/gluetun-monitor:2
+    # Or from Docker Hub: chasmarshall/gluetun-monitor:2
     container_name: gluetun-monitor
     restart: unless-stopped
     depends_on:
@@ -458,8 +459,8 @@ services:
       - docker-proxy
 
   gluetun-monitor:
-    image: ghcr.io/csmarshall/gluetun-monitor:latest
-    # Or from Docker Hub: chasmarshall/gluetun-monitor:latest
+    image: ghcr.io/csmarshall/gluetun-monitor:2
+    # Or from Docker Hub: chasmarshall/gluetun-monitor:2
     container_name: gluetun-monitor
     restart: unless-stopped
     depends_on:
@@ -497,7 +498,7 @@ If you prefer a simpler setup without the socket proxy, you can mount the Docker
 ```yaml
 services:
   gluetun-monitor:
-    image: ghcr.io/csmarshall/gluetun-monitor:latest
+    image: ghcr.io/csmarshall/gluetun-monitor:2
     container_name: gluetun-monitor
     restart: unless-stopped
     network_mode: none

--- a/README.md
+++ b/README.md
@@ -509,8 +509,17 @@ latency in ms; eff% = restart-effectiveness (n/a = no restarts triggered)
 ```
 
 Sites are sorted by `p90` (worst tail first) by default; `--sort` accepts
-`p90|p99|avg|max|p50|rate|polls|name`. Add `--json` to emit the same data for
+`p90|p99|avg|max|p50|rate|polls|eff|name`. Add `--json` to emit the same data for
 `jq`/dashboards, and `--file PATH` if your `STATS_FILE` lives elsewhere.
+
+The latency columns show the **recent** window (last ~200 polls) by default. Add
+`--lifetime` for **all-time** percentiles — these come from a bounded per-site
+histogram (DDSketch-style, within 5% relative error at a few dozen buckets/site;
+see [ADR-0009](docs/adr/0009-all-time-latency-histogram.md)) that records every
+successful poll for the site's whole life, so you get a lifetime baseline rather
+than just "recently." `--json` includes both windows (`latency_ms` and
+`lifetime_latency_ms`). Exact avg/min/max are kept either way; only the percentiles
+are approximate.
 
 ## Docker Compose Example
 

--- a/README.md
+++ b/README.md
@@ -187,6 +187,8 @@ docker compose up -d
 | `AUTO_RECREATE` | `1` | Recreate a dependent stranded by a Gluetun recreate (id changed). Set `0` to disable → such a dependent is reported FAILED instead |
 | `DNS_WAIT_TIMEOUT` | `30` | Max seconds to wait for Gluetun DNS to stabilize after a restart |
 | `LOG_LEVEL` | `INFO` | `DEBUG` to include per-site/per-dependent detail lines |
+| `LOG_MAX_BYTES` | `10485760` | Rotate the `/logs` file at this size (≈10 MB); `0` disables rotation |
+| `LOG_BACKUP_COUNT` | `5` | How many rotated log backups to keep (≈60 MB total at defaults) |
 | `TZ` | `UTC` | Timezone for log timestamps |
 
 ### Configuration is validated — sane defaults, but bad config is fatal
@@ -572,17 +574,21 @@ gluetun container (through the tunnel); each dependent logs its interface/route
 check, then its viability result.
 ```
 [2025-01-15 10:00:00] [CHECK] Start
-[2025-01-15 10:00:02] [DEBUG] [gluetun] site https://www.google.com: ok (769ms)
-[2025-01-15 10:00:02] [DEBUG] [gluetun] site https://cloudflare.com: ok (1768ms)
-[2025-01-15 10:00:04] [DEBUG] [qbittorrent] interface check: live [eth0,lo,tun0]
-[2025-01-15 10:00:04] [DEBUG] [qbittorrent] viability: https://cloudflare.com: resolved + connected (HTTP 200) [wget] [fails 0]
+[2025-01-15 10:00:02] [DEBUG] [gateway:gluetun] site https://www.google.com: ok (769ms)
+[2025-01-15 10:00:02] [DEBUG] [gateway:gluetun] site https://cloudflare.com: ok (1768ms)
+[2025-01-15 10:00:04] [DEBUG] [dependent:qbittorrent] interface check: live [eth0,lo,tun0]
+[2025-01-15 10:00:04] [DEBUG] [dependent:qbittorrent] viability: https://cloudflare.com: resolved + connected (HTTP 200) [wget] [fails 0]
 [2025-01-15 10:00:04] [CHECK] End - Sleeping 30s
 ```
 
+Each test line is tagged `[gateway:<name>]` (the gluetun VPN container, where the
+site tests run — through the tunnel) or `[dependent:<name>]`, so you can tell at a
+glance what kind of container a line is about (`grep gateway:` / `grep dependent:jackett`).
+
 ### Gluetun connectivity failure + recovery
 ```
-[2025-01-15 10:10:00] [WARN] [gluetun] site https://example.com: FAILED 2x consecutive - THRESHOLD REACHED - Network failure (DNS or connection)
-[2025-01-15 10:10:00] [ERROR] [gluetun] failed sites (exceeded threshold): https://example.com
+[2025-01-15 10:10:00] [WARN] [gateway:gluetun] site https://example.com: FAILED 2x consecutive - THRESHOLD REACHED - Network failure (DNS or connection)
+[2025-01-15 10:10:00] [ERROR] [gateway:gluetun] failed sites (exceeded threshold): https://example.com
 [2025-01-15 10:10:00] [WARN] Health check failed, initiating recovery...
 [2025-01-15 10:10:00] [ENDPOINT] Status: FAILING | IP: 203.x.x.x | Country: United States | City: New York | VPN Server: us123.vpn.com | Reason: Site connectivity test failed
 [2025-01-15 10:10:05] [INFO] Restarting gluetun to force new endpoint...
@@ -600,6 +606,22 @@ check, then its viability result.
 [2025-01-15 11:00:02] [INFO] qbittorrent recreated as 7a1b2c3d4e5f and started
 [2025-01-15 11:00:04] [INFO] qbittorrent verified healthy after remediation
 ```
+
+### Log rotation (both sinks)
+
+The monitor logs to **two** places, and both are bounded so a long-running
+watchdog never fills the disk:
+
+- **The `/logs` file** is **size-rotated by the monitor itself** —
+  `LOG_MAX_BYTES` (≈10 MB) × `LOG_BACKUP_COUNT` (5) ≈ 60 MB cap. Set
+  `LOG_MAX_BYTES=0` to disable (e.g. if you run external `logrotate`).
+- **The Docker/stderr stream** (`docker logs`) is **not rotated by Docker
+  automatically** — its default `json-file` driver grows unbounded. The compose
+  example sets a `logging:` cap (`max-size`/`max-file`) on the services; keep it,
+  or configure rotation globally in `daemon.json`.
+
+At `LOG_LEVEL=DEBUG` the per-site/per-dependent lines are verbose (good for
+soak-testing); `INFO` is much quieter for steady-state.
 
 ## Requirements
 

--- a/README.md
+++ b/README.md
@@ -566,10 +566,23 @@ Note: This gives the container full read access to the Docker API. The socket pr
 [2025-01-15 10:00:00] [ENDPOINT] Status: STARTUP | IP: 203.x.x.x | Country: United States | City: New York | VPN Server: us123.vpn.com | Reason: Monitor starting
 ```
 
+### A normal check cycle (DEBUG)
+Every test line is tagged with the container it ran in: site tests run inside the
+gluetun container (through the tunnel); each dependent logs its interface/route
+check, then its viability result.
+```
+[2025-01-15 10:00:00] [CHECK] Start
+[2025-01-15 10:00:02] [DEBUG] [gluetun] site https://www.google.com: ok (769ms)
+[2025-01-15 10:00:02] [DEBUG] [gluetun] site https://cloudflare.com: ok (1768ms)
+[2025-01-15 10:00:04] [DEBUG] [qbittorrent] interface check: live [eth0,lo,tun0]
+[2025-01-15 10:00:04] [DEBUG] [qbittorrent] viability: https://cloudflare.com: resolved + connected (HTTP 200) [wget] [fails 0]
+[2025-01-15 10:00:04] [CHECK] End - Sleeping 30s
+```
+
 ### Gluetun connectivity failure + recovery
 ```
-[2025-01-15 10:10:00] [WARN] Site https://example.com failed 2 consecutive times - THRESHOLD REACHED - Network failure (DNS or connection)
-[2025-01-15 10:10:00] [ERROR] Failed sites (exceeded threshold): https://example.com
+[2025-01-15 10:10:00] [WARN] [gluetun] site https://example.com: FAILED 2x consecutive - THRESHOLD REACHED - Network failure (DNS or connection)
+[2025-01-15 10:10:00] [ERROR] [gluetun] failed sites (exceeded threshold): https://example.com
 [2025-01-15 10:10:00] [WARN] Health check failed, initiating recovery...
 [2025-01-15 10:10:00] [ENDPOINT] Status: FAILING | IP: 203.x.x.x | Country: United States | City: New York | VPN Server: us123.vpn.com | Reason: Site connectivity test failed
 [2025-01-15 10:10:05] [INFO] Restarting gluetun to force new endpoint...

--- a/docker-compose.yml.example
+++ b/docker-compose.yml.example
@@ -57,6 +57,10 @@ services:
       # - DEPENDENT_CONTAINER_FAILURES=2
       # Cap on concurrent dependent probes per loop
       # - MAX_PARALLEL_CHECKS=6
+      # Per-dependent L7 DNS/connectivity probe; 0 = interface/strand check only (no URL fetch)
+      # - DEPENDENT_VIABILITY=1
+      # Optional per-dispatch jitter (ms) to spread the probe burst; 0 = off (cap already bounds it)
+      # - MAX_JITTER_MS=0
       # Recreate a dependent stranded by a gluetun recreate (id changed); 0 disables
       # - AUTO_RECREATE=1
       # Seconds to wait for gluetun DNS to stabilize after a restart

--- a/docker-compose.yml.example
+++ b/docker-compose.yml.example
@@ -66,6 +66,9 @@ services:
       # - MAX_PARALLEL_CHECKS=6
       # Per-dependent L7 DNS/connectivity probe; 0 = interface/strand check only (no URL fetch)
       # - DEPENDENT_VIABILITY=1
+      # Sites each dependent tests per loop: 1 (one shuffled), N (N distinct), -1 (all).
+      # >1 is largely redundant (dependents share gluetun's netns); the dial is for completeness.
+      # - DEPENDENT_VIABILITY_SAMPLES=1
       # Optional per-dispatch jitter (ms) to spread the probe burst; 0 = off (cap already bounds it)
       # - MAX_JITTER_MS=0
       # Observe-only: detect + log intended actions but never restart/recreate (soak-testing)

--- a/docker-compose.yml.example
+++ b/docker-compose.yml.example
@@ -34,7 +34,12 @@ services:
       - GLUETUN_CONTAINER=gluetun
       # Dependent containers: "auto" to discover dynamically, or comma-separated list
       # Auto-discovery finds all containers using network_mode: container:<GLUETUN_CONTAINER>
+      # (an explicit list must name containers that exist at startup, or the monitor exits)
       - DEPENDENT_CONTAINERS=auto
+      # Test URLs may be supplied here (comma-separated) instead of / in addition to
+      # the mounted sites.conf below; the two are unioned. At least one site is required.
+      # Note: SITES is read once at startup; sites.conf is re-read live each loop.
+      # - SITES=https://www.google.com,https://cloudflare.com
       # Check interval in seconds
       - CHECK_INTERVAL=30
       # Timeout for each site test (seconds)

--- a/docker-compose.yml.example
+++ b/docker-compose.yml.example
@@ -63,6 +63,8 @@ services:
       # - DEPENDENT_VIABILITY=1
       # Optional per-dispatch jitter (ms) to spread the probe burst; 0 = off (cap already bounds it)
       # - MAX_JITTER_MS=0
+      # Observe-only: detect + log intended actions but never restart/recreate (soak-testing)
+      # - DRY_RUN=0
       # Recreate a dependent stranded by a gluetun recreate (id changed); 0 disables
       # - AUTO_RECREATE=1
       # Seconds to wait for gluetun DNS to stabilize after a restart

--- a/docker-compose.yml.example
+++ b/docker-compose.yml.example
@@ -99,10 +99,12 @@ services:
       # Sites configuration file
       - ./sites.conf:/config/sites.conf:ro
       # Persistent logs + stats (the monitor rotates the file inside this dir).
-      # The image runs as non-root (uid 10001); make this dir writable by it, e.g.
-      #   mkdir -p ./logs && sudo chown 10001:10001 ./logs
-      # If it isn't writable the monitor still runs and logs to stdout (docker
-      # logs) — it just can't persist the file log / site-stats sidecar.
+      # The image runs non-root (default uid/gid 1000 = the typical first host
+      # user), so a ./logs you created is usually already writable. If your user
+      # isn't 1000 (check: id), either chown it (sudo chown -R <uid>:<gid> ./logs)
+      # or run as your uid with `user: "1000:1000"` on this service. If it isn't
+      # writable the monitor still runs and logs to stdout (docker logs) — it just
+      # can't persist the file log / site-stats sidecar.
       - ./logs:/logs
     networks:
       - docker-proxy

--- a/docker-compose.yml.example
+++ b/docker-compose.yml.example
@@ -36,6 +36,9 @@ services:
       # Auto-discovery finds all containers using network_mode: container:<GLUETUN_CONTAINER>
       # (an explicit list must name containers that exist at startup, or the monitor exits)
       - DEPENDENT_CONTAINERS=auto
+      # Denylist: containers to NEVER manage (skip checks + restart/recreate). Useful with
+      # auto = "discover everything except these". Exclude wins over an include on overlap.
+      # - EXCLUDE_CONTAINERS=some-batch-job,do-not-touch-me
       # Test URLs may be supplied here (comma-separated) instead of / in addition to
       # the mounted sites.conf below; the two are unioned. At least one site is required.
       # Note: SITES is read once at startup; sites.conf is re-read live each loop.

--- a/docker-compose.yml.example
+++ b/docker-compose.yml.example
@@ -18,9 +18,11 @@ services:
       - docker-proxy
 
   gluetun-monitor:
-    image: ghcr.io/csmarshall/gluetun-monitor:latest
+    # Pin the major (:2) for production: all v2.x patches, no surprise future major.
+    # Alternatives: :latest (newest, may roll to v3), :2.0.0 (fully pinned). See docs/VERSIONING.md.
+    image: ghcr.io/csmarshall/gluetun-monitor:2
     # Or from Docker Hub:
-    # image: chasmarshall/gluetun-monitor:latest
+    # image: chasmarshall/gluetun-monitor:2
     # Or build locally from source:
     # build: .
     container_name: gluetun-monitor
@@ -86,7 +88,7 @@ networks:
 #
 # services:
 #   gluetun-monitor:
-#     image: ghcr.io/csmarshall/gluetun-monitor:latest
+#     image: ghcr.io/csmarshall/gluetun-monitor:2
 #     container_name: gluetun-monitor
 #     restart: unless-stopped
 #     network_mode: none  # No network needed - communicates via Docker socket only

--- a/docker-compose.yml.example
+++ b/docker-compose.yml.example
@@ -16,6 +16,11 @@ services:
       - /var/run/docker.sock:/var/run/docker.sock:ro
     networks:
       - docker-proxy
+    logging:  # the proxy's access log is chatty; cap it too
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"
 
   gluetun-monitor:
     # Pin the major (:2) for production: all v2.x patches, no surprise future major.
@@ -78,13 +83,24 @@ services:
       # - DNS_WAIT_TIMEOUT=30
       # DEBUG to include per-site / per-dependent detail lines
       # - LOG_LEVEL=INFO
+      # The /logs file is size-rotated by the monitor itself (LOG_MAX_BYTES x
+      # LOG_BACKUP_COUNT). Defaults ~10MB x 5; 0 disables rotation.
+      # - LOG_MAX_BYTES=10485760
+      # - LOG_BACKUP_COUNT=5
     volumes:
       # Sites configuration file
       - ./sites.conf:/config/sites.conf:ro
-      # Persistent logs
+      # Persistent logs (the monitor rotates the file inside this dir)
       - ./logs:/logs
     networks:
       - docker-proxy
+    # Cap the *Docker* (stderr) log too — Docker's default json-file driver does
+    # NOT rotate on its own. Without this, `docker logs` grows unbounded.
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"
 
 networks:
   docker-proxy:

--- a/docker-compose.yml.example
+++ b/docker-compose.yml.example
@@ -36,6 +36,11 @@ services:
       - docker-socket-proxy
     environment:
       - TZ=UTC
+      # Run non-root (recommended, LSIO-style): the entrypoint chowns /logs and
+      # drops to this uid/gid. Leave unset to run as root (drop-in, like v1). Use
+      # your host user's ids (run `id`).
+      - PUID=1000
+      - PGID=1000
       - DOCKER_HOST=tcp://docker-socket-proxy:2375
       # Name of the gluetun container to monitor
       - GLUETUN_CONTAINER=gluetun
@@ -99,12 +104,9 @@ services:
       # Sites configuration file
       - ./sites.conf:/config/sites.conf:ro
       # Persistent logs + stats (the monitor rotates the file inside this dir).
-      # The image runs non-root (default uid/gid 1000 = the typical first host
-      # user), so a ./logs you created is usually already writable. If your user
-      # isn't 1000 (check: id), either chown it (sudo chown -R <uid>:<gid> ./logs)
-      # or run as your uid with `user: "1000:1000"` on this service. If it isn't
-      # writable the monitor still runs and logs to stdout (docker logs) — it just
-      # can't persist the file log / site-stats sidecar.
+      # With PUID/PGID set above, the entrypoint chowns this mount for you — no
+      # manual step. (Without PUID/PGID the container runs as root and writes it as
+      # root; either way an unwritable dir just degrades to stdout, never a crash.)
       - ./logs:/logs
     networks:
       - docker-proxy

--- a/docker-compose.yml.example
+++ b/docker-compose.yml.example
@@ -68,6 +68,7 @@ services:
       # Persistent per-site stats sidecar (best-effort; survives restarts) + flaky-site advisory.
       # The monitor records how each site behaves and warns when one site causes most restarts.
       # - STATS_FILE=/logs/site-stats.json
+      # - STATS_RETENTION_DAYS=90    # drop a site's stats N days after it leaves sites.conf (0=keep)
       # - ADVISORY_WINDOW=86400      # seconds (24h)
       # - ADVISORY_MIN_RESTARTS=5
       # - ADVISORY_DOMINANCE=0.5     # one site causing >=50% of recent restarts -> flag it

--- a/docker-compose.yml.example
+++ b/docker-compose.yml.example
@@ -52,8 +52,11 @@ services:
       # - SITES=https://www.google.com,https://cloudflare.com
       # Check interval in seconds
       - CHECK_INTERVAL=30
-      # Timeout for each site test (seconds)
+      # Per-request network timeout (seconds) — applied to every wget/ping probe,
+      # including the wget run inside the dependent containers.
       - TIMEOUT=10
+      # Attempts per wget probe (noise is handled by the shuffle + thresholds, not retries)
+      # - WGET_TRIES=1
       # Number of consecutive failures before triggering restart
       - FAIL_THRESHOLD=2
       # Max seconds to wait for gluetun to become healthy after restart

--- a/docker-compose.yml.example
+++ b/docker-compose.yml.example
@@ -65,6 +65,12 @@ services:
       # - MAX_JITTER_MS=0
       # Observe-only: detect + log intended actions but never restart/recreate (soak-testing)
       # - DRY_RUN=0
+      # Persistent per-site stats sidecar (best-effort; survives restarts) + flaky-site advisory.
+      # The monitor records how each site behaves and warns when one site causes most restarts.
+      # - STATS_FILE=/logs/site-stats.json
+      # - ADVISORY_WINDOW=86400      # seconds (24h)
+      # - ADVISORY_MIN_RESTARTS=5
+      # - ADVISORY_DOMINANCE=0.5     # one site causing >=50% of recent restarts -> flag it
       # Recreate a dependent stranded by a gluetun recreate (id changed); 0 disables
       # - AUTO_RECREATE=1
       # Seconds to wait for gluetun DNS to stabilize after a restart

--- a/docker-compose.yml.example
+++ b/docker-compose.yml.example
@@ -93,10 +93,16 @@ services:
       # LOG_BACKUP_COUNT). Defaults ~10MB x 5; 0 disables rotation.
       # - LOG_MAX_BYTES=10485760
       # - LOG_BACKUP_COUNT=5
+      # Log file path inside the /logs mount (also always logged to stdout)
+      # - LOG_FILE=/logs/gluetun-monitor.log
     volumes:
       # Sites configuration file
       - ./sites.conf:/config/sites.conf:ro
-      # Persistent logs (the monitor rotates the file inside this dir)
+      # Persistent logs + stats (the monitor rotates the file inside this dir).
+      # The image runs as non-root (uid 10001); make this dir writable by it, e.g.
+      #   mkdir -p ./logs && sudo chown 10001:10001 ./logs
+      # If it isn't writable the monitor still runs and logs to stdout (docker
+      # logs) — it just can't persist the file log / site-stats sidecar.
       - ./logs:/logs
     networks:
       - docker-proxy
@@ -116,6 +122,10 @@ networks:
 
 # Alternative: Direct Docker socket mount (simpler, less secure)
 # Replace the services above with this if you prefer not to use a socket proxy.
+# The image runs as a non-root user, which cannot read the root:docker-owned
+# socket by default — so this variant adds the host's docker group via group_add.
+# Find the gid with: getent group docker | cut -d: -f3   (commonly 999 on Debian/
+# Ubuntu). The socket-proxy path above needs none of this (it talks TCP).
 #
 # services:
 #   gluetun-monitor:
@@ -123,6 +133,8 @@ networks:
 #     container_name: gluetun-monitor
 #     restart: unless-stopped
 #     network_mode: none  # No network needed - communicates via Docker socket only
+#     group_add:
+#       - "999"  # <- your host's `docker` group gid; lets the non-root user read the socket
 #     environment:
 #       - TZ=UTC
 #       - GLUETUN_CONTAINER=gluetun

--- a/docker-compose.yml.example
+++ b/docker-compose.yml.example
@@ -43,6 +43,18 @@ services:
       - FAIL_THRESHOLD=2
       # Max seconds to wait for gluetun to become healthy after restart
       - HEALTHY_WAIT_TIMEOUT=120
+      # --- v2 dependent-aware knobs (all optional; sensible defaults) ---
+      # Consecutive per-dependent viability failures before remediating it
+      # (defaults to FAIL_THRESHOLD if unset)
+      # - DEPENDENT_CONTAINER_FAILURES=2
+      # Cap on concurrent dependent probes per loop
+      # - MAX_PARALLEL_CHECKS=6
+      # Recreate a dependent stranded by a gluetun recreate (id changed); 0 disables
+      # - AUTO_RECREATE=1
+      # Seconds to wait for gluetun DNS to stabilize after a restart
+      # - DNS_WAIT_TIMEOUT=30
+      # DEBUG to include per-site / per-dependent detail lines
+      # - LOG_LEVEL=INFO
     volumes:
       # Sites configuration file
       - ./sites.conf:/config/sites.conf:ro

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+# gluetun-monitor entrypoint.
+#
+# Drop-in by default: with no PUID/PGID set, the monitor runs as root — exactly
+# like v1, with nothing to configure and no host-side chown.
+#
+# Recommended (LSIO-style, opt-in): set PUID/PGID and the container makes the
+# /logs mount writable by that user and drops privileges to it. gosu accepts a
+# numeric uid:gid with no matching /etc/passwd entry, so no user need exist.
+set -e
+
+if [ -n "${PUID}" ] || [ -n "${PGID}" ]; then
+    PUID="${PUID:-1000}"
+    PGID="${PGID:-1000}"
+    # Persisting the log file + site-stats needs /logs writable by the runtime
+    # user. Best-effort: if the chown can't happen (e.g. a read-only mount), the
+    # monitor still runs and just logs to stdout (Tenet 7 — never block on it).
+    chown -R "${PUID}:${PGID}" /logs 2>/dev/null || true
+    exec gosu "${PUID}:${PGID}" "$@"
+fi
+
+exec "$@"

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -18,7 +18,9 @@ the **FAILED state** (ADR-0006) and optionally on recovery/endpoint-change.
 - Config: opt-in URL(s) via env; quiet by default (no surprise outbound traffic).
 - Why backlog: it's a separate, sizeable feature surface; the **FAILED state** in
   ADR-0006 is the natural trigger point and is the only prerequisite. Until it
-  lands, FAILED = loud log + unhealthy status.
+  lands, FAILED surfaces only as a **loud ERROR log** — there is no separate
+  machine-readable health surface (no HTTP endpoint, no container `HEALTHCHECK`);
+  exposing one could be a follow-up to this item.
 
 ## Socket-proxy hardening (verify first)
 Today's reference proxy ships `CONTAINERS=1 + POST=1 + EXEC=1`. tecnativa provides

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -22,6 +22,31 @@ the **FAILED state** (ADR-0006) and optionally on recovery/endpoint-change.
   machine-readable health surface (no HTTP endpoint, no container `HEALTHCHECK`);
   exposing one could be a follow-up to this item.
 
+## Portable injected viability probe
+Today the per-dependent viability probe execs the dependent's **own** `wget`,
+whose behavior varies (gluetun ships GNU wget; linuxserver/Alpine dependents ship
+busybox wget with a different exit-code convention; distroless ships none). v2
+works around this by keying on "did DNS resolve / did we get any HTTP response"
+rather than wget's exit code, but it still depends on the container having a
+usable `wget`.
+
+A cleaner, fully portable approach: ship a tiny **static, CGO-free binary**
+(`gm-probe`) inside the monitor image, `docker cp` it into each dependent (to an
+ephemeral path) and `docker exec` it — a uniform DNS-resolve (+ optional TCP
+connect) check with an unambiguous exit code, identical on every container.
+
+- **Wins:** identical behavior everywhere; we define "success" exactly (no wget
+  quirks); extends viability to **distroless/scratch** dependents (a static
+  binary execs without a shell).
+- **To resolve first:** (1) does the socket proxy allow the archive endpoints
+  (`PUT /containers/{id}/archive`) under `CONTAINERS`, or is it a new permission?
+  (Tenet 4 — least privilege.) (2) multi-arch binaries (amd64/arm64/arm) selected
+  per dependent; (3) re-inject after a dependent is recreated; (4) it writes into
+  the container's ephemeral layer — benign but a deliberate mutation.
+- **Why backlog:** sizable (a Go sub-project + build/release pipeline) and gated
+  on the proxy-permission question. The v2 HTTP-response/DNS-only classification
+  makes the wget-based probe correct for the common case in the meantime.
+
 ## Socket-proxy hardening (verify first)
 Today's reference proxy ships `CONTAINERS=1 + POST=1 + EXEC=1`. tecnativa provides
 granular carve-outs (`ALLOW_RESTARTS`, `EXEC`) intended to permit those ops

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -7,9 +7,12 @@ A pluggable way to **announce** monitor events to the outside world — fired fr
 the **FAILED state** (ADR-0006) and optionally on recovery/endpoint-change.
 
 - Decouple *what happened* (the monitor's state machine) from *how it's announced*.
-- Likely a single outbound hook with adapters: generic **webhook**, plus common
-  targets (ntfy, Apprise, Slack/Discord, email). [Apprise](https://github.com/caronc/apprise)
-  would cover many targets in one dependency.
+- **Leverage a standard, maintained Python library rather than hand-rolling
+  senders.** [Apprise](https://github.com/caronc/apprise) is the strong default:
+  one well-supported dependency covers 100+ targets (ntfy, Slack, Discord,
+  Telegram, email, generic webhook, …) behind a single URL-string API — a natural
+  fit for "opt-in URL(s) via env." Hand-written senders per service are exactly
+  the bespoke surface we'd avoid (cf. ADR-0007: use the SDK, don't reinvent).
 - Triggers to consider: entering FAILED, recovering from FAILED, gluetun endpoint
   change, dependent recreated.
 - Config: opt-in URL(s) via env; quiet by default (no surprise outbound traffic).
@@ -23,7 +26,7 @@ granular carve-outs (`ALLOW_RESTARTS`, `EXEC`) intended to permit those ops
 **without** the broad `POST=1`.
 
 - Hypothesis: restart + exec + inspect could run on `CONTAINERS + ALLOW_RESTARTS +
-  EXEC` with **`POST=0`** — tighter than today (Tenet 3).
+  EXEC` with **`POST=0`** — tighter than today (Tenet 4).
 - Bonus: with that baseline, `POST=1` becomes the *natural permission-gate* for
   `AUTO_RECREATE` (the proxy config is the opt-in), with graceful fallback to
   alert when absent — no separate flag needed.

--- a/docs/TENETS.md
+++ b/docs/TENETS.md
@@ -7,33 +7,50 @@ decision is unclear, it should be resolved in favor of these.
 
 ---
 
-### 1. Verify the tunnel from inside it.
+### 1. First, do no harm — when intent is unclear, choose the option that can't hurt.
+A watchdog that damages the system it guards is worse than one that does nothing.
+When configuration is **contradictory** or a signal is **ambiguous about *what* to
+act on**, resolve toward the **non-destructive** choice: refuse to start on
+malformed config rather than guess parameters (fail loud, Tenet 7); **exclude**
+over manage when an include and an exclude conflict; **alert** rather than recreate
+a container we can't confidently attribute to gluetun; never restart/recreate
+against targets the operator didn't choose — where *choose* means **either** an
+explicit `DEPENDENT_CONTAINERS` list **or** the deliberate delegation of `auto`
+(opting in to let our discovery logic pick). Both are a choice; what's off-limits
+is acting on a target *neither* named nor implied by that choice — a guessed
+default, or an orphan we can't attribute. This is the companion to Tenet 8:
+Tenet 8 governs *when* to act on a confirmed failure; this governs *what* we are
+willing to do when we are not sure we are acting on the right thing. Acting on a
+guess can restart the wrong container — "I wasn't sure, so I left it alone and said
+so" beats that every time. <sub>design policy (v2.0.0); see Tenets 7, 8, 9</sub>
+
+### 2. Verify the tunnel from inside it.
 Health means *traffic actually egresses through the VPN* — so test from **inside
 gluetun's network namespace** (`docker exec gluetun wget ...`), never from the
 host. A green check that quietly bypassed the tunnel is worse than no check at
 all. The public IP we report is read from gluetun's own logs for the same
 reason: it reflects the tunnel, not the host. <sub>ADR-0001</sub>
 
-### 2. A broken tunnel is not a sad website.
+### 3. A broken tunnel is not a sad website.
 Distinguish "the VPN path is down" from "a test site is unhappy." A site that
 **responds at all** — even 401/403/5xx — proves egress works; only
 connection/DNS/TLS failures count as VPN failures. And never act on a single
 blip: require repeated, **consecutive** failures across **multiple parallel**
 sites before doing anything disruptive. <sub>design policy; see ADR-0003</sub>
 
-### 3. Least privilege by default.
+### 4. Least privilege by default.
 Controlling Docker is root-equivalent, so a network-facing watchdog should not
 hold the raw socket. Default to a **locked-down socket proxy** exposing only the
 endpoints the monitor needs; the bare socket mount is an explicit opt-in. The
 permission surface is allowed to grow only as far as the chosen recovery
 strategy actually requires. <sub>ADR-0002</sub>
 
-### 4. Heal the whole stack, in order, only when it'll stick.
+### 5. Heal the whole stack, in order, only when it'll stick.
 Recovery is **ordered and gated**: restore gluetun and **re-verify egress**
 *before* touching anything downstream. Don't churn dependents into a
 still-broken tunnel, and don't restart on noise. <sub>ADR-0003</sub>
 
-### 5. The dependents are the point — watch them, not just the gateway.
+### 6. The dependents are the point — watch them, not just the gateway.
 gluetun being healthy is necessary but **not sufficient**. Containers that route
 through it (auto-discovered by who shares its netns) can be **stranded
 loopback-only** — cut down to `lo` — while gluetun itself looks perfect. Health
@@ -45,21 +62,21 @@ gluetun's **identity**: a `restart` of the dependent suffices while gluetun keep
 the same container ID, but once gluetun is **replaced** (recreated, new ID) the
 dependent must be **recreated**, not restarted. <sub>ADR-0004, 0006</sub>
 
-### 6. Fail loud; never fake-green.
+### 7. Fail loud; never fake-green.
 The cardinal sin is reporting "healthy" while the stack is broken. Prefer an
 honest, actionable ERROR over a green light that lies. (Corollary, learned the
 hard way: under `set -euo pipefail` a careless parse can crash the loop into a
 restart cycle — parse defensively so the watchdog never becomes the outage.)
 <sub>ADR-0004; issues #17, #20</sub>
 
-### 7. Over-observe, under-react.
+### 8. Over-observe, under-react.
 Test broadly and redundantly — from the gateway *and* from every reachable
-dependent, connectivity *and* DNS — so a real outage is never missed (Tenet 6).
+dependent, connectivity *and* DNS — so a real outage is never missed (Tenet 7).
 But gate *action* behind consecutive, threshold-confirmed failure: more vantage
 points raise **signal and attribution**, never **trigger-happiness**. A watchdog
-that flaps is its own outage (Tenet 2). <sub>ADR-0006; Tenets 2, 6</sub>
+that flaps is its own outage (Tenet 3). <sub>ADR-0006; Tenets 3, 7</sub>
 
-### 8. Recovery over prevention — simple and stateless beats clever and fragile.
+### 9. Recovery over prevention — simple and stateless beats clever and fragile.
 Failures are inevitable, so optimize for fast, safe **recovery** rather than
 elaborate prevention or detection
 ([Recovery-Oriented Computing](https://en.wikipedia.org/wiki/Recovery-oriented_computing)).
@@ -72,4 +89,4 @@ that fixes it beats a clever guess that might not. <sub>ADR-0005, 0006; Recovery
 
 ---
 
-Tenet → ADR map: 1→0001 (+0006), 2→(design), 3→0002, 4→0003, 5→0004 (+0006; recreate mechanism: 0005), 6→0004, 7→0006, 8→0005/0006.
+Tenet → ADR map: 1→(design policy; Tenets 7–9), 2→0001 (+0006), 3→(design), 4→0002, 5→0003, 6→0004 (+0006; recreate mechanism: 0005), 7→0004, 8→0006, 9→0005/0006.

--- a/docs/VERSIONING.md
+++ b/docs/VERSIONING.md
@@ -15,10 +15,21 @@ Every release publishes, to both GHCR and Docker Hub:
 | `MAJOR.MINOR.PATCH` | `2.0.0` | never (frozen) | reproducible / fully pinned deploys |
 | `MAJOR.MINOR` | `2.0` | latest patch of that minor | pinning to a feature line |
 | **`MAJOR`** | **`2`** | latest release within that major | **recommended for production** |
-| `latest` | — | newest release, **including the next major** | "always newest", attended updates |
+| `latest` | — | newest **stable** release, **including across a major** | "always newest", attended updates |
+
+`:latest` tracks the newest **non-pre-release** version only (the workflow uses
+`latest=auto`). Two guarantees follow, both enforced in CI config rather than by
+discipline:
+
+- A **pre-release** (`-rc`, etc.) never moves `:latest`.
+- An **EOL/older-major patch never claims `:latest`.** When v1 is EOL and we still
+  ship a v1 patch (e.g. an end-of-life notice), that build sets `latest=false`, so
+  it updates only `:1` / `:1.x` and **cannot** drag `:latest` back off v2. So once
+  `:latest` is on a major, it only ever moves forward.
 
 The previous major's `MAJOR` tag (e.g. `1`) is **retained but frozen** as a
-rollback anchor after it goes EOL — it is never deleted.
+rollback anchor after it goes EOL — it is never deleted, and an EOL patch to it
+(see above) still won't disturb the current `:latest`.
 
 ### Why `:MAJOR` is the recommended pin
 This is a privileged watchdog: it holds Docker `POST` rights and will
@@ -29,9 +40,9 @@ a major boundary — exactly the kind of surprise a container-restarting tool
 should avoid (Tenet 1: first, do no harm).
 
 `:latest` is still published for people who explicitly want the newest thing and
-update attentively. We do **not** use a `stable` tag today; if pre-releases
-(`-rc`) are ever published, `stable` would be introduced to mean "newest full
-release" and `latest` would include pre-releases.
+update attentively — but it is **newest *stable***, so it's safe from half-baked
+pre-releases. If a pre-release channel is ever wanted, it would get its own
+explicit tag (e.g. `:edge`/`:rc`); `:latest` would keep meaning "newest stable".
 
 ## What each bump means
 

--- a/docs/VERSIONING.md
+++ b/docs/VERSIONING.md
@@ -1,0 +1,80 @@
+# Versioning & release policy
+
+gluetun-monitor follows [Semantic Versioning](https://semver.org/) and ships
+Docker images on every release. This document is the contract for what the tags
+mean and how upgrades (including a future reimplementation) are handled, so the
+next major is a mechanical, low-pain move — the same playbook the v1→v2
+transition used.
+
+## Image tags
+
+Every release publishes, to both GHCR and Docker Hub:
+
+| Tag | Example | Moves to | Use for |
+|-----|---------|----------|---------|
+| `MAJOR.MINOR.PATCH` | `2.0.0` | never (frozen) | reproducible / fully pinned deploys |
+| `MAJOR.MINOR` | `2.0` | latest patch of that minor | pinning to a feature line |
+| **`MAJOR`** | **`2`** | latest release within that major | **recommended for production** |
+| `latest` | — | newest release, **including the next major** | "always newest", attended updates |
+
+The previous major's `MAJOR` tag (e.g. `1`) is **retained but frozen** as a
+rollback anchor after it goes EOL — it is never deleted.
+
+### Why `:MAJOR` is the recommended pin
+This is a privileged watchdog: it holds Docker `POST` rights and will
+restart/recreate other containers. Pinning the major means an unattended updater
+(Watchtower, etc.) picks up **features and fixes automatically** but **never a
+breaking major** without a human deciding to move. `:latest` would silently cross
+a major boundary — exactly the kind of surprise a container-restarting tool
+should avoid (Tenet 1: first, do no harm).
+
+`:latest` is still published for people who explicitly want the newest thing and
+update attentively. We do **not** use a `stable` tag today; if pre-releases
+(`-rc`) are ever published, `stable` would be introduced to mean "newest full
+release" and `latest` would include pre-releases.
+
+## What each bump means
+
+- **PATCH** (`2.0.0 → 2.0.1`): bug fixes only. Always safe to take.
+- **MINOR** (`2.0 → 2.1`): new features, backward-compatible. New config is
+  **additive and defaults to current behavior** — upgrading changes nothing
+  unless you opt in. Safe to take.
+- **MAJOR** (`2 → 3`): a deliberate line that **may** change defaults, remove
+  config, or alter behavior. Requires reading the migration notes. **The
+  implementation language is irrelevant to the version** — a major is defined by
+  *user-facing change*, not by how it's built (v1 was bash, v2 is Python; a
+  hypothetical Go/Rust rewrite that kept the same interface could even be a
+  minor — see below).
+
+## The major-upgrade contract (how we keep it painless)
+
+When a new major ships, we hold to the same guarantees that made v1→v2 a
+drop-in:
+
+1. **Config compatibility is preserved wherever feasible**, even across a
+   rewrite. Same env var names + defaults, same file paths (`/config`, `/logs`),
+   same Docker API permission set. The goal is "change the tag, it keeps working"
+   for the common case. A reimplementation in another language is an
+   *implementation detail* and should aim to honor the existing interface — if it
+   does, the only reason it's a new major is any *intentional* behavior change it
+   carries, not the rewrite itself.
+2. **Breaking changes are loud and documented**, never silent: enumerated in the
+   CHANGELOG `### Migration` section and a README "Upgrading from vN" section,
+   with the conservative-equivalent settings spelled out.
+3. **The upgrade is validated**, not assumed: a drop-in test boots the new image
+   with the previous major's config/env against a real socket proxy and asserts a
+   clean start (see `issue20-upgrade-validation.sh` for the v1→v2 instance), plus
+   a differential check that shared defaults didn't drift.
+4. **The previous major is EOL'd but kept pullable** as its `MAJOR` tag, so
+   rollback is a one-line tag change.
+5. **"Fail loud, don't guess" can tighten across a major**: a new major may
+   reject a misconfiguration an older one tolerated silently (v2 made empty/bad
+   config fatal). That's a deliberate, documented breaking change, not a
+   regression.
+
+## History
+
+| Major | Implementation | Status |
+|-------|----------------|--------|
+| v1 | bash (`gluetun-monitor.sh`) | **EOL** — frozen at `:1` as rollback anchor |
+| v2 | Python (`gluetun_monitor`, docker-py) | **current** ([ADR-0007](adr/0007-reimplement-in-python.md)) |

--- a/docs/adr/0002-socket-proxy-default.md
+++ b/docs/adr/0002-socket-proxy-default.md
@@ -27,6 +27,6 @@ as an explicit, opt-in fallback for users who prefer it.
   needed for in-namespace testing (ADR-0001), and a recreate-based recovery
   (ADR-0004) would additionally require container create/remove. Each capability
   added to the recovery path is a capability that must be opened on the proxy —
-  a tradeoff to weigh explicitly, per Tenet 3.
+  a tradeoff to weigh explicitly, per Tenet 4.
 - The `docker:*-cli` image honors `DOCKER_HOST` natively, so supporting the
   proxy needed no changes to the script itself.

--- a/docs/adr/0002-socket-proxy-default.md
+++ b/docs/adr/0002-socket-proxy-default.md
@@ -29,4 +29,5 @@ as an explicit, opt-in fallback for users who prefer it.
   added to the recovery path is a capability that must be opened on the proxy —
   a tradeoff to weigh explicitly, per Tenet 4.
 - The `docker:*-cli` image honors `DOCKER_HOST` natively, so supporting the
-  proxy needed no changes to the script itself.
+  proxy needed no changes to the script itself. *(v2.0.0: the Python image +
+  docker-py likewise honor `DOCKER_HOST` — ADR-0007.)*

--- a/docs/adr/0004-dependent-aware-health.md
+++ b/docs/adr/0004-dependent-aware-health.md
@@ -19,7 +19,7 @@ only interface is `lo`.)
 Because the monitor tests connectivity *only from inside gluetun* (ADR-0001),
 every site check passes and the monitor reports healthy while the dependents are
 cut off from the network entirely. This is the core complaint: the watchdog
-reports green while the stack is broken (violates Tenet 6).
+reports green while the stack is broken (violates Tenet 7).
 
 We validated the mechanics empirically on rosa (Docker 29.1.3,
 `issue20-netns-experiment.sh`): Q1 a dependent's `HostConfig.NetworkMode` is

--- a/docs/adr/0004-dependent-aware-health.md
+++ b/docs/adr/0004-dependent-aware-health.md
@@ -74,6 +74,15 @@ must therefore be evaluated **per dependent**, not as a single global flag.
      > "catches a strand that predates the monitor's own startup" claim holds only
      > for *discovered/known/explicitly-listed* dependents — a recreate-strand
      > pre-dating startup needs an explicit `DEPENDENT_CONTAINERS` (see README).
+     >
+     > What v2 *does* keep across cycles is a **remembered-dependent set**: the
+     > union of everything discovered (or listed) so far, pruned to containers
+     > that still exist. This is what lets a dependent stay tracked after gluetun
+     > is recreated under it (its `NetworkMode` now points at the dead old id, so
+     > current-id discovery no longer matches it — but we remember it). It is
+     > *discovery* memory, not failure/backoff state: it carries no counters, and
+     > a monitor restart resets it — so it stays within Tenet 8's "re-act rather
+     > than remember" (which is about not persisting *fault* state).
 2. **Recovery is conditional on gluetun's identity — per dependent, not a blanket
    recreate.** Read the stranded dependent's `NetworkMode` (`container:<X>`) and
    compare `<X>` to gluetun's current `.Id`:

--- a/docs/adr/0004-dependent-aware-health.md
+++ b/docs/adr/0004-dependent-aware-health.md
@@ -57,12 +57,23 @@ must therefore be evaluated **per dependent**, not as a single global flag.
      — a dependent showing only `lo` is **stranded loopback-only**. This is
      ground truth and catches it regardless of cause. (Connectivity + DNS
      verification is layered on top in ADR-0006.)
-   - **Inspect (pre-filter, branch-selector, fallback):** track gluetun's **ID**
-     + `.State.StartedAt` across cycles and compare **each** dependent's
-     `NetworkMode` target-ID to gluetun's current ID. This cheaply flags
-     *suspect* dependents, **selects the recovery branch** (below), catches a
-     strand that predates the monitor's own startup, and is the **fallback** when
-     a dependent can't be exec'd (distroless/scratch).
+   - **Inspect (pre-filter, branch-selector, fallback):** compare **each**
+     dependent's `NetworkMode` target-ID to gluetun's current **ID**. This cheaply
+     flags *suspect* dependents, **selects the recovery branch** (below), and is
+     the **fallback** when a dependent can't be exec'd (distroless/scratch).
+
+     > **Implementation note (v2.0.0):** this ADR originally also proposed
+     > tracking gluetun's `.State.StartedAt` across cycles. The v2 build does
+     > **not** — it tracks the current id only. `StartedAt` would detect a
+     > *same-id in-place restart*, but the **interface check is ground truth every
+     > loop** and already detects the resulting strand from *any* cause (same-id
+     > restart *and* recreate both strand dependents to `lo`, per Q2/Q3), while the
+     > id comparison selects restart-vs-recreate. `StartedAt` would only duplicate
+     > detection the interface check already does, so we dropped it rather than
+     > carry extra cross-cycle state (Tenets 8/9 — simple/stateless). Likewise the
+     > "catches a strand that predates the monitor's own startup" claim holds only
+     > for *discovered/known/explicitly-listed* dependents — a recreate-strand
+     > pre-dating startup needs an explicit `DEPENDENT_CONTAINERS` (see README).
 2. **Recovery is conditional on gluetun's identity — per dependent, not a blanket
    recreate.** Read the stranded dependent's `NetworkMode` (`container:<X>`) and
    compare `<X>` to gluetun's current `.Id`:

--- a/docs/adr/0004-dependent-aware-health.md
+++ b/docs/adr/0004-dependent-aware-health.md
@@ -74,6 +74,12 @@ must therefore be evaluated **per dependent**, not as a single global flag.
      > "catches a strand that predates the monitor's own startup" claim holds only
      > for *discovered/known/explicitly-listed* dependents — a recreate-strand
      > pre-dating startup needs an explicit `DEPENDENT_CONTAINERS` (see README).
+     > To partly recover the original intent, v2 logs a **startup WARN** for any
+     > running container stranded on a *dead* netns parent that it isn't managing,
+     > pointing the operator at `DEPENDENT_CONTAINERS` — but it does **not**
+     > auto-recreate such an orphan: with the parent gone it can't be confirmed as
+     > *this* gluetun's dependent, and acting on that guess could churn the wrong
+     > container (Tenet 1).
      >
      > What v2 *does* keep across cycles is a **remembered-dependent set**: the
      > union of everything discovered (or listed) so far, pruned to containers

--- a/docs/adr/0005-recreate-mechanism.md
+++ b/docs/adr/0005-recreate-mechanism.md
@@ -63,7 +63,7 @@ considered:
 
 ## Decision
 - **Mechanism = B (Docker-API reconstruct).** It satisfies #20's request, stays
-  socket-only (Tenet 3), and avoids coupling the monitor to the user's on-disk
+  socket-only (Tenet 4), and avoids coupling the monitor to the user's on-disk
   compose layout. **C is rejected** as too heavy for a watchdog.
 - **Default = B, attempted automatically (default ON).** When a dependent is
   stranded loopback-only and its `NetworkMode` target ≠ the current gluetun ID,

--- a/docs/adr/0005-recreate-mechanism.md
+++ b/docs/adr/0005-recreate-mechanism.md
@@ -4,6 +4,14 @@
 - **Date:** 2026-05-28
 - **Refines:** ADR-0004 (the ID-changed recovery branch)
 
+> **v2.0.0 note (ADR-0007):** the *mechanism* below (inspect → strip
+> netns-conflicting fields → `rm` without `-v` → recreate with the same `Mounts`
+> → `start`) is exactly what shipped — but in **Python via docker-py**, not the
+> bash + `jq`/`curl` sketched here, so v2 adds **no `jq`/`curl`** to the image.
+> And while this ADR framed it as a *MINOR* release, it actually shipped in
+> **v2.0.0** (a major bump, driven by the language rewrite — ADR-0007 — not by a
+> change to this decision). The "no new proxy permission" conclusion still holds.
+
 ## Context
 ADR-0004 establishes that when gluetun is **recreated** (new container ID), a
 **stranded loopback-only** dependent must be **recreated** — restart can't rejoin

--- a/docs/adr/0006-per-dependent-viability-testing.md
+++ b/docs/adr/0006-per-dependent-viability-testing.md
@@ -205,9 +205,9 @@ the L7 viability result — each prefixed with the container the test ran in, so
 "can it route out" and "what did we actually validate" are both visible:
 
 ```
-[app1] interface check: live [eth0,lo,tun0]
-[app1] viability: https://example.com: resolved + connected (HTTP 200) [wget] [fails 0]
-[app1] viability: https://example.org: DNS FAILED — bad address [wget] [fails 2/2 -> remediate]   (WARN)
+[dependent:app1] interface check: live [eth0,lo,tun0]
+[dependent:app1] viability: https://example.com: resolved + connected (HTTP 200) [wget] [fails 0]
+[dependent:app1] viability: https://example.org: DNS FAILED — bad address [wget] [fails 2/2 -> remediate]   (WARN)
 ```
 
 ## Consequences

--- a/docs/adr/0006-per-dependent-viability-testing.md
+++ b/docs/adr/0006-per-dependent-viability-testing.md
@@ -156,8 +156,16 @@ paths is the per-loop reset.
 per loop** (plus gluetun's full set). That's inherent: each container is verified
 independently (you can't prove container X via container Y). It is O(#live deps)
 per loop, **not** O(#deps × names), because each dependent runs a single name
-test. A concurrency cap (`MAX_PARALLEL_CHECKS`, default ~6) + per-dispatch jitter
-bound the burst on host CPU (one `docker exec` fork per job) and the shared tunnel.
+test. A concurrency cap (`MAX_PARALLEL_CHECKS`, default 6) bounds the burst on
+host CPU (one `docker exec` fork per job) and the shared tunnel.
+
+> **Implementation note (v2.0.0):** the cap is the primary bound and is sufficient
+> at homelab scale (≤6 trivial header requests at a time). Per-dispatch jitter
+> ships as an opt-in knob (`MAX_JITTER_MS`) that **defaults to 0 (off)** — it only
+> de-synchronizes start times within the already-capped burst, so it's available
+> for anyone who wants to spread load further, not on by default (Tenet 9 —
+> simple beats clever). The viability layer itself is opt-out via
+> `DEPENDENT_VIABILITY` (default on); the interface check is never optional.
 
 **Degradation:** 0 live dependents → gluetun only (today's behavior). **No
 resolvable names** (all IP-literals) → `WARN` + dependents tested against one

--- a/docs/adr/0006-per-dependent-viability-testing.md
+++ b/docs/adr/0006-per-dependent-viability-testing.md
@@ -174,11 +174,12 @@ this config — a documented limitation). **distroless/scratch** dependents (no
 shell to exec) can't be viability-tested → fall back to ADR-0004's
 interface/inspect signals for those.
 
-Per-dependent results log at DEBUG, e.g. (generic placeholders):
+Per-dependent results log (generic placeholders; the actual v2.0.0 format —
+a pass at DEBUG, a remediation trigger at WARN):
 
 ```
-[DEBUG] Dependent app1: https://example.com ok (1064ms) [fails 0/2]
-[DEBUG] Dependent app1: https://example.org FAILED (DNS) [fails 2/2 -> remediate]
+[DEBUG] Dependent app1: https://example.com: HTTP 200 [fails 0]
+[WARN] Dependent app1: https://example.org: Network failure (DNS or connection) [fails 2/2 -> remediate]
 ```
 
 ## Consequences

--- a/docs/adr/0006-per-dependent-viability-testing.md
+++ b/docs/adr/0006-per-dependent-viability-testing.md
@@ -12,7 +12,7 @@ are healthy: a dependent can be stranded loopback-only (netns) or carry a
 **per-container** fault — most notably a broken `/etc/resolv.conf`, which is
 per-container filesystem and **not** shared by the netns. The #20 lesson is to
 stop inferring stack health from the gateway and **measure each dependent
-directly** (Tenet 5), without becoming trigger-happy (Tenet 2).
+directly** (Tenet 6), without becoming trigger-happy (Tenet 3).
 
 Two physical facts shape the design:
 - All dependents **share gluetun's netns**, so a test from a dependent egresses
@@ -37,7 +37,7 @@ Each loop, in order:
    itself is the problem → gluetun-restart recovery (ADR-0003), which
    **re-verifies the full set after the restart** and only proceeds to the
    dependent phase if the tunnel is restored; if still failing, dependents are
-   left untouched until next cycle (don't churn them into a dead tunnel — Tenet 4).
+   left untouched until next cycle (don't churn them into a dead tunnel — Tenet 5).
 3. **Per-dependent viability test — one shuffled name per loop.** Build the
    **resolvable-name pool** (the hostname URLs). For each live dependent, pick
    **one shuffled name** from the pool and test resolve+connect *from inside that
@@ -61,7 +61,7 @@ Each loop, in order:
    nodes 2–5), so a container-only failure is still correctly attributed to the
    container — the root test is the disambiguator, so a tiny pool is not a
    false-positive risk.
-5. **Reaction — one knob, two failure classes (Tenet 7).**
+5. **Reaction — one knob, two failure classes (Tenet 8).**
    - **`DEPENDENT_CONTAINER_FAILURES`** (default `$FAIL_THRESHOLD`) — consecutive
      per-container failures before remediation. It mirrors gluetun's retry count
      so there is one mental model and one default for the whole stack; override
@@ -85,7 +85,7 @@ Each loop, in order:
    - **Asymmetry, deliberate:** gluetun tests the **full set** each loop (root,
      comprehensive); each dependent tests **one shuffled name** per loop (spread
      load across many containers — see Load).
-   - **FAILED state (Tenet 6):** when recovery can't restore health — gluetun
+   - **FAILED state (Tenet 7):** when recovery can't restore health — gluetun
      won't come back after its restart, a dependent's post-recovery verify fails,
      or recreate is disabled/denied — the monitor enters an explicit **FAILED**
      state: report unhealthy loudly (and fire a notification once that layer
@@ -182,7 +182,7 @@ Per-dependent results log at DEBUG, e.g. (generic placeholders):
   *different* name each loop is what turns the consecutive-failure count into a
   container-health signal instead of a URL-uptime signal. Testing the same name
   repeatedly would be a bug.
-- **Reaction stays conservative** (Tenet 7): the hard netns strand acts fast
+- **Reaction stays conservative** (Tenet 8): the hard netns strand acts fast
   (single re-check); the soft DNS/connect fault waits `DEPENDENT_CONTAINER_FAILURES`
   loops so a transient blip never recreates a container.
 - Requires `docker exec` into dependents (already required for gluetun, ADR-0001)
@@ -194,5 +194,5 @@ Per-dependent results log at DEBUG, e.g. (generic placeholders):
   (2) per-dependent viability test + the `DEPENDENT_CONTAINER_FAILURES` gate.
 - New knobs: `DEPENDENT_CONTAINER_FAILURES` (default `$FAIL_THRESHOLD`),
   `MAX_PARALLEL_CHECKS` (~6), jitter window, and an **opt-out** for the dependent
-  viability layer — it is **on by default** (Tenet 7); the interface check is not
+  viability layer — it is **on by default** (Tenet 8); the interface check is not
   optional.

--- a/docs/adr/0006-per-dependent-viability-testing.md
+++ b/docs/adr/0006-per-dependent-viability-testing.md
@@ -167,6 +167,20 @@ host CPU (one `docker exec` fork per job) and the shared tunnel.
 > simple beats clever). The viability layer itself is opt-out via
 > `DEPENDENT_VIABILITY` (default on); the interface check is never optional.
 
+> **Implementation note (v2.0.0) — what "viability failure" means.** A live
+> dependent (passed the interface check) **shares gluetun's netns**, so its L3/L4
+> egress *is* gluetun's — already proven by the root test — and the orphaned/
+> stranded case is caught upstream by the interface check (loopback-only). The
+> only fault left that is genuinely **per-container is DNS** (its own
+> `resolv.conf`). So viability **fails only on a positively-identified DNS
+> resolution failure**; any HTTP response (incl. 4xx/5xx) *or* a
+> resolved-but-unreached site (connection refused / timeout / TLS) counts as
+> viable — those are the remote's business, not a dependent fault, and treating
+> them as failures caused spurious restarts (a busybox-wget dependent returns
+> exit 1 for a harmless 404; found in dogfooding). The strict "did it respond"
+> signal is retained separately for gluetun's *root* test (tunnel-down detection).
+> A fully portable injected probe is the long-term improvement (see ROADMAP).
+
 **Degradation:** 0 live dependents → gluetun only (today's behavior). **No
 resolvable names** (all IP-literals) → `WARN` + dependents tested against one
 shuffled IP per loop (connectivity only; **dependent DNS is never validated** in

--- a/docs/adr/0006-per-dependent-viability-testing.md
+++ b/docs/adr/0006-per-dependent-viability-testing.md
@@ -205,9 +205,9 @@ the L7 viability result — each prefixed with the container the test ran in, so
 "can it route out" and "what did we actually validate" are both visible:
 
 ```
-[dependent:app1] interface check: live [eth0,lo,tun0]
-[dependent:app1] viability: https://example.com: resolved + connected (HTTP 200) [wget] [fails 0]
-[dependent:app1] viability: https://example.org: DNS FAILED — bad address [wget] [fails 2/2 -> remediate]   (WARN)
+[dependent:app1] link live: eth0,lo,tun0
+[dependent:app1] reach ok: example.com (HTTP 200) [wget]
+[dependent:app1] reach fail: example.org (bad address) [wget] [2/2 → remediate]   (WARN)
 ```
 
 ## Consequences

--- a/docs/adr/0006-per-dependent-viability-testing.md
+++ b/docs/adr/0006-per-dependent-viability-testing.md
@@ -199,12 +199,15 @@ this config — a documented limitation). **distroless/scratch** dependents (no
 shell to exec) can't be viability-tested → fall back to ADR-0004's
 interface/inspect signals for those.
 
-Per-dependent results log (generic placeholders; the actual v2.0.0 format —
-a pass at DEBUG, a remediation trigger at WARN):
+Per-dependent results log (generic placeholders; the actual v2.0.0 format). Each
+dependent logs two ordered DEBUG lines — the L3 interface/route check first, then
+the L7 viability result — each prefixed with the container the test ran in, so
+"can it route out" and "what did we actually validate" are both visible:
 
 ```
-[DEBUG] Dependent app1: https://example.com: HTTP 200 [fails 0]
-[WARN] Dependent app1: https://example.org: Network failure (DNS or connection) [fails 2/2 -> remediate]
+[app1] interface check: live [eth0,lo,tun0]
+[app1] viability: https://example.com: resolved + connected (HTTP 200) [wget] [fails 0]
+[app1] viability: https://example.org: DNS FAILED — bad address [wget] [fails 2/2 -> remediate]   (WARN)
 ```
 
 ## Consequences

--- a/docs/adr/0006-per-dependent-viability-testing.md
+++ b/docs/adr/0006-per-dependent-viability-testing.md
@@ -179,7 +179,18 @@ host CPU (one `docker exec` fork per job) and the shared tunnel.
 > them as failures caused spurious restarts (a busybox-wget dependent returns
 > exit 1 for a harmless 404; found in dogfooding). The strict "did it respond"
 > signal is retained separately for gluetun's *root* test (tunnel-down detection).
-> A fully portable injected probe is the long-term improvement (see ROADMAP).
+>
+> DNS is validated with a **cascade of getaddrinfo-faithful tools** (`gluetun_monitor/dns_check.py`):
+> **wget → getent → ping**, stopping at the first one present in the container.
+> These resolve the way the application does (libc `getaddrinfo`/nsswitch);
+> `nslookup`/`dig`/`host` are deliberately **excluded** — they query DNS servers
+> directly, bypassing nsswitch/`hosts`/libc, so they can report "resolves" when
+> the app's `getaddrinfo` does not. The check has **three** outcomes: OK, BROKEN
+> (a tool ran and resolution failed → the fault we act on), and **UNVALIDATED**
+> (no usable tool in the container — e.g. distroless): we don't guess, we log it
+> once and fall back to the interface check. A fully portable **injected** static
+> probe is the long-term improvement that also covers the UNVALIDATED case (see
+> ROADMAP).
 
 **Degradation:** 0 live dependents → gluetun only (today's behavior). **No
 resolvable names** (all IP-literals) → `WARN` + dependents tested against one

--- a/docs/adr/0007-reimplement-in-python.md
+++ b/docs/adr/0007-reimplement-in-python.md
@@ -41,11 +41,12 @@ tecnativa socket-proxy already exposes (`CONTAINERS`/`POST`/`EXEC`), and a thin
 wrapper over it is the injection point that makes the whole monitor unit-testable
 with a `FakeDockerClient` — **no live daemon required for the test suite**.
 
-The connectivity test keeps its ADR-0001 semantics exactly: still
-`exec` **inside gluetun's netns** running `wget --spider -S`, still the same
-exit-code → pass/fail map (`0/6/8` = pass). docker-py's `exec_run` returns the
-same exit code shell did, so Python only reorganizes **orchestration**, not the
-HTTP probe — which is where almost all of the regression surface would be.
+The connectivity test keeps its ADR-0001 semantics: still `exec` **inside
+gluetun's netns** running `wget --spider -S`, still "any HTTP response = up" (the
+GNU `0/6/8` exit-code map is retained only as a fallback when no HTTP status line
+is captured — see ADR-0006). docker-py's `exec_run` returns the same exit code
+shell did, so Python only reorganizes **orchestration**, not the HTTP probe —
+which is where almost all of the regression surface would be.
 
 **No-regressions strategy (the contract):**
 1. **Characterization-first.** Before porting behavior, pin v1.x's observable

--- a/docs/adr/0007-reimplement-in-python.md
+++ b/docs/adr/0007-reimplement-in-python.md
@@ -1,0 +1,86 @@
+# ADR-0007: Reimplement the monitor in Python (v2.0.0)
+
+- **Status:** Accepted
+- **Date:** 2026-05-28
+- **Enables:** ADR-0004, ADR-0005, ADR-0006 (the dependent-aware design they
+  describe is what motivates the rewrite)
+
+## Context
+v1.x is pure bash (`gluetun-monitor.sh`): a flat loop that tests a URL set from
+inside gluetun (ADR-0001) and restarts gluetun + dependents on failure. The #20
+design (ADRs 0004–0006) adds materially harder logic on top of that:
+
+- a **22-node state machine** (ADR-0006) with two failure classes and per-loop
+  re-evaluation,
+- **per-dependent** counters, an independent **shuffle** per container, and a
+  bounded-concurrency fan-out,
+- a restart-vs-recreate **decision** keyed on resolving each dependent's
+  `NetworkMode` to gluetun's current `.Id` (ADR-0004), and
+- the part that forces the question — the **default-on `AUTO_RECREATE`
+  reconstruct** (ADR-0005): inspect the dependent, copy its `Mounts` (including
+  anonymous volumes), strip the netns-conflicting fields, recreate without `-v`,
+  and verify. That is JSON surgery — read a container's full inspect, mutate a
+  nested structure, and POST a create body.
+
+In bash this is `curl | jq` against the Docker API (or `docker inspect --format`
+gymnastics), with `set -euo pipefail` foot-guns on every non-zero return and no
+practical way to unit-test the mutate-and-recreate path without a live daemon.
+The logic is now complex enough that **testability is the dominant concern**, and
+the recreate path is destructive-adjacent (it `rm`s a container) so it must be
+tested hard before it ships on by default.
+
+Python is the preferred language for this kind of tooling (Ruff, mypy, pytest,
+pyproject). The blocker was never preference — it was **no-regressions** on a
+published v1.x tool.
+
+## Decision
+Reimplement as a **Python package** (`gluetun_monitor`) and release it as
+**v2.0.0**. Use **docker-py** (the official SDK) as the Docker seam rather than
+shelling out to the `docker` CLI: it speaks the same Docker HTTP API the
+tecnativa socket-proxy already exposes (`CONTAINERS`/`POST`/`EXEC`), and a thin
+wrapper over it is the injection point that makes the whole monitor unit-testable
+with a `FakeDockerClient` — **no live daemon required for the test suite**.
+
+The connectivity test keeps its ADR-0001 semantics exactly: still
+`exec` **inside gluetun's netns** running `wget --spider -S`, still the same
+exit-code → pass/fail map (`0/6/8` = pass). docker-py's `exec_run` returns the
+same exit code shell did, so Python only reorganizes **orchestration**, not the
+HTTP probe — which is where almost all of the regression surface would be.
+
+**No-regressions strategy (the contract):**
+1. **Characterization-first.** Before porting behavior, pin v1.x's observable
+   contract as tests: env-var defaults, `sites.conf` parsing (comments, blanks,
+   whitespace, the issue-#17 apostrophe), the wget exit-code map, the
+   `FAIL_THRESHOLD` consecutive-failure counting, auto-discovery by NetworkMode
+   match, and the log tokens (`[CHECK]`, `[ENDPOINT]`, `ip getter` parsing).
+   These pass against bash today and are the bar Python must clear green.
+2. **Differential harness.** Run old-bash and new-python against identical
+   mock-Docker inputs and assert identical decisions (pass/fail/restart) on the
+   shared contract.
+3. **Port the bats regressions to pytest** — especially #17 (apostrophe parse)
+   and shellcheck-clean's spirit (ruff + mypy --strict gate instead).
+4. **Promote the `issue20-*.sh` experiment scripts** to integration tests.
+5. **Staged rollout (ROC, Tenet 8).** Bash stays in-tree and tagged; the v1.x
+   image stays pullable as `:1`. Ship Python as `:2` / `:latest` / v2.0.0,
+   dogfood on rosa, and keep **rollback = repin `:1`** — one-step, non-destructive.
+
+## Consequences
+- **The hard path becomes testable.** The recreate reconstruct (ADR-0005) gets
+  real unit coverage against a fake daemon, including the data-loss guards (copy
+  anon volumes, `rm` without `-v`) — the single biggest reason to move.
+- **Type safety + lint gate.** `mypy --strict` and `ruff` replace shellcheck;
+  the state machine's states/transitions become explicit types, not string
+  conventions.
+- **New runtime dependency.** v2 needs a Python base image + docker-py instead of
+  `docker:cli`. Image grows modestly; the `docker` CLI is no longer required in
+  the image (the SDK talks the API directly). Accepted.
+- **A real rewrite carries risk** — mitigated by the characterization +
+  differential gates above; we do not merge until the bash contract passes green
+  in Python and the differential harness agrees.
+- **Bash is now legacy.** `gluetun-monitor.sh` is retained for rollback and as
+  the differential oracle, not for further feature work. v1.x bug-fixes, if any,
+  are backports.
+- **Versioning:** the language swap + behavior expansion (dependent-aware) is a
+  major bump → **v2.0.0**. The `:1` tag is the compatibility anchor.
+- Follow-ups unchanged from the design: notification layer + socket-proxy
+  hardening remain in `docs/ROADMAP.md`.

--- a/docs/adr/0007-reimplement-in-python.md
+++ b/docs/adr/0007-reimplement-in-python.md
@@ -60,7 +60,7 @@ HTTP probe — which is where almost all of the regression surface would be.
 3. **Port the bats regressions to pytest** — especially #17 (apostrophe parse)
    and shellcheck-clean's spirit (ruff + mypy --strict gate instead).
 4. **Promote the `issue20-*.sh` experiment scripts** to integration tests.
-5. **Staged rollout (ROC, Tenet 8).** Bash stays in-tree and tagged; the v1.x
+5. **Staged rollout (ROC, Tenet 9).** Bash stays in-tree and tagged; the v1.x
    image stays pullable as `:1`. Ship Python as `:2` / `:latest` / v2.0.0,
    dogfood on rosa, and keep **rollback = repin `:1`** — one-step, non-destructive.
 

--- a/docs/adr/0008-persistent-site-stats-and-advisory.md
+++ b/docs/adr/0008-persistent-site-stats-and-advisory.md
@@ -51,9 +51,12 @@ fragile.
    triggered and **restart-effectiveness** (fraction that actually cleared the
    site on re-verify — distinguishes a site fault from a VPN fault), and
    first-seen / last-failure / last-success timestamps. Plus a bounded
-   **recent-restarts** ring buffer for the windowed advisory. The saved JSON also
-   includes the computed metrics (rates, percentiles) so it reads at a glance.
-   Corrupt/missing file → start fresh, never crash.
+   **recent-restarts** ring buffer for the windowed advisory. A top-level
+   **`monitor`** section carries monitor-wide totals (version, first/last start,
+   uptime, total loops, accumulated runtime, cumulative gluetun restarts /
+   dependent remediations / advisories). The saved JSON also includes the computed
+   metrics (rates, percentiles) so it reads at a glance. Corrupt/missing file →
+   start fresh, never crash.
 3. **Emit a flaky-site advisory.** When one site accounts for a dominant share of
    the gluetun restarts within a recent window — default: ≥ `ADVISORY_MIN_RESTARTS`
    restarts in `ADVISORY_WINDOW`, of which ≥ `ADVISORY_DOMINANCE` fraction are that

--- a/docs/adr/0008-persistent-site-stats-and-advisory.md
+++ b/docs/adr/0008-persistent-site-stats-and-advisory.md
@@ -1,0 +1,74 @@
+# ADR-0008: Persistent per-site stats + a flaky-site advisory
+
+- **Status:** Accepted
+- **Date:** 2026-06-02
+- **Relates to:** ADR-0003 (gluetun restart), ADR-0006 (per-loop flow); ROADMAP (notification layer)
+
+## Context
+Dogfooding v2 on a real stack overnight surfaced a problem that predates v2 (it's
+faithfully inherited from the v1 bash): the gluetun root test restarts gluetun when
+**any single site** reaches `FAIL_THRESHOLD` consecutive failures, and
+`handle_failure` then **resets all counters** — so there is no memory across
+restarts. A single *flaky* test site (an indexer that intermittently times out or
+SSL-errors) therefore drives an unbounded **restart storm**: 22 gluetun restarts in
+one night → 66 dependent restarts, every one of them triggered by two flaky indexer
+sites while the tunnel was provably up (the other 7 sites passed each loop). Each
+restart even logged "Recovery complete" because the transient cleared on re-verify,
+masking the churn.
+
+Two observations shaped the decision:
+- A restart **is** a legitimate cheap fix — a genuinely blocked VPN endpoint is
+  often resolved by forcing a new one. So we do **not** want to stop restarting on
+  a single-site failure.
+- But the monitor has no way to tell the operator *which* site is the chronic
+  troublemaker, or that restarts aren't durably helping. The fix the operator
+  actually wants is to **prune the flaky site** — they just need to be told.
+
+We considered an automatic circuit-breaker (back off / quarantine a site after N
+restarts). It was **rejected** for now: it adds opinionated auto-suppression, and
+the operator preferred to keep the cheap auto-fix and decide pruning themselves,
+informed by data.
+
+This requires something v2 deliberately avoided (Tenets 8/9 — "re-act rather than
+remember; no persistence"): **state that survives a monitor restart.** That stance
+was about *fault/backoff* state for cheap, non-destructive dependent remediation;
+it does not preclude **observability** data. Recording how sites behave *over time*
+is reporting, not control flow, so persisting it does not make recovery stateful or
+fragile.
+
+## Decision
+1. **Keep restart-first as-is.** A single site breaching `FAIL_THRESHOLD` still
+   triggers a gluetun restart (the cheap fix). No auto back-off, no quarantine.
+   `FAIL_THRESHOLD` and the per-loop flow are unchanged.
+2. **Record persistent per-site stats** in a human-readable JSON sidecar
+   (`STATS_FILE`, default `/logs/site-stats.json`), loaded on startup and written
+   periodically (not every loop). Per site: total polls, total failures (→ rate),
+   failure **episodes** and total failure-polls (→ average episode length in
+   polls), restarts triggered, and first-seen / last-failure / last-success
+   timestamps. Plus a bounded **recent-restarts** ring buffer (timestamp + site)
+   to answer windowed questions. Corrupt/missing file → start fresh, never crash.
+3. **Emit a flaky-site advisory.** When one site accounts for a dominant share of
+   the gluetun restarts within a recent window — default: ≥ `ADVISORY_MIN_RESTARTS`
+   restarts in `ADVISORY_WINDOW`, of which ≥ `ADVISORY_DOMINANCE` fraction are that
+   site — log a loud, deduped WARN: *"<site> caused A of the last B restarts over
+   the last <window> — it may be flaky; consider reviewing/removing it from
+   sites.conf."* This is the human-in-the-loop escalation; when the notification
+   layer (ROADMAP) lands, it fires there too.
+
+## Consequences
+- **The operator gets attribution + history**, not just symptoms: "this site keeps
+  being flaky," and "which sites cause the restarts, how often." That's the data
+  needed to prune a bad test site.
+- **The churn is *not* auto-stopped** — by deliberate choice. Until the operator
+  prunes the flagged site, restarts continue (the advisory exists to prompt that
+  quickly). A future automatic back-off remains possible if this proves
+  insufficient (it would be a new, opt-in decision).
+- **We relax the stateless stance (Tenets 8/9) for observability only.** Recovery
+  control flow stays in-memory and reset-on-restart; only the *stats* persist.
+  Persistence is best-effort: a missing/corrupt/unwritable stats file degrades to
+  in-memory and never blocks the monitor (Tenet 7 — the watchdog must not become
+  the outage).
+- **New surface:** a writable stats path (the existing `/logs` mount by default)
+  and the advisory knobs. JSON (not SQLite) keeps it dependency-free, greppable,
+  and easy to inspect; a heavier store is a future option if richer queries are
+  needed.

--- a/docs/adr/0008-persistent-site-stats-and-advisory.md
+++ b/docs/adr/0008-persistent-site-stats-and-advisory.md
@@ -42,11 +42,18 @@ fragile.
    `FAIL_THRESHOLD` and the per-loop flow are unchanged.
 2. **Record persistent per-site stats** in a human-readable JSON sidecar
    (`STATS_FILE`, default `/logs/site-stats.json`), loaded on startup and written
-   periodically (not every loop). Per site: total polls, total failures (→ rate),
-   failure **episodes** and total failure-polls (→ average episode length in
-   polls), restarts triggered, and first-seen / last-failure / last-success
-   timestamps. Plus a bounded **recent-restarts** ring buffer (timestamp + site)
-   to answer windowed questions. Corrupt/missing file → start fresh, never crash.
+   every loop (a small atomic write). Per site: total polls, total failures (→ rate),
+   failure **episodes** (→ average episode length in polls; every failing poll is
+   in exactly one episode, so avg = total_failures / episodes), the longest such
+   streak, a **failure-reason breakdown** (dns/tls/timeout/connection/http-error/
+   other), **response-latency** of successful polls over a bounded ring
+   (avg/min/max + **p50/p90/p99** — slowness often precedes failure), restarts
+   triggered and **restart-effectiveness** (fraction that actually cleared the
+   site on re-verify — distinguishes a site fault from a VPN fault), and
+   first-seen / last-failure / last-success timestamps. Plus a bounded
+   **recent-restarts** ring buffer for the windowed advisory. The saved JSON also
+   includes the computed metrics (rates, percentiles) so it reads at a glance.
+   Corrupt/missing file → start fresh, never crash.
 3. **Emit a flaky-site advisory.** When one site accounts for a dominant share of
    the gluetun restarts within a recent window — default: ≥ `ADVISORY_MIN_RESTARTS`
    restarts in `ADVISORY_WINDOW`, of which ≥ `ADVISORY_DOMINANCE` fraction are that

--- a/docs/adr/0009-all-time-latency-histogram.md
+++ b/docs/adr/0009-all-time-latency-histogram.md
@@ -1,0 +1,73 @@
+# ADR-0009: All-time latency percentiles via a bounded histogram
+
+- **Status:** Accepted
+- **Date:** 2026-06-02
+- **Relates to:** ADR-0008 (persistent per-site stats — this extends the sidecar)
+
+## Context
+ADR-0008 records per-site response latency from a **recent ring** of the last N
+successful polls (default 200), and reports avg/min/max + p50/p90/p99 over it. That
+answers "how is this site doing **now**" — by design it forgets older samples, so a
+site that has been slow all week but is fast in the last 200 polls looks fine, and
+there's no lifetime baseline to compare a bad day against.
+
+We wanted an **all-time** latency view too ("how has this site behaved over its
+whole life") without unbounded memory. The obvious approaches each fail one
+requirement:
+
+- **Keep every sample** → exact percentiles, but unbounded memory and an
+  ever-growing sidecar. Out (Tenet 7 — the watchdog must not grow without bound).
+- **Just widen the ring** → still a fixed window, still forgets; and a large ring
+  is a lot of raw floats to persist every loop.
+- **A running percentile from O(1) state** (the old "nudge the estimate" idea / the
+  stochastic-quantile and P² estimators) → genuinely O(1), but exact all-time
+  percentiles in bounded memory are **impossible**: percentiles are order
+  statistics, so unlike the mean (which *does* have an exact O(1) update) you cannot
+  recover the new percentile from the old one, the count, and the new sample — the
+  answer depends on the distribution's shape around that quantile, which one number
+  can't carry. The stochastic estimators approximate, but they're noisy at the
+  tails (p99 especially) and slow to react when the distribution shifts (a VPN
+  endpoint change) — the worst case for *latency tail* monitoring.
+
+## Decision
+Add a small per-site **log-bucketed histogram** (a DDSketch-style sketch;
+`histogram.py`) alongside the recent ring, persisted in the same best-effort
+sidecar, and surface it as an opt-in "all-time" view in `gluetun-monitor-stats`
+(`--lifetime`) and always in `--json`.
+
+How it works: bucket a latency on a logarithmic scale where consecutive bucket
+boundaries differ by a factor `gamma = (1+a)/(1-a)`, and represent each bucket by a
+single value. That makes every reported percentile **within `a` (relative) of the
+true value** — the DDSketch guarantee (Dunning; Ertl). We use `a = 5%`, far tighter
+than latency decisions need. Exact `count`/`sum`/`min`/`max` are tracked alongside,
+so only the *percentiles* are approximate (avg/min/max stay exact).
+
+Why this over the alternatives:
+- **Bounded + sparse.** For latencies spanning ~1 ms to ~100 s, that's a few dozen
+  populated `{bucket: count}` entries per site — a few hundred bytes, vs. 200 raw
+  floats for the ring. The bucket count grows with the *log* of the value range,
+  not with the sample count.
+- **Tail-accurate.** The relative-error guarantee holds at p99, unlike the
+  stochastic estimators — exactly where latency monitoring cares most.
+- **Mergeable.** Bucket counts simply add, so it survives restarts trivially
+  (reload = restore counts) and could later merge across containers/sites.
+- **Honest.** It complements, not replaces, the ring: "recent" vs "all-time" are
+  both shown, and the recent ring stays the default.
+
+The sketch is persisted as `lifetime_latency` (the reloadable counts, bucket keys
+as strings) plus a human-readable `lifetime_latency_ms` summary. Like everything in
+the sidecar it is best-effort: a malformed `lifetime_latency` degrades to an empty
+histogram, never a crash (Tenet 7).
+
+## Consequences
+- A second latency lens (lifetime baseline) for spotting chronic-vs-transient
+  slowness and "today vs its own normal," at trivial memory cost.
+- Percentiles are approximate (≤5% relative); avg/min/max remain exact. Acceptable
+  — latency thresholds are not set to 5% precision.
+- A new persisted field. Older files simply lack it (reload yields an empty
+  histogram that fills going forward); newer files carry it. No migration needed.
+- **Decay is intentionally out of scope for now.** The histogram is equal-weight
+  all-time. A time-decayed variant (periodically scaling bucket counts so recent
+  samples dominate — the "weighted all-time" idea) is a clean future extension that
+  this structure supports, but it adds a decay schedule + last-decay bookkeeping we
+  don't need yet. If added, it would be opt-in.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -36,3 +36,4 @@ Format: [`_template.md`](_template.md). Status ∈ Proposed | Accepted | Superse
 | [0005](0005-recreate-mechanism.md) | Recreate mechanism — Docker-API reconstruct, default-on + capability-gated (`AUTO_RECREATE=0` to disable), non-destructive (validated) | Accepted |
 | [0006](0006-per-dependent-viability-testing.md) | Per-dependent connectivity + DNS viability testing (gluetun root + one shuffled name per dependent per loop) | Accepted |
 | [0007](0007-reimplement-in-python.md) | Reimplement the monitor in Python (v2.0.0) — docker-py seam, characterization + differential no-regressions gate | Accepted |
+| [0008](0008-persistent-site-stats-and-advisory.md) | Persistent per-site stats + a flaky-site advisory (keep restart-first; record + advise, don't auto-quarantine) | Accepted |

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -37,3 +37,4 @@ Format: [`_template.md`](_template.md). Status ∈ Proposed | Accepted | Superse
 | [0006](0006-per-dependent-viability-testing.md) | Per-dependent connectivity + DNS viability testing (gluetun root + one shuffled name per dependent per loop) | Accepted |
 | [0007](0007-reimplement-in-python.md) | Reimplement the monitor in Python (v2.0.0) — docker-py seam, characterization + differential no-regressions gate | Accepted |
 | [0008](0008-persistent-site-stats-and-advisory.md) | Persistent per-site stats + a flaky-site advisory (keep restart-first; record + advise, don't auto-quarantine) | Accepted |
+| [0009](0009-all-time-latency-histogram.md) | All-time latency percentiles via a bounded DDSketch-style histogram (lifetime view alongside the recent ring) | Accepted |

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -15,6 +15,16 @@ or in the code, not here.
 
 Format: [`_template.md`](_template.md). Status ∈ Proposed | Accepted | Superseded.
 
+> **v1.x → v2.0.0 note.** ADRs 0001–0006 were written against the original
+> **bash** implementation (`gluetun-monitor.sh`). [ADR-0007](0007-reimplement-in-python.md)
+> reimplemented the monitor in **Python** (the `gluetun_monitor` package) for
+> v2.0.0. Their *decisions* still hold, but bash-era specifics — `gluetun-monitor.sh:NNN`
+> line citations, shell function names (`test_site_async`, `handle_failure`,
+> `wait_for_gluetun_healthy`, …), the `docker:*-cli` base image, and the
+> `jq`/`curl` approach — describe the v1.x code and now map onto the Python
+> package (which talks the Docker API via docker-py). The bash script is retained
+> only as the rollback anchor and differential-test oracle.
+
 ## Index
 
 | # | Decision | Status |

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -25,3 +25,4 @@ Format: [`_template.md`](_template.md). Status ∈ Proposed | Accepted | Superse
 | [0004](0004-dependent-aware-health.md) | Health is dependent-aware; recovery is conditional on gluetun's identity (restart if same ID, recreate if changed) | Accepted |
 | [0005](0005-recreate-mechanism.md) | Recreate mechanism — Docker-API reconstruct, default-on + capability-gated (`AUTO_RECREATE=0` to disable), non-destructive (validated) | Accepted |
 | [0006](0006-per-dependent-viability-testing.md) | Per-dependent connectivity + DNS viability testing (gluetun root + one shuffled name per dependent per loop) | Accepted |
+| [0007](0007-reimplement-in-python.md) | Reimplement the monitor in Python (v2.0.0) — docker-py seam, characterization + differential no-regressions gate | Accepted |

--- a/docs/release-notes-v2.0.0.md
+++ b/docs/release-notes-v2.0.0.md
@@ -1,0 +1,70 @@
+# gluetun-monitor v2.0.0
+
+**v2 is a ground-up reimplementation that makes the monitor *dependent-aware*: it
+now detects and heals the containers behind gluetun, not just gluetun itself.**
+It is a drop-in upgrade from v1 — same env vars, same files, same socket-proxy
+permissions — and **v1 is now end-of-life**.
+
+## Why v2
+
+v1 tested connectivity only from inside gluetun, so it reported "healthy" while
+dependent containers (`network_mode: service:gluetun`) could be **stranded
+loopback-only** after gluetun restarted or was recreated — cut off from the
+network while the monitor showed green (issue #20). v2 measures each dependent
+directly and heals it.
+
+## Highlights
+
+- **Dependent-aware health (#20).** Every loop, each dependent is interface-checked
+  (is it stranded to `lo`?) and given a quick DNS + connectivity probe from inside
+  its own namespace. A healthy gluetun no longer masks a broken dependent.
+- **Self-healing, non-destructively.** A stranded dependent is **restarted** when
+  it still shares gluetun's current network, or **recreated** when gluetun was
+  replaced (new container id). Recreate preserves all data — named, bind, **and
+  anonymous** volumes are carried over; only the container's ephemeral writable
+  layer is rebuilt from the image. On by default; `AUTO_RECREATE=0` to disable.
+- **Reimplemented in Python** (docker-py) for testability — the connectivity test
+  itself is unchanged (`wget --spider` inside gluetun's namespace, same pass/fail
+  rules). 220+ tests, including a differential suite that checks behavior against
+  the original bash.
+- **Configuration is validated; bad config fails loud.** Empty `sites.conf`, a
+  malformed env value, or an explicit `DEPENDENT_CONTAINERS` naming a missing
+  container now refuse to start with a clear message instead of running degraded.
+- **New controls:** `EXCLUDE_CONTAINERS` (never-manage denylist), `SITES`
+  (test URLs via env, unioned with `sites.conf`), `DEPENDENT_VIABILITY`,
+  `DEPENDENT_CONTAINER_FAILURES`, `MAX_PARALLEL_CHECKS`, `MAX_JITTER_MS`,
+  `DNS_WAIT_TIMEOUT`, `LOG_LEVEL`.
+
+## Upgrading from v1 (drop-in)
+
+Change the image tag — that's it for the common case. v2 reads the same env vars
+(same names + defaults), the same `/config/sites.conf` and `/logs`, and needs the
+same socket-proxy permissions (`CONTAINERS` / `POST` / `EXEC`).
+
+```diff
+-    image: ghcr.io/csmarshall/gluetun-monitor:1
++    image: ghcr.io/csmarshall/gluetun-monitor:2
+```
+
+Two behavior changes to know about:
+1. v2 **heals dependents by default**. To stay close to v1, set `AUTO_RECREATE=0`
+   (alert instead of recreate) and/or `DEPENDENT_VIABILITY=0` (interface check
+   only).
+2. **Bad config is now fatal** (see above) — if it refuses to start after the
+   upgrade, the log says exactly what to fix.
+
+**Rollback** is one step: repin `:1`.
+
+## Image tags
+
+- **`:2`** — recommended for production (all v2.x patches, no surprise major).
+- `:2.0.0` — fully pinned.
+- `:latest` — newest; will eventually roll to a future major.
+- `:1` — frozen v1, kept only as a rollback anchor (EOL, unsupported).
+
+See [docs/VERSIONING.md](https://github.com/csmarshall/gluetun-monitor/blob/main/docs/VERSIONING.md)
+for the full policy and [CHANGELOG](https://github.com/csmarshall/gluetun-monitor/blob/main/CHANGELOG.md)
+for the complete list. Design rationale lives in [docs/](https://github.com/csmarshall/gluetun-monitor/tree/main/docs)
+(tenets + ADRs).
+
+**Closes #20.**

--- a/docs/release-notes-v2.0.0.md
+++ b/docs/release-notes-v2.0.0.md
@@ -26,14 +26,20 @@ directly and heals it.
   layer is rebuilt from the image. On by default; `AUTO_RECREATE=0` to disable.
 - **Reimplemented in Python** (docker-py) for testability — the connectivity test
   itself is unchanged (`wget --spider` inside gluetun's namespace, same pass/fail
-  rules). 349 tests at 99% line+branch coverage, including a differential suite
-  that checks behavior against the original bash.
+  rules). 380+ tests at 99% line+branch coverage (enforced in CI), including a
+  differential suite that checks behavior against the original bash.
 - **Per-site stats + flaky-site advisory.** A best-effort JSON sidecar
   (`/logs/site-stats.json`) records each site's failure rate, episodes, restart
   effectiveness, response-latency percentiles (p50/p90/p99) and failure-reason
   breakdown, plus monitor-wide totals. When one site dominates recent gluetun
   restarts the monitor warns ("X of the last Y restarts were this site") and
-  escalates to a human rather than auto-suppressing it.
+  escalates to a human rather than auto-suppressing it. Both a **recent** window
+  and a bounded all-time **histogram** (≤5% error) are kept per site.
+- **`gluetun-monitor-stats` command** shipped in the image — `docker exec
+  gluetun-monitor gluetun-monitor-stats` renders the sidecar as a sortable per-site
+  matrix (latency percentiles, failure rate, restart-effectiveness) plus
+  monitor-wide totals; `--lifetime` for the all-time view, `--json` for
+  jq/dashboards. Read-only, no Docker API.
 - **Configuration is validated; bad config fails loud.** Empty `sites.conf`, a
   malformed or out-of-range env value (e.g. `TIMEOUT=0`), or an explicit
   `DEPENDENT_CONTAINERS` naming a missing container now refuse to start with a

--- a/docs/release-notes-v2.0.0.md
+++ b/docs/release-notes-v2.0.0.md
@@ -66,12 +66,13 @@ Three behavior changes to know about:
    only).
 2. **Bad config is now fatal** (see above) — if it refuses to start after the
    upgrade, the log says exactly what to fix.
-3. v2 **runs as a non-root user** (uid 10001). v1 ran as root, so an existing
-   `./logs` dir is likely root-owned — make it writable by the new user
-   (`sudo chown 10001:10001 ./logs`) to keep the file log + stats sidecar. If you
-   skip this the monitor still runs and logs to `docker logs`; it just can't
-   persist them. Using the direct socket mount instead of the proxy? Add your host
-   `docker` group via `group_add` (see the compose example).
+3. v2 **runs as a non-root user** (default uid/gid 1000 — the typical first host
+   user). v1 ran as root, so existing `./logs` files are likely root-owned — run
+   `sudo chown -R 1000:1000 ./logs` (or override `user:` to match your uid) to keep
+   the file log + stats sidecar. If you skip this the monitor still runs and logs
+   to `docker logs`; it just can't persist them. Using the direct socket mount
+   instead of the proxy? Add your host `docker` group via `group_add` (see the
+   compose example).
 
 **Rollback** is one step: repin `:1`.
 

--- a/docs/release-notes-v2.0.0.md
+++ b/docs/release-notes-v2.0.0.md
@@ -2,9 +2,8 @@
 
 **v2 is a ground-up reimplementation that makes the monitor *dependent-aware*: it
 now detects and heals the containers behind gluetun, not just gluetun itself.**
-It is a near drop-in upgrade from v1 — same env vars, same files, same
-socket-proxy permissions (one note: it now runs as a non-root user, so make
-`./logs` writable by it — see Upgrading) — and **v1 is now end-of-life**.
+It is a drop-in upgrade from v1 — same env vars, same files, same socket-proxy
+permissions; just change the image tag — and **v1 is now end-of-life**.
 
 ## Why v2
 
@@ -66,19 +65,21 @@ same socket-proxy permissions (`CONTAINERS` / `POST` / `EXEC`).
 +    image: ghcr.io/csmarshall/gluetun-monitor:2
 ```
 
-Three behavior changes to know about:
+Two behavior changes to know about:
 1. v2 **heals dependents by default**. To stay close to v1, set `AUTO_RECREATE=0`
-   (alert instead of recreate) and/or `DEPENDENT_VIABILITY=0` (interface check
-   only).
+   (log a loud alert line instead of recreating) and/or `DEPENDENT_VIABILITY=0`
+   (interface check only). ("alert"/"advisory" = a log line; no external
+   notification yet — that's on the roadmap.)
 2. **Bad config is now fatal** (see above) — if it refuses to start after the
    upgrade, the log says exactly what to fix.
-3. v2 **runs as a non-root user** (default uid/gid 1000 — the typical first host
-   user). v1 ran as root, so existing `./logs` files are likely root-owned — run
-   `sudo chown -R 1000:1000 ./logs` (or override `user:` to match your uid) to keep
-   the file log + stats sidecar. If you skip this the monitor still runs and logs
-   to `docker logs`; it just can't persist them. Using the direct socket mount
-   instead of the proxy? Add your host `docker` group via `group_add` (see the
-   compose example).
+
+Optional, recommended security hygiene: v2 can **run as a non-root user**, using
+the same `PUID`/`PGID` knob as the LinuxServer.io `*arr` images. Set
+`PUID`/`PGID` and the entrypoint chowns `/logs` and drops privileges for you — no
+manual chown. Leave them unset and it runs as **root, exactly like v1** (which is
+why the upgrade is drop-in — non-root is opt-in). (Direct socket mount rather than
+the proxy, and want non-root? See the README note — use Docker's `user:` +
+`group_add` there, since the privilege drop resets supplementary groups.)
 
 **Rollback** is one step: repin `:1`.
 

--- a/docs/release-notes-v2.0.0.md
+++ b/docs/release-notes-v2.0.0.md
@@ -2,8 +2,9 @@
 
 **v2 is a ground-up reimplementation that makes the monitor *dependent-aware*: it
 now detects and heals the containers behind gluetun, not just gluetun itself.**
-It is a drop-in upgrade from v1 — same env vars, same files, same socket-proxy
-permissions — and **v1 is now end-of-life**.
+It is a near drop-in upgrade from v1 — same env vars, same files, same
+socket-proxy permissions (one note: it now runs as a non-root user, so make
+`./logs` writable by it — see Upgrading) — and **v1 is now end-of-life**.
 
 ## Why v2
 
@@ -25,15 +26,28 @@ directly and heals it.
   layer is rebuilt from the image. On by default; `AUTO_RECREATE=0` to disable.
 - **Reimplemented in Python** (docker-py) for testability — the connectivity test
   itself is unchanged (`wget --spider` inside gluetun's namespace, same pass/fail
-  rules). 220+ tests, including a differential suite that checks behavior against
-  the original bash.
+  rules). 349 tests at 99% line+branch coverage, including a differential suite
+  that checks behavior against the original bash.
+- **Per-site stats + flaky-site advisory.** A best-effort JSON sidecar
+  (`/logs/site-stats.json`) records each site's failure rate, episodes, restart
+  effectiveness, response-latency percentiles (p50/p90/p99) and failure-reason
+  breakdown, plus monitor-wide totals. When one site dominates recent gluetun
+  restarts the monitor warns ("X of the last Y restarts were this site") and
+  escalates to a human rather than auto-suppressing it.
 - **Configuration is validated; bad config fails loud.** Empty `sites.conf`, a
-  malformed env value, or an explicit `DEPENDENT_CONTAINERS` naming a missing
-  container now refuse to start with a clear message instead of running degraded.
+  malformed or out-of-range env value (e.g. `TIMEOUT=0`), or an explicit
+  `DEPENDENT_CONTAINERS` naming a missing container now refuse to start with a
+  clear message instead of running degraded.
+- **Hardened for release.** Runs as a non-root user; site entries can't be turned
+  into `wget`/`ping` options; the site shuffle is thread-safe; a corrupt stats file
+  can never crash startup. One standardized `TIMEOUT`/`WGET_TRIES` now reaches
+  every probe, including the `wget` inside the dependents.
 - **New controls:** `EXCLUDE_CONTAINERS` (never-manage denylist), `SITES`
   (test URLs via env, unioned with `sites.conf`), `DEPENDENT_VIABILITY`,
-  `DEPENDENT_CONTAINER_FAILURES`, `MAX_PARALLEL_CHECKS`, `MAX_JITTER_MS`,
-  `DNS_WAIT_TIMEOUT`, `LOG_LEVEL`.
+  `DEPENDENT_VIABILITY_SAMPLES`, `DEPENDENT_CONTAINER_FAILURES`,
+  `MAX_PARALLEL_CHECKS`, `MAX_JITTER_MS`, `DRY_RUN`, `WGET_TRIES`,
+  `DNS_WAIT_TIMEOUT`, log rotation (`LOG_MAX_BYTES`/`LOG_BACKUP_COUNT`), the
+  flaky-site advisory knobs, and `LOG_LEVEL`.
 
 ## Upgrading from v1 (drop-in)
 
@@ -46,12 +60,18 @@ same socket-proxy permissions (`CONTAINERS` / `POST` / `EXEC`).
 +    image: ghcr.io/csmarshall/gluetun-monitor:2
 ```
 
-Two behavior changes to know about:
+Three behavior changes to know about:
 1. v2 **heals dependents by default**. To stay close to v1, set `AUTO_RECREATE=0`
    (alert instead of recreate) and/or `DEPENDENT_VIABILITY=0` (interface check
    only).
 2. **Bad config is now fatal** (see above) — if it refuses to start after the
    upgrade, the log says exactly what to fix.
+3. v2 **runs as a non-root user** (uid 10001). v1 ran as root, so an existing
+   `./logs` dir is likely root-owned — make it writable by the new user
+   (`sudo chown 10001:10001 ./logs`) to keep the file log + stats sidecar. If you
+   skip this the monitor still runs and logs to `docker logs`; it just can't
+   persist them. Using the direct socket mount instead of the proxy? Add your host
+   `docker` group via `group_add` (see the compose example).
 
 **Rollback** is one step: repin `:1`.
 

--- a/gluetun_monitor/__init__.py
+++ b/gluetun_monitor/__init__.py
@@ -1,0 +1,9 @@
+"""Dependent-aware connectivity monitor and self-healer for gluetun VPN stacks.
+
+See ``docs/adr/`` for the architecture: ADR-0001 (test from inside the netns),
+ADR-0004 (dependent-aware health + restart-vs-recreate), ADR-0005 (the recreate
+mechanism), ADR-0006 (per-dependent viability testing), ADR-0007 (this Python
+rewrite).
+"""
+
+__version__ = "2.0.0"

--- a/gluetun_monitor/__main__.py
+++ b/gluetun_monitor/__main__.py
@@ -1,0 +1,8 @@
+"""``python -m gluetun_monitor`` entry point."""
+
+from __future__ import annotations
+
+from .cli import main
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/gluetun_monitor/cli.py
+++ b/gluetun_monitor/cli.py
@@ -18,7 +18,7 @@ def check_prerequisites(client: DockerClient, config: Config, logger: Logger) ->
     """Validate everything required to start. Any failure is fatal (return False).
 
     We refuse to start on bad config rather than guess, because guessing can lead
-    to acting on the wrong containers (Tenet 2/6). Specifically: there must be at
+    to acting on the wrong containers (Tenet 3/7). Specifically: there must be at
     least one testable site (from sites.conf and/or the SITES env — an empty set
     is a fake-green trap), the Docker API must be reachable, gluetun must exist,
     and an explicit DEPENDENT_CONTAINERS list must name only containers that exist

--- a/gluetun_monitor/cli.py
+++ b/gluetun_monitor/cli.py
@@ -26,7 +26,14 @@ def check_prerequisites(client: DockerClient, config: Config, logger: Logger) ->
     (overlap with the include list, or names that match nothing) WARN but are not
     fatal: excluding is the "do no harm" direction.
     """
-    if not load_sites(config.config_file, config.sites_env):
+    try:
+        sites = load_sites(config.config_file, config.sites_env)
+    except OSError as exc:
+        # e.g. CONFIG_FILE is a directory (a missing bind-mount source that Docker
+        # silently created) or unreadable — fail loud and cleanly, not a traceback.
+        logger.error(f"Cannot read sites config {config.config_file}: {exc}")
+        return False
+    if not sites:
         logger.error(
             "No testable sites configured: provide URLs via the sites file "
             f"({config.config_file}) and/or the SITES env var — refusing to run a "

--- a/gluetun_monitor/cli.py
+++ b/gluetun_monitor/cli.py
@@ -125,7 +125,12 @@ def main() -> int:
     Returns a process exit code: 0 on clean shutdown, 1 if startup fails.
     """
     config = Config.from_env()
-    logger = Logger(log_file=config.log_file, level=config.log_level)
+    logger = Logger(
+        log_file=config.log_file,
+        level=config.log_level,
+        max_bytes=config.log_max_bytes,
+        backup_count=config.log_backup_count,
+    )
     install_bash_format_on_root()  # make stray docker-py/urllib3 logs match our format
     _install_signal_handlers(logger)
     _announce_banner(config, logger)

--- a/gluetun_monitor/cli.py
+++ b/gluetun_monitor/cli.py
@@ -1,0 +1,75 @@
+"""Entry point: build config + logger + client, check prerequisites, run the loop."""
+
+from __future__ import annotations
+
+import signal
+import sys
+from pathlib import Path
+from types import FrameType
+
+from .config import Config
+from .docker_client import DockerClient, DockerPyClient
+from .logging_setup import Logger
+from .monitor import Monitor
+
+
+def check_prerequisites(client: DockerClient, config: Config, logger: Logger) -> bool:
+    """Verify Docker is reachable and the gluetun container exists (v1.x parity)."""
+    if not Path(config.config_file).is_file():
+        logger.error(f"Config file not found: {config.config_file}")
+        return False
+    if not client.ping():
+        logger.error("Cannot connect to Docker daemon")
+        return False
+    if client.inspect(config.gluetun_container) is None:
+        logger.error(f"Gluetun container '{config.gluetun_container}' not found")
+        return False
+    logger.info("Prerequisites check passed")
+    return True
+
+
+def _install_signal_handlers(logger: Logger) -> None:
+    def handler(signum: int, _frame: FrameType | None) -> None:
+        logger.info(f"Received signal {signal.Signals(signum).name}, exiting...")
+        sys.exit(0)
+
+    signal.signal(signal.SIGTERM, handler)
+    signal.signal(signal.SIGINT, handler)
+
+
+def _announce_banner(config: Config, logger: Logger) -> None:
+    """The startup banner, logged before prerequisites (v1.x order) so it is
+    visible even when the prereq check then fails."""
+    logger.info("Gluetun Monitor starting...")
+    logger.info(
+        f"Config: CHECK_INTERVAL={config.check_interval}s, TIMEOUT={config.timeout}s, "
+        f"FAIL_THRESHOLD={config.fail_threshold}, "
+        f"DEPENDENT_CONTAINER_FAILURES={config.dependent_container_failures}, "
+        f"AUTO_RECREATE={int(config.auto_recreate)}"
+    )
+    logger.info(f"Monitoring container: {config.gluetun_container}")
+
+
+def main() -> int:
+    config = Config.from_env()
+    logger = Logger(log_file=config.log_file, level=config.log_level)
+    _install_signal_handlers(logger)
+    _announce_banner(config, logger)
+
+    try:
+        client: DockerClient = DockerPyClient(timeout=max(config.timeout * 2, 60))
+    except Exception as exc:
+        logger.error(f"Failed to initialize Docker client: {exc}")
+        return 1
+
+    if not check_prerequisites(client, config, logger):
+        return 1
+
+    monitor = Monitor(client, config, logger)
+    monitor.announce()
+    monitor.run()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/gluetun_monitor/cli.py
+++ b/gluetun_monitor/cli.py
@@ -106,7 +106,8 @@ def _install_signal_handlers(logger: Logger) -> None:
 
 def _announce_banner(config: Config, logger: Logger) -> None:
     """The startup banner, logged before prerequisites (v1.x order) so it is
-    visible even when the prereq check then fails."""
+    visible even when the prereq check then fails.
+    """
     logger.info("Gluetun Monitor starting...")
     logger.info(
         f"Config: CHECK_INTERVAL={config.check_interval}s, TIMEOUT={config.timeout}s, "

--- a/gluetun_monitor/cli.py
+++ b/gluetun_monitor/cli.py
@@ -7,6 +7,7 @@ import sys
 from types import FrameType
 
 from .config import Config
+from .dependents import parse_csv_names
 from .docker_client import DockerClient, DockerPyClient
 from .logging_setup import Logger
 from .monitor import Monitor
@@ -20,7 +21,10 @@ def check_prerequisites(client: DockerClient, config: Config, logger: Logger) ->
     to acting on the wrong containers (Tenet 2/6). Specifically: there must be at
     least one testable site (from sites.conf and/or the SITES env — an empty set
     is a fake-green trap), the Docker API must be reachable, gluetun must exist,
-    and an explicit DEPENDENT_CONTAINERS list must name only containers that exist.
+    and an explicit DEPENDENT_CONTAINERS list must name only containers that exist
+    (excluding any in EXCLUDE_CONTAINERS — those need not exist). EXCLUDE issues
+    (overlap with the include list, or names that match nothing) WARN but are not
+    fatal: excluding is the "do no harm" direction.
     """
     if not load_sites(config.config_file, config.sites_env):
         logger.error(
@@ -35,21 +39,48 @@ def check_prerequisites(client: DockerClient, config: Config, logger: Logger) ->
     if client.inspect(config.gluetun_container) is None:
         logger.error(f"Gluetun container '{config.gluetun_container}' not found")
         return False
+
+    excluded = parse_csv_names(config.exclude_containers)
     if config.dependent_containers != "auto":
-        names = [n for n in (s.strip() for s in config.dependent_containers.split(",")) if n]
+        names = parse_csv_names(config.dependent_containers)
         if not names:
             logger.error(
                 "DEPENDENT_CONTAINERS is set but lists no valid container names; "
                 "use 'auto' for discovery or name existing containers"
             )
             return False
-        missing = [n for n in names if client.inspect(n) is None]
-        if missing:
-            logger.error(
-                f"DEPENDENT_CONTAINERS names container(s) not found: {', '.join(missing)} "
-                f"— refusing to start (will not guess which containers to manage)"
+        overlap = sorted(set(names) & set(excluded))
+        if overlap:
+            logger.warn(
+                f"Container(s) in both DEPENDENT_CONTAINERS and EXCLUDE_CONTAINERS: "
+                f"{', '.join(overlap)} — excluding them (first, do no harm)"
             )
-            return False
+        # Excluded names need not exist (the point is to not manage them); only the
+        # effectively-included names are required to be present.
+        effective = [n for n in names if n not in excluded]
+        if not effective:
+            logger.warn(
+                "Every name in DEPENDENT_CONTAINERS is also excluded; "
+                "no dependents will be managed (gluetun-only)"
+            )
+        else:
+            missing = [n for n in effective if client.inspect(n) is None]
+            if missing:
+                logger.error(
+                    f"DEPENDENT_CONTAINERS names container(s) not found: {', '.join(missing)} "
+                    f"— refusing to start (will not guess which containers to manage)"
+                )
+                return False
+
+    # An exclude name matching nothing is usually a typo — and a dangerous one,
+    # since the container you meant to protect would still be managed. Warn (not
+    # fatal: it may legitimately not exist yet).
+    unmatched = [n for n in excluded if client.inspect(n) is None]
+    if unmatched:
+        logger.warn(
+            f"EXCLUDE_CONTAINERS names container(s) not found: {', '.join(unmatched)} "
+            f"(typo? they currently exclude nothing)"
+        )
     logger.info("Prerequisites check passed")
     return True
 

--- a/gluetun_monitor/cli.py
+++ b/gluetun_monitor/cli.py
@@ -113,6 +113,10 @@ def _announce_banner(config: Config, logger: Logger) -> None:
         f"AUTO_RECREATE={int(config.auto_recreate)}"
     )
     logger.info(f"Monitoring container: {config.gluetun_container}")
+    if config.dry_run:
+        logger.warn(
+            "DRY_RUN enabled: observe-only — logs intended actions, never restarts/recreates"
+        )
 
 
 def main() -> int:

--- a/gluetun_monitor/cli.py
+++ b/gluetun_monitor/cli.py
@@ -9,7 +9,7 @@ from types import FrameType
 from .config import Config
 from .dependents import parse_csv_names
 from .docker_client import DockerClient, DockerPyClient
-from .logging_setup import Logger
+from .logging_setup import Logger, install_bash_format_on_root
 from .monitor import Monitor
 from .sites import load_sites
 
@@ -126,6 +126,7 @@ def main() -> int:
     """
     config = Config.from_env()
     logger = Logger(log_file=config.log_file, level=config.log_level)
+    install_bash_format_on_root()  # make stray docker-py/urllib3 logs match our format
     _install_signal_handlers(logger)
     _announce_banner(config, logger)
 

--- a/gluetun_monitor/cli.py
+++ b/gluetun_monitor/cli.py
@@ -11,7 +11,7 @@ from .dependents import parse_csv_names
 from .docker_client import DockerClient, DockerPyClient
 from .logging_setup import Logger, install_bash_format_on_root
 from .monitor import Monitor
-from .sites import load_sites
+from .sites import load_sites_report
 
 
 def check_prerequisites(client: DockerClient, config: Config, logger: Logger) -> bool:
@@ -27,12 +27,14 @@ def check_prerequisites(client: DockerClient, config: Config, logger: Logger) ->
     fatal: excluding is the "do no harm" direction.
     """
     try:
-        sites = load_sites(config.config_file, config.sites_env)
+        sites, rejected = load_sites_report(config.config_file, config.sites_env)
     except OSError as exc:
         # e.g. CONFIG_FILE is a directory (a missing bind-mount source that Docker
         # silently created) or unreadable — fail loud and cleanly, not a traceback.
         logger.error(f"Cannot read sites config {config.config_file}: {exc}")
         return False
+    for entry, reason in rejected:
+        logger.warn(f"Ignoring unsafe site entry {entry!r}: {reason}")
     if not sites:
         logger.error(
             "No testable sites configured: provide URLs via the sites file "

--- a/gluetun_monitor/cli.py
+++ b/gluetun_monitor/cli.py
@@ -4,19 +4,30 @@ from __future__ import annotations
 
 import signal
 import sys
-from pathlib import Path
 from types import FrameType
 
 from .config import Config
 from .docker_client import DockerClient, DockerPyClient
 from .logging_setup import Logger
 from .monitor import Monitor
+from .sites import load_sites
 
 
 def check_prerequisites(client: DockerClient, config: Config, logger: Logger) -> bool:
-    """Verify Docker is reachable and the gluetun container exists (v1.x parity)."""
-    if not Path(config.config_file).is_file():
-        logger.error(f"Config file not found: {config.config_file}")
+    """Validate everything required to start. Any failure is fatal (return False).
+
+    We refuse to start on bad config rather than guess, because guessing can lead
+    to acting on the wrong containers (Tenet 2/6). Specifically: there must be at
+    least one testable site (from sites.conf and/or the SITES env — an empty set
+    is a fake-green trap), the Docker API must be reachable, gluetun must exist,
+    and an explicit DEPENDENT_CONTAINERS list must name only containers that exist.
+    """
+    if not load_sites(config.config_file, config.sites_env):
+        logger.error(
+            "No testable sites configured: provide URLs via the sites file "
+            f"({config.config_file}) and/or the SITES env var — refusing to run a "
+            f"monitor that tests nothing"
+        )
         return False
     if not client.ping():
         logger.error("Cannot connect to Docker daemon")
@@ -24,12 +35,28 @@ def check_prerequisites(client: DockerClient, config: Config, logger: Logger) ->
     if client.inspect(config.gluetun_container) is None:
         logger.error(f"Gluetun container '{config.gluetun_container}' not found")
         return False
+    if config.dependent_containers != "auto":
+        names = [n for n in (s.strip() for s in config.dependent_containers.split(",")) if n]
+        if not names:
+            logger.error(
+                "DEPENDENT_CONTAINERS is set but lists no valid container names; "
+                "use 'auto' for discovery or name existing containers"
+            )
+            return False
+        missing = [n for n in names if client.inspect(n) is None]
+        if missing:
+            logger.error(
+                f"DEPENDENT_CONTAINERS names container(s) not found: {', '.join(missing)} "
+                f"— refusing to start (will not guess which containers to manage)"
+            )
+            return False
     logger.info("Prerequisites check passed")
     return True
 
 
 def _install_signal_handlers(logger: Logger) -> None:
     def handler(signum: int, _frame: FrameType | None) -> None:
+        """Log the signal and exit cleanly (0) so the container stops gracefully."""
         logger.info(f"Received signal {signal.Signals(signum).name}, exiting...")
         sys.exit(0)
 
@@ -51,10 +78,20 @@ def _announce_banner(config: Config, logger: Logger) -> None:
 
 
 def main() -> int:
+    """Build config + logger + Docker client, check prerequisites, run the loop.
+
+    Returns a process exit code: 0 on clean shutdown, 1 if startup fails.
+    """
     config = Config.from_env()
     logger = Logger(log_file=config.log_file, level=config.log_level)
     _install_signal_handlers(logger)
     _announce_banner(config, logger)
+
+    if config.errors:  # malformed env values — fatal; don't run with unparseable params
+        for err in config.errors:
+            logger.error(err)
+        logger.error("Refusing to start due to invalid configuration")
+        return 1
 
     try:
         client: DockerClient = DockerPyClient(timeout=max(config.timeout * 2, 60))

--- a/gluetun_monitor/config.py
+++ b/gluetun_monitor/config.py
@@ -82,6 +82,10 @@ class Config:
     # parity with the other knobs). None = not set. Unlike the file, this is fixed
     # at process start (no live reload).
     sites_env: str | None = None
+    # Comma-separated container names to NEVER manage (denylist). Filters auto
+    # discovery and subtracts from an explicit list; exclude wins on overlap
+    # ("first, do no harm"). Empty = exclude nothing.
+    exclude_containers: str = ""
 
     # Fatal config errors (malformed env values), collected during from_env and
     # surfaced by the CLI once the logger exists — the CLI then refuses to start.
@@ -123,5 +127,6 @@ class Config:
             dns_wait_timeout=_env_int("DNS_WAIT_TIMEOUT", 30, errors),
             log_level=log_level,
             sites_env=os.environ.get("SITES") or None,
+            exclude_containers=os.environ.get("EXCLUDE_CONTAINERS", ""),
             errors=tuple(errors),
         )

--- a/gluetun_monitor/config.py
+++ b/gluetun_monitor/config.py
@@ -90,6 +90,10 @@ class Config:
     # Seconds to wait for gluetun DNS to stabilize after a restart (ADR-0003).
     dns_wait_timeout: int = 30
     log_level: str = "INFO"
+    # Rotate the log file at this size, keeping this many backups (so the watchdog
+    # never fills its own disk). ~10 MB x 5 backups ≈ 60 MB cap. 0 = no rotation.
+    log_max_bytes: int = 10 * 1024 * 1024
+    log_backup_count: int = 5
     # Optional comma-separated test URLs, unioned with sites.conf (config-via-env
     # parity with the other knobs). None = not set. Unlike the file, this is fixed
     # at process start (no live reload).
@@ -161,6 +165,8 @@ class Config:
             auto_recreate=_env_bool("AUTO_RECREATE", True, errors),
             dns_wait_timeout=_env_int("DNS_WAIT_TIMEOUT", 30, errors),
             log_level=log_level,
+            log_max_bytes=_env_int("LOG_MAX_BYTES", 10 * 1024 * 1024, errors),
+            log_backup_count=_env_int("LOG_BACKUP_COUNT", 5, errors),
             sites_env=os.environ.get("SITES") or None,
             exclude_containers=os.environ.get("EXCLUDE_CONTAINERS", ""),
             dependent_viability=_env_bool("DEPENDENT_VIABILITY", True, errors),

--- a/gluetun_monitor/config.py
+++ b/gluetun_monitor/config.py
@@ -33,6 +33,18 @@ def _env_int(name: str, default: int, errors: list[str]) -> int:
         return default
 
 
+def _env_float(name: str, default: float, errors: list[str]) -> float:
+    """Read a float env var; a set-but-unparseable value is a fatal error."""
+    raw = os.environ.get(name)
+    if raw is None or raw.strip() == "":
+        return default
+    try:
+        return float(raw)
+    except ValueError:
+        errors.append(f"Invalid {name}={raw!r}: not a number")
+        return default
+
+
 def _env_bool(name: str, default: bool, errors: list[str]) -> bool:
     """Read a boolean env var (1/0, true/false, yes/no, on/off).
 
@@ -99,6 +111,14 @@ class Config:
     # v2 instance soak-test against a real stack alongside an active monitor
     # without two actors conflicting. Off by default.
     dry_run: bool = False
+    # Persistent per-site stats sidecar (ADR-0008). Observability only; best-effort.
+    stats_file: str = "/logs/site-stats.json"
+    stats_save_every: int = 10  # write the stats file every N loops (plus on restarts)
+    # Flaky-site advisory: warn when one site dominates the gluetun restarts in a
+    # recent window. window in seconds (default 24h).
+    advisory_window: int = 86400
+    advisory_min_restarts: int = 5
+    advisory_dominance: float = 0.5
 
     # Fatal config errors (malformed env values), collected during from_env and
     # surfaced by the CLI once the logger exists — the CLI then refuses to start.
@@ -144,5 +164,10 @@ class Config:
             dependent_viability=_env_bool("DEPENDENT_VIABILITY", True, errors),
             max_jitter_ms=_env_int("MAX_JITTER_MS", 0, errors),
             dry_run=_env_bool("DRY_RUN", False, errors),
+            stats_file=os.environ.get("STATS_FILE", "/logs/site-stats.json"),
+            stats_save_every=_env_int("STATS_SAVE_EVERY", 10, errors),
+            advisory_window=_env_int("ADVISORY_WINDOW", 86400, errors),
+            advisory_min_restarts=_env_int("ADVISORY_MIN_RESTARTS", 5, errors),
+            advisory_dominance=_env_float("ADVISORY_DOMINANCE", 0.5, errors),
             errors=tuple(errors),
         )

--- a/gluetun_monitor/config.py
+++ b/gluetun_monitor/config.py
@@ -113,7 +113,9 @@ class Config:
     dry_run: bool = False
     # Persistent per-site stats sidecar (ADR-0008). Observability only; best-effort.
     stats_file: str = "/logs/site-stats.json"
-    stats_save_every: int = 10  # write the stats file every N loops (plus on restarts)
+    # Drop a site's stats if it hasn't been polled (e.g. removed from sites.conf)
+    # for this many days; <=0 keeps them forever.
+    stats_retention_days: int = 90
     # Flaky-site advisory: warn when one site dominates the gluetun restarts in a
     # recent window. window in seconds (default 24h).
     advisory_window: int = 86400
@@ -165,7 +167,7 @@ class Config:
             max_jitter_ms=_env_int("MAX_JITTER_MS", 0, errors),
             dry_run=_env_bool("DRY_RUN", False, errors),
             stats_file=os.environ.get("STATS_FILE", "/logs/site-stats.json"),
-            stats_save_every=_env_int("STATS_SAVE_EVERY", 10, errors),
+            stats_retention_days=_env_int("STATS_RETENTION_DAYS", 90, errors),
             advisory_window=_env_int("ADVISORY_WINDOW", 86400, errors),
             advisory_min_restarts=_env_int("ADVISORY_MIN_RESTARTS", 5, errors),
             advisory_dominance=_env_float("ADVISORY_DOMINANCE", 0.5, errors),

--- a/gluetun_monitor/config.py
+++ b/gluetun_monitor/config.py
@@ -1,0 +1,84 @@
+"""Runtime configuration, loaded from environment variables.
+
+The env-var contract (names + defaults) is part of the v1.x compatibility surface
+pinned by the characterization suite. New v2.0.0 knobs (dependent viability,
+recreate) are additive and default to safe, on-by-default behavior per Tenet 7.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+
+
+def _env_int(name: str, default: int) -> int:
+    """Read an int env var, falling back to ``default`` if unset or unparseable."""
+    raw = os.environ.get(name)
+    if raw is None or raw.strip() == "":
+        return default
+    try:
+        return int(raw)
+    except ValueError:
+        return default
+
+
+def _env_bool(name: str, default: bool) -> bool:
+    """Read a boolean env var. Accepts 1/0, true/false, yes/no, on/off."""
+    raw = os.environ.get(name)
+    if raw is None or raw.strip() == "":
+        return default
+    return raw.strip().lower() in {"1", "true", "yes", "on"}
+
+
+@dataclass(frozen=True, slots=True)
+class Config:
+    """Immutable runtime configuration."""
+
+    # --- v1.x contract (defaults must not drift) ---
+    config_file: str = "/config/sites.conf"
+    log_file: str = "/logs/gluetun-monitor.log"
+    check_interval: int = 30
+    timeout: int = 10
+    fail_threshold: int = 2
+    gluetun_container: str = "gluetun"
+    healthy_wait_timeout: int = 120
+    dependent_containers: str = "auto"
+    docker_host: str | None = None
+
+    # --- v2.0.0 additions (dependent-aware; ADR-0004/0005/0006) ---
+    # Consecutive per-dependent viability failures before remediation. Mirrors
+    # FAIL_THRESHOLD so the stack has one mental model (ADR-0006, step 5).
+    dependent_container_failures: int = 2
+    # Bound the per-loop docker exec fan-out across live dependents (ADR-0006 Load).
+    max_parallel_checks: int = 6
+    # Recreate a dependent whose netns target moved to a new gluetun id
+    # (ADR-0004/0005). On by default (Tenet 7); set 0 to disable -> FAILED state.
+    auto_recreate: bool = True
+    # Seconds to wait for gluetun DNS to stabilize after a restart (ADR-0003).
+    dns_wait_timeout: int = 30
+    log_level: str = "INFO"
+
+    @classmethod
+    def from_env(cls) -> Config:
+        """Build a Config from the process environment, applying v1.x defaults."""
+        fail_threshold = _env_int("FAIL_THRESHOLD", 2)
+        docker_host = os.environ.get("DOCKER_HOST") or None
+        return cls(
+            config_file=os.environ.get("CONFIG_FILE", "/config/sites.conf"),
+            log_file=os.environ.get("LOG_FILE", "/logs/gluetun-monitor.log"),
+            check_interval=_env_int("CHECK_INTERVAL", 30),
+            timeout=_env_int("TIMEOUT", 10),
+            fail_threshold=fail_threshold,
+            gluetun_container=os.environ.get("GLUETUN_CONTAINER", "gluetun"),
+            healthy_wait_timeout=_env_int("HEALTHY_WAIT_TIMEOUT", 120),
+            dependent_containers=os.environ.get("DEPENDENT_CONTAINERS", "auto"),
+            docker_host=docker_host,
+            # DEPENDENT_CONTAINER_FAILURES defaults to FAIL_THRESHOLD (ADR-0006).
+            dependent_container_failures=_env_int(
+                "DEPENDENT_CONTAINER_FAILURES", fail_threshold
+            ),
+            max_parallel_checks=_env_int("MAX_PARALLEL_CHECKS", 6),
+            auto_recreate=_env_bool("AUTO_RECREATE", True),
+            dns_wait_timeout=_env_int("DNS_WAIT_TIMEOUT", 30),
+            log_level=os.environ.get("LOG_LEVEL", "INFO").upper(),
+        )

--- a/gluetun_monitor/config.py
+++ b/gluetun_monitor/config.py
@@ -2,7 +2,7 @@
 
 The env-var contract (names + defaults) is part of the v1.x compatibility surface
 pinned by the characterization suite. New v2.0.0 knobs (dependent viability,
-recreate) are additive and default to safe, on-by-default behavior per Tenet 7.
+recreate) are additive and default to safe, on-by-default behavior per Tenet 8.
 """
 
 from __future__ import annotations
@@ -73,7 +73,7 @@ class Config:
     # Bound the per-loop docker exec fan-out across live dependents (ADR-0006 Load).
     max_parallel_checks: int = 6
     # Recreate a dependent whose netns target moved to a new gluetun id
-    # (ADR-0004/0005). On by default (Tenet 7); set 0 to disable -> FAILED state.
+    # (ADR-0004/0005). On by default (Tenet 8); set 0 to disable -> FAILED state.
     auto_recreate: bool = True
     # Seconds to wait for gluetun DNS to stabilize after a restart (ADR-0003).
     dns_wait_timeout: int = 30

--- a/gluetun_monitor/config.py
+++ b/gluetun_monitor/config.py
@@ -106,6 +106,11 @@ class Config:
     # container) — ADR-0006. On by default; 0 = interface/strand check only (no
     # URL fetch). The interface check is never optional.
     dependent_viability: bool = True
+    # How many sites each dependent samples per loop: 1 (default, one shuffled
+    # site — optimal, since dependents share gluetun's netns so only their DNS
+    # differs), N for N distinct shuffled sites, or -1 for all. >1 is largely
+    # redundant; the dial is for completeness (and costs N execs/dependent/loop).
+    dependent_viability_samples: int = 1
     # Optional per-dispatch jitter (ms) to de-sync the dependent exec burst.
     # Default 0 = off: the MAX_PARALLEL_CHECKS cap already bounds the burst, so
     # jitter is opt-in for anyone who wants to spread load further (ADR-0006).
@@ -170,6 +175,7 @@ class Config:
             sites_env=os.environ.get("SITES") or None,
             exclude_containers=os.environ.get("EXCLUDE_CONTAINERS", ""),
             dependent_viability=_env_bool("DEPENDENT_VIABILITY", True, errors),
+            dependent_viability_samples=_env_int("DEPENDENT_VIABILITY_SAMPLES", 1, errors),
             max_jitter_ms=_env_int("MAX_JITTER_MS", 0, errors),
             dry_run=_env_bool("DRY_RUN", False, errors),
             stats_file=os.environ.get("STATS_FILE", "/logs/site-stats.json"),

--- a/gluetun_monitor/config.py
+++ b/gluetun_monitor/config.py
@@ -15,34 +15,55 @@ _FALSE_VALUES = {"0", "false", "no", "off"}
 _VALID_LOG_LEVELS = {"DEBUG", "INFO", "WARN", "WARNING", "ERROR"}
 
 
-def _env_int(name: str, default: int, errors: list[str]) -> int:
+def _env_int(
+    name: str, default: int, errors: list[str],
+    *, minimum: int | None = None, maximum: int | None = None,
+) -> int:
     """Read an int env var, returning ``default`` when **unset**.
 
     An *unset* var is just the (sane) default. A var that is **set** to an
-    unparseable value is malformed config: record a fatal error so the CLI
-    refuses to start, rather than guessing a substitute and risking acting on the
-    larger system with bad parameters. The return value is irrelevant then.
+    unparseable value — *or* a parseable value outside ``[minimum, maximum]`` — is
+    malformed config: record a fatal error so the CLI refuses to start, rather
+    than guessing a substitute and risking acting on the larger system with bad
+    parameters (e.g. TIMEOUT=0 = infinite wget, WGET_TRIES=0 = infinite retries).
     """
     raw = os.environ.get(name)
     if raw is None or raw.strip() == "":
         return default
     try:
-        return int(raw)
+        value = int(raw)
     except ValueError:
         errors.append(f"Invalid {name}={raw!r}: not an integer")
         return default
+    if minimum is not None and value < minimum:
+        errors.append(f"Invalid {name}={value}: must be >= {minimum}")
+        return default
+    if maximum is not None and value > maximum:
+        errors.append(f"Invalid {name}={value}: must be <= {maximum}")
+        return default
+    return value
 
 
-def _env_float(name: str, default: float, errors: list[str]) -> float:
-    """Read a float env var; a set-but-unparseable value is a fatal error."""
+def _env_float(
+    name: str, default: float, errors: list[str],
+    *, minimum: float | None = None, maximum: float | None = None,
+) -> float:
+    """Read a float env var; a set-but-unparseable or out-of-range value is fatal."""
     raw = os.environ.get(name)
     if raw is None or raw.strip() == "":
         return default
     try:
-        return float(raw)
+        value = float(raw)
     except ValueError:
         errors.append(f"Invalid {name}={raw!r}: not a number")
         return default
+    if minimum is not None and value < minimum:
+        errors.append(f"Invalid {name}={value}: must be >= {minimum}")
+        return default
+    if maximum is not None and value > maximum:
+        errors.append(f"Invalid {name}={value}: must be <= {maximum}")
+        return default
+    return value
 
 
 def _env_bool(name: str, default: bool, errors: list[str]) -> bool:
@@ -71,7 +92,8 @@ class Config:
     config_file: str = "/config/sites.conf"
     log_file: str = "/logs/gluetun-monitor.log"
     check_interval: int = 30
-    timeout: int = 10
+    timeout: int = 10  # per-request network timeout (wget --timeout, ping -W) everywhere
+    wget_tries: int = 1  # attempts per wget probe (the shuffle+threshold handle noise)
     fail_threshold: int = 2
     gluetun_container: str = "gluetun"
     healthy_wait_timeout: int = 120
@@ -145,7 +167,9 @@ class Config:
         system must not run with parameters it couldn't parse.
         """
         errors: list[str] = []
-        fail_threshold = _env_int("FAIL_THRESHOLD", 2, errors)
+        # Bounds are validated (out-of-range -> fatal) so a parseable-but-nonsensical
+        # value can't create a downstream bug (TIMEOUT=0 -> infinite wget, etc.).
+        fail_threshold = _env_int("FAIL_THRESHOLD", 2, errors, minimum=1)
         docker_host = os.environ.get("DOCKER_HOST") or None
         log_level = os.environ.get("LOG_LEVEL", "INFO").upper()
         if log_level not in _VALID_LOG_LEVELS:
@@ -155,33 +179,39 @@ class Config:
         return cls(
             config_file=os.environ.get("CONFIG_FILE", "/config/sites.conf"),
             log_file=os.environ.get("LOG_FILE", "/logs/gluetun-monitor.log"),
-            check_interval=_env_int("CHECK_INTERVAL", 30, errors),
-            timeout=_env_int("TIMEOUT", 10, errors),
+            check_interval=_env_int("CHECK_INTERVAL", 30, errors, minimum=1),
+            timeout=_env_int("TIMEOUT", 10, errors, minimum=1),
+            wget_tries=_env_int("WGET_TRIES", 1, errors, minimum=1),
             fail_threshold=fail_threshold,
             gluetun_container=os.environ.get("GLUETUN_CONTAINER", "gluetun"),
-            healthy_wait_timeout=_env_int("HEALTHY_WAIT_TIMEOUT", 120, errors),
+            healthy_wait_timeout=_env_int("HEALTHY_WAIT_TIMEOUT", 120, errors, minimum=1),
             dependent_containers=os.environ.get("DEPENDENT_CONTAINERS", "auto"),
             docker_host=docker_host,
             # DEPENDENT_CONTAINER_FAILURES defaults to FAIL_THRESHOLD (ADR-0006).
             dependent_container_failures=_env_int(
-                "DEPENDENT_CONTAINER_FAILURES", fail_threshold, errors
+                "DEPENDENT_CONTAINER_FAILURES", fail_threshold, errors, minimum=1
             ),
-            max_parallel_checks=_env_int("MAX_PARALLEL_CHECKS", 6, errors),
+            max_parallel_checks=_env_int("MAX_PARALLEL_CHECKS", 6, errors, minimum=1),
             auto_recreate=_env_bool("AUTO_RECREATE", True, errors),
-            dns_wait_timeout=_env_int("DNS_WAIT_TIMEOUT", 30, errors),
+            dns_wait_timeout=_env_int("DNS_WAIT_TIMEOUT", 30, errors, minimum=0),
             log_level=log_level,
-            log_max_bytes=_env_int("LOG_MAX_BYTES", 10 * 1024 * 1024, errors),
-            log_backup_count=_env_int("LOG_BACKUP_COUNT", 5, errors),
+            log_max_bytes=_env_int("LOG_MAX_BYTES", 10 * 1024 * 1024, errors, minimum=0),
+            log_backup_count=_env_int("LOG_BACKUP_COUNT", 5, errors, minimum=0),
             sites_env=os.environ.get("SITES") or None,
             exclude_containers=os.environ.get("EXCLUDE_CONTAINERS", ""),
             dependent_viability=_env_bool("DEPENDENT_VIABILITY", True, errors),
-            dependent_viability_samples=_env_int("DEPENDENT_VIABILITY_SAMPLES", 1, errors),
-            max_jitter_ms=_env_int("MAX_JITTER_MS", 0, errors),
+            # -1 = all sites; otherwise >= 1 (0 would be meaningless).
+            dependent_viability_samples=_env_int(
+                "DEPENDENT_VIABILITY_SAMPLES", 1, errors, minimum=-1
+            ),
+            max_jitter_ms=_env_int("MAX_JITTER_MS", 0, errors, minimum=0),
             dry_run=_env_bool("DRY_RUN", False, errors),
             stats_file=os.environ.get("STATS_FILE", "/logs/site-stats.json"),
+            # No lower bound: <= 0 intentionally means "keep stats forever".
             stats_retention_days=_env_int("STATS_RETENTION_DAYS", 90, errors),
-            advisory_window=_env_int("ADVISORY_WINDOW", 86400, errors),
-            advisory_min_restarts=_env_int("ADVISORY_MIN_RESTARTS", 5, errors),
-            advisory_dominance=_env_float("ADVISORY_DOMINANCE", 0.5, errors),
+            advisory_window=_env_int("ADVISORY_WINDOW", 86400, errors, minimum=1),
+            advisory_min_restarts=_env_int("ADVISORY_MIN_RESTARTS", 5, errors, minimum=1),
+            advisory_dominance=_env_float("ADVISORY_DOMINANCE", 0.5, errors,
+                                          minimum=0.0, maximum=1.0),
             errors=tuple(errors),
         )

--- a/gluetun_monitor/config.py
+++ b/gluetun_monitor/config.py
@@ -86,6 +86,14 @@ class Config:
     # discovery and subtracts from an explicit list; exclude wins on overlap
     # ("first, do no harm"). Empty = exclude nothing.
     exclude_containers: str = ""
+    # Per-dependent L7 viability probe (DNS + connectivity from inside the
+    # container) — ADR-0006. On by default; 0 = interface/strand check only (no
+    # URL fetch). The interface check is never optional.
+    dependent_viability: bool = True
+    # Optional per-dispatch jitter (ms) to de-sync the dependent exec burst.
+    # Default 0 = off: the MAX_PARALLEL_CHECKS cap already bounds the burst, so
+    # jitter is opt-in for anyone who wants to spread load further (ADR-0006).
+    max_jitter_ms: int = 0
 
     # Fatal config errors (malformed env values), collected during from_env and
     # surfaced by the CLI once the logger exists — the CLI then refuses to start.
@@ -128,5 +136,7 @@ class Config:
             log_level=log_level,
             sites_env=os.environ.get("SITES") or None,
             exclude_containers=os.environ.get("EXCLUDE_CONTAINERS", ""),
+            dependent_viability=_env_bool("DEPENDENT_VIABILITY", True, errors),
+            max_jitter_ms=_env_int("MAX_JITTER_MS", 0, errors),
             errors=tuple(errors),
         )

--- a/gluetun_monitor/config.py
+++ b/gluetun_monitor/config.py
@@ -170,6 +170,13 @@ class Config:
         # Bounds are validated (out-of-range -> fatal) so a parseable-but-nonsensical
         # value can't create a downstream bug (TIMEOUT=0 -> infinite wget, etc.).
         fail_threshold = _env_int("FAIL_THRESHOLD", 2, errors, minimum=1)
+        # Samples is -1 (all) or >= 1; 0 is meaningless (probe nothing) and the
+        # monitor would silently coerce it to 1, so reject it rather than guess.
+        viability_samples = _env_int("DEPENDENT_VIABILITY_SAMPLES", 1, errors, minimum=-1)
+        if viability_samples == 0:
+            errors.append(
+                "Invalid DEPENDENT_VIABILITY_SAMPLES=0: use -1 (all sites) or a positive count"
+            )
         docker_host = os.environ.get("DOCKER_HOST") or None
         log_level = os.environ.get("LOG_LEVEL", "INFO").upper()
         if log_level not in _VALID_LOG_LEVELS:
@@ -200,10 +207,7 @@ class Config:
             sites_env=os.environ.get("SITES") or None,
             exclude_containers=os.environ.get("EXCLUDE_CONTAINERS", ""),
             dependent_viability=_env_bool("DEPENDENT_VIABILITY", True, errors),
-            # -1 = all sites; otherwise >= 1 (0 would be meaningless).
-            dependent_viability_samples=_env_int(
-                "DEPENDENT_VIABILITY_SAMPLES", 1, errors, minimum=-1
-            ),
+            dependent_viability_samples=viability_samples,
             max_jitter_ms=_env_int("MAX_JITTER_MS", 0, errors, minimum=0),
             dry_run=_env_bool("DRY_RUN", False, errors),
             stats_file=os.environ.get("STATS_FILE", "/logs/site-stats.json"),

--- a/gluetun_monitor/config.py
+++ b/gluetun_monitor/config.py
@@ -10,24 +10,45 @@ from __future__ import annotations
 import os
 from dataclasses import dataclass
 
+_TRUE_VALUES = {"1", "true", "yes", "on"}
+_FALSE_VALUES = {"0", "false", "no", "off"}
+_VALID_LOG_LEVELS = {"DEBUG", "INFO", "WARN", "WARNING", "ERROR"}
 
-def _env_int(name: str, default: int) -> int:
-    """Read an int env var, falling back to ``default`` if unset or unparseable."""
+
+def _env_int(name: str, default: int, errors: list[str]) -> int:
+    """Read an int env var, returning ``default`` when **unset**.
+
+    An *unset* var is just the (sane) default. A var that is **set** to an
+    unparseable value is malformed config: record a fatal error so the CLI
+    refuses to start, rather than guessing a substitute and risking acting on the
+    larger system with bad parameters. The return value is irrelevant then.
+    """
     raw = os.environ.get(name)
     if raw is None or raw.strip() == "":
         return default
     try:
         return int(raw)
     except ValueError:
+        errors.append(f"Invalid {name}={raw!r}: not an integer")
         return default
 
 
-def _env_bool(name: str, default: bool) -> bool:
-    """Read a boolean env var. Accepts 1/0, true/false, yes/no, on/off."""
+def _env_bool(name: str, default: bool, errors: list[str]) -> bool:
+    """Read a boolean env var (1/0, true/false, yes/no, on/off).
+
+    Unset → ``default``. Set to an unrecognized value → fatal error (never
+    silently coerced to False — see _env_int).
+    """
     raw = os.environ.get(name)
     if raw is None or raw.strip() == "":
         return default
-    return raw.strip().lower() in {"1", "true", "yes", "on"}
+    value = raw.strip().lower()
+    if value in _TRUE_VALUES:
+        return True
+    if value in _FALSE_VALUES:
+        return False
+    errors.append(f"Invalid {name}={raw!r}: not a boolean (use 1/0, true/false, yes/no, on/off)")
+    return default
 
 
 @dataclass(frozen=True, slots=True)
@@ -57,28 +78,50 @@ class Config:
     # Seconds to wait for gluetun DNS to stabilize after a restart (ADR-0003).
     dns_wait_timeout: int = 30
     log_level: str = "INFO"
+    # Optional comma-separated test URLs, unioned with sites.conf (config-via-env
+    # parity with the other knobs). None = not set. Unlike the file, this is fixed
+    # at process start (no live reload).
+    sites_env: str | None = None
+
+    # Fatal config errors (malformed env values), collected during from_env and
+    # surfaced by the CLI once the logger exists — the CLI then refuses to start.
+    # Not an env var.
+    errors: tuple[str, ...] = ()
 
     @classmethod
     def from_env(cls) -> Config:
-        """Build a Config from the process environment, applying v1.x defaults."""
-        fail_threshold = _env_int("FAIL_THRESHOLD", 2)
+        """Build a Config from the process environment, applying v1.x defaults.
+
+        Malformed values are collected in ``errors`` (the CLI treats any as
+        fatal) rather than guessed around — a watchdog acting on the larger
+        system must not run with parameters it couldn't parse.
+        """
+        errors: list[str] = []
+        fail_threshold = _env_int("FAIL_THRESHOLD", 2, errors)
         docker_host = os.environ.get("DOCKER_HOST") or None
+        log_level = os.environ.get("LOG_LEVEL", "INFO").upper()
+        if log_level not in _VALID_LOG_LEVELS:
+            errors.append(
+                f"Invalid LOG_LEVEL={log_level!r}: expected one of {sorted(_VALID_LOG_LEVELS)}"
+            )
         return cls(
             config_file=os.environ.get("CONFIG_FILE", "/config/sites.conf"),
             log_file=os.environ.get("LOG_FILE", "/logs/gluetun-monitor.log"),
-            check_interval=_env_int("CHECK_INTERVAL", 30),
-            timeout=_env_int("TIMEOUT", 10),
+            check_interval=_env_int("CHECK_INTERVAL", 30, errors),
+            timeout=_env_int("TIMEOUT", 10, errors),
             fail_threshold=fail_threshold,
             gluetun_container=os.environ.get("GLUETUN_CONTAINER", "gluetun"),
-            healthy_wait_timeout=_env_int("HEALTHY_WAIT_TIMEOUT", 120),
+            healthy_wait_timeout=_env_int("HEALTHY_WAIT_TIMEOUT", 120, errors),
             dependent_containers=os.environ.get("DEPENDENT_CONTAINERS", "auto"),
             docker_host=docker_host,
             # DEPENDENT_CONTAINER_FAILURES defaults to FAIL_THRESHOLD (ADR-0006).
             dependent_container_failures=_env_int(
-                "DEPENDENT_CONTAINER_FAILURES", fail_threshold
+                "DEPENDENT_CONTAINER_FAILURES", fail_threshold, errors
             ),
-            max_parallel_checks=_env_int("MAX_PARALLEL_CHECKS", 6),
-            auto_recreate=_env_bool("AUTO_RECREATE", True),
-            dns_wait_timeout=_env_int("DNS_WAIT_TIMEOUT", 30),
-            log_level=os.environ.get("LOG_LEVEL", "INFO").upper(),
+            max_parallel_checks=_env_int("MAX_PARALLEL_CHECKS", 6, errors),
+            auto_recreate=_env_bool("AUTO_RECREATE", True, errors),
+            dns_wait_timeout=_env_int("DNS_WAIT_TIMEOUT", 30, errors),
+            log_level=log_level,
+            sites_env=os.environ.get("SITES") or None,
+            errors=tuple(errors),
         )

--- a/gluetun_monitor/config.py
+++ b/gluetun_monitor/config.py
@@ -94,6 +94,11 @@ class Config:
     # Default 0 = off: the MAX_PARALLEL_CHECKS cap already bounds the burst, so
     # jitter is opt-in for anyone who wants to spread load further (ADR-0006).
     max_jitter_ms: int = 0
+    # Observe-only: run all detection/probing (read-only) but take NO mutating
+    # action — log "[DRY-RUN] would ..." instead of restarting/recreating. Lets a
+    # v2 instance soak-test against a real stack alongside an active monitor
+    # without two actors conflicting. Off by default.
+    dry_run: bool = False
 
     # Fatal config errors (malformed env values), collected during from_env and
     # surfaced by the CLI once the logger exists — the CLI then refuses to start.
@@ -138,5 +143,6 @@ class Config:
             exclude_containers=os.environ.get("EXCLUDE_CONTAINERS", ""),
             dependent_viability=_env_bool("DEPENDENT_VIABILITY", True, errors),
             max_jitter_ms=_env_int("MAX_JITTER_MS", 0, errors),
+            dry_run=_env_bool("DRY_RUN", False, errors),
             errors=tuple(errors),
         )

--- a/gluetun_monitor/connectivity.py
+++ b/gluetun_monitor/connectivity.py
@@ -1,9 +1,19 @@
 """Connectivity probing — ``wget --spider`` from inside a container's netns.
 
-This is the ADR-0001 authoritative test, preserved verbatim from v1.x: the same
-``wget --spider -S`` invocation, the same exit-code -> pass/fail map (0/6/8 mean
-the site responded => the VPN is up). Only the dispatch moved from a shell
-background job to ``DockerClient.exec_run``.
+This is the ADR-0001 authoritative test. The question it answers is "did traffic
+that's supposed to traverse the tunnel reach a server?" — so **any HTTP response
+(even 401/403/404/5xx) is a pass**: it proves DNS resolved, the connection went
+through the tunnel, and a server answered (Tenet 3 — a broken tunnel is not a sad
+website). Only a genuine failure to get *any* HTTP response (DNS failure,
+connection refused, TLS error, timeout) counts as a connectivity failure.
+
+Keying on "did we get an HTTP status?" rather than on wget's exit code is also
+what makes this correct across wget implementations: gluetun ships **GNU wget**
+(HTTP errors → exit 6/8), but dependent containers commonly run **busybox wget**
+(linuxserver/Alpine images), which returns **exit 1 for any HTTP error response**.
+The old exit-code-only map (0/6/8 = pass) silently misclassified a busybox
+dependent's harmless 404 as a failure. The exit code is now only a fallback for
+the case where no HTTP status was emitted at all.
 """
 
 from __future__ import annotations
@@ -14,9 +24,10 @@ from dataclasses import dataclass
 
 from .docker_client import DockerClient
 
-# wget exit codes where the site *responded* — the tunnel is therefore working:
-#   0 = success, 6 = auth required, 8 = HTTP 4xx/5xx. Everything else is a real
-# connectivity failure (4 = DNS/connect, 5 = SSL, ...).
+# wget exit codes where the site *responded* — used only as a fallback when no
+# HTTP status line was captured (GNU: 0 success, 6 auth, 8 HTTP 4xx/5xx). Note
+# busybox wget does NOT follow this scheme (it returns 1 for HTTP errors), which
+# is exactly why HTTP-response detection takes priority over the exit code.
 WGET_PASS_CODES = frozenset({0, 6, 8})
 
 _WGET_EXIT_MESSAGES: dict[int, str] = {
@@ -32,6 +43,23 @@ _WGET_EXIT_MESSAGES: dict[int, str] = {
 }
 
 _HTTP_CODE_RE = re.compile(r"HTTP/[0-9.]+\s+(\d+)")
+# Lines wget (GNU or busybox) emits describing an actual failure, newest-last.
+_ERROR_HINTS = ("wget:", "failed:", "unable to resolve", "bad address",
+                "connection refused", "timed out", "tls", "ssl", "name or service")
+# Substrings that specifically indicate a DNS *resolution* failure (GNU + busybox
+# + musl/glibc resolver wording). This is the one per-container fault a dependent
+# viability probe uniquely detects (ADR-0006): dependents share gluetun's netns,
+# so their L3/L4 egress is gluetun's (already proven) — only their own resolver
+# can differ.
+_DNS_FAIL_HINTS = ("bad address", "unable to resolve", "name or service not known",
+                   "temporary failure in name resolution", "could not resolve",
+                   "name does not resolve", "no address associated")
+
+
+def _is_dns_failure(output: str) -> bool:
+    """True if wget's output positively indicates a DNS resolution failure."""
+    low = output.lower()
+    return any(hint in low for hint in _DNS_FAIL_HINTS)
 
 
 def decode_wget_exit_code(code: int) -> str:
@@ -45,9 +73,27 @@ def _parse_http_code(output: str) -> str:
     return matches[-1] if matches else "N/A"
 
 
+def _extract_error(output: str, exit_code: int) -> str:
+    """The real failure reason: wget's own last diagnostic line if we can find it,
+    otherwise the decoded exit code. Avoids the useless bare 'Generic error'."""
+    for line in reversed([ln.strip() for ln in output.splitlines() if ln.strip()]):
+        low = line.lower()
+        if any(hint in low for hint in _ERROR_HINTS):
+            # Trim a leading "wget: " for readability.
+            return line[len("wget:"):].strip() if low.startswith("wget:") else line
+    return decode_wget_exit_code(exit_code)
+
+
 @dataclass(frozen=True, slots=True)
 class SiteResult:
-    """Outcome of testing one URL from inside a container."""
+    """Outcome of testing one URL from inside a container.
+
+    ``ok`` is the strict "did the site respond" signal used by gluetun's root test
+    (tunnel up?). ``dns_failed`` is the narrower "this container's resolver failed"
+    signal used by dependent viability (the only per-container fault — see module
+    docstring). They are distinct on purpose: a connect-refused/timeout makes
+    ``ok`` False but ``dns_failed`` False (the dependent's DNS still worked).
+    """
 
     url: str
     ok: bool
@@ -55,6 +101,7 @@ class SiteResult:
     http_code: str
     reason: str
     exit_code: int
+    dns_failed: bool = False
 
 
 def probe_site(
@@ -63,8 +110,13 @@ def probe_site(
     url: str,
     timeout: int,
 ) -> SiteResult:
-    """Probe ``url`` with ``wget --spider`` from inside ``container``'s netns."""
-    cmd = ["wget", "--spider", "-S", f"--timeout={timeout}", "--tries=1", "-q", url]
+    """Probe ``url`` with ``wget --spider`` from inside ``container``'s netns.
+
+    No ``-q``: we want wget's diagnostics in the output so a real failure reports
+    *why* (not a bare exit code). Classification is HTTP-response-first (see the
+    module docstring), so it's correct for both GNU and busybox wget.
+    """
+    cmd = ["wget", "--spider", "-S", f"--timeout={timeout}", "--tries=1", url]
     start = time.monotonic()
     try:
         result = client.exec_run(container, cmd)
@@ -76,12 +128,20 @@ def probe_site(
     duration_ms = int((time.monotonic() - start) * 1000)
     http_code = _parse_http_code(output)
 
-    if exit_code == 0:
-        return SiteResult(url, True, duration_ms, http_code, f"HTTP {http_code}", 0)
+    # Primary signal: any HTTP response proves resolve + connect + egress worked,
+    # whatever the status code or wget implementation's exit convention.
+    if http_code != "N/A":
+        suffix = "" if exit_code == 0 else " (responded)"
+        return SiteResult(url, True, duration_ms, http_code, f"HTTP {http_code}{suffix}", exit_code)
+    # No HTTP status seen. Fall back to the GNU exit-code map for the rare case
+    # wget signals "responded" without a parseable header...
     if exit_code in WGET_PASS_CODES:
-        # Site answered with an error (auth/4xx/5xx) — the tunnel is still up.
-        reason = f"HTTP {http_code} (VPN working)"
+        reason = f"responded (exit {exit_code})"
         return SiteResult(url, True, duration_ms, http_code, reason, exit_code)
+    # ...otherwise it's a genuine no-response failure — report the real reason and
+    # flag whether it was specifically a DNS resolution failure (the dependent
+    # viability layer acts only on that; gluetun's root test acts on `ok`).
     return SiteResult(
-        url, False, duration_ms, http_code, decode_wget_exit_code(exit_code), exit_code
+        url, False, duration_ms, http_code, _extract_error(output, exit_code), exit_code,
+        dns_failed=_is_dns_failure(output),
     )

--- a/gluetun_monitor/connectivity.py
+++ b/gluetun_monitor/connectivity.py
@@ -1,0 +1,87 @@
+"""Connectivity probing — ``wget --spider`` from inside a container's netns.
+
+This is the ADR-0001 authoritative test, preserved verbatim from v1.x: the same
+``wget --spider -S`` invocation, the same exit-code -> pass/fail map (0/6/8 mean
+the site responded => the VPN is up). Only the dispatch moved from a shell
+background job to ``DockerClient.exec_run``.
+"""
+
+from __future__ import annotations
+
+import re
+import time
+from dataclasses import dataclass
+
+from .docker_client import DockerClient
+
+# wget exit codes where the site *responded* — the tunnel is therefore working:
+#   0 = success, 6 = auth required, 8 = HTTP 4xx/5xx. Everything else is a real
+# connectivity failure (4 = DNS/connect, 5 = SSL, ...).
+WGET_PASS_CODES = frozenset({0, 6, 8})
+
+_WGET_EXIT_MESSAGES: dict[int, str] = {
+    0: "Success",
+    1: "Generic error",
+    2: "Parse error",
+    3: "File I/O error",
+    4: "Network failure (DNS or connection)",
+    5: "SSL verification failure",
+    6: "Authentication required",
+    7: "Protocol error",
+    8: "Server error (HTTP 4xx/5xx)",
+}
+
+_HTTP_CODE_RE = re.compile(r"HTTP/[0-9.]+\s+(\d+)")
+
+
+def decode_wget_exit_code(code: int) -> str:
+    """Human-readable reason for a wget exit code (v1.x ``decode_wget_exit_code``)."""
+    return _WGET_EXIT_MESSAGES.get(code, f"Unknown error (code {code})")
+
+
+def _parse_http_code(output: str) -> str:
+    """Last HTTP status code seen in ``wget -S`` output, or 'N/A'."""
+    matches = _HTTP_CODE_RE.findall(output)
+    return matches[-1] if matches else "N/A"
+
+
+@dataclass(frozen=True, slots=True)
+class SiteResult:
+    """Outcome of testing one URL from inside a container."""
+
+    url: str
+    ok: bool
+    duration_ms: int
+    http_code: str
+    reason: str
+    exit_code: int
+
+
+def probe_site(
+    client: DockerClient,
+    container: str,
+    url: str,
+    timeout: int,
+) -> SiteResult:
+    """Probe ``url`` with ``wget --spider`` from inside ``container``'s netns."""
+    cmd = ["wget", "--spider", "-S", f"--timeout={timeout}", "--tries=1", "-q", url]
+    start = time.monotonic()
+    try:
+        result = client.exec_run(container, cmd)
+        exit_code, output = result.exit_code, result.output
+    except Exception as exc:  # exec itself failed (container gone, daemon error)
+        duration_ms = int((time.monotonic() - start) * 1000)
+        return SiteResult(url, False, duration_ms, "N/A", f"exec failed: {exc}", -1)
+
+    duration_ms = int((time.monotonic() - start) * 1000)
+    http_code = _parse_http_code(output)
+
+    if exit_code == 0:
+        return SiteResult(url, True, duration_ms, http_code, f"HTTP {http_code}", 0)
+    if exit_code in WGET_PASS_CODES:
+        # Site answered with an error (auth/4xx/5xx) — the tunnel is still up.
+        reason = f"HTTP {http_code} (VPN working)"
+        return SiteResult(url, True, duration_ms, http_code, reason, exit_code)
+    return SiteResult(
+        url, False, duration_ms, http_code, decode_wget_exit_code(exit_code), exit_code
+    )

--- a/gluetun_monitor/connectivity.py
+++ b/gluetun_monitor/connectivity.py
@@ -109,14 +109,17 @@ def probe_site(
     container: str,
     url: str,
     timeout: int,
+    tries: int = 1,
 ) -> SiteResult:
     """Probe ``url`` with ``wget --spider`` from inside ``container``'s netns.
 
-    No ``-q``: we want wget's diagnostics in the output so a real failure reports
-    *why* (not a bare exit code). Classification is HTTP-response-first (see the
-    module docstring), so it's correct for both GNU and busybox wget.
+    ``timeout`` (TIMEOUT) and ``tries`` (WGET_TRIES) are the standardized per-request
+    knobs, applied identically to gluetun's GNU wget and the dependents' busybox
+    wget. No ``-q``: we want wget's diagnostics in the output so a real failure
+    reports *why* (not a bare exit code). Classification is HTTP-response-first (see
+    the module docstring), so it's correct for both GNU and busybox wget.
     """
-    cmd = ["wget", "--spider", "-S", f"--timeout={timeout}", "--tries=1", url]
+    cmd = ["wget", "--spider", "-S", f"--timeout={timeout}", f"--tries={tries}", url]
     start = time.monotonic()
     try:
         result = client.exec_run(container, cmd)

--- a/gluetun_monitor/connectivity.py
+++ b/gluetun_monitor/connectivity.py
@@ -75,7 +75,8 @@ def _parse_http_code(output: str) -> str:
 
 def _extract_error(output: str, exit_code: int) -> str:
     """The real failure reason: wget's own last diagnostic line if we can find it,
-    otherwise the decoded exit code. Avoids the useless bare 'Generic error'."""
+    otherwise the decoded exit code. Avoids the useless bare 'Generic error'.
+    """
     for line in reversed([ln.strip() for ln in output.splitlines() if ln.strip()]):
         low = line.lower()
         if any(hint in low for hint in _ERROR_HINTS):

--- a/gluetun_monitor/connectivity.py
+++ b/gluetun_monitor/connectivity.py
@@ -119,7 +119,11 @@ def probe_site(
     reports *why* (not a bare exit code). Classification is HTTP-response-first (see
     the module docstring), so it's correct for both GNU and busybox wget.
     """
-    cmd = ["wget", "--spider", "-S", f"--timeout={timeout}", f"--tries={tries}", url]
+    # ``--`` ends option parsing: a site like "--directory-prefix=/etc" must be
+    # treated as a (bad) URL, never as a wget flag that could write files inside
+    # the container. sites.py already rejects leading-dash entries; this is the
+    # belt-and-suspenders second layer (Tenet 1).
+    cmd = ["wget", "--spider", "-S", f"--timeout={timeout}", f"--tries={tries}", "--", url]
     start = time.monotonic()
     try:
         result = client.exec_run(container, cmd)

--- a/gluetun_monitor/dependents.py
+++ b/gluetun_monitor/dependents.py
@@ -32,6 +32,13 @@ def _ids_match(a: str, b: str) -> bool:
     return a == b or a.startswith(b) or b.startswith(a)
 
 
+def is_container_id(value: str) -> bool:
+    """True if ``value`` looks like a Docker container id (12-64 hex chars), as
+    opposed to a container *name* (used to tell id-form NetworkMode targets apart
+    from name-form ones)."""
+    return bool(_CONTAINER_ID_RE.match(value))
+
+
 def discover_dependents(client: DockerClient, gluetun_container: str) -> list[str]:
     """Names of running containers sharing gluetun's network namespace."""
     gluetun = client.inspect(gluetun_container)

--- a/gluetun_monitor/dependents.py
+++ b/gluetun_monitor/dependents.py
@@ -67,7 +67,10 @@ def get_dependents(client: DockerClient, config: Config, logger: Logger) -> list
     if config.dependent_containers == "auto":
         discovered = discover_dependents(client, config.gluetun_container)
         if discovered:
-            logger.info(f"Discovered dependent containers: {','.join(discovered)}")
+            # DEBUG, not INFO: the per-loop INFO heartbeat already reports the
+            # dependent count ("dependents: N/M ok"), so naming them every loop
+            # is redundant noise at the default level.
+            logger.debug(f"Discovered dependent containers: {','.join(discovered)}")
         else:
             logger.warn("No dependent containers discovered")
         return discovered

--- a/gluetun_monitor/dependents.py
+++ b/gluetun_monitor/dependents.py
@@ -121,7 +121,7 @@ def remediation_action(dep_info: ContainerInfo, gluetun_id: str) -> RemediationA
     target = nm.split(":", 1)[1]
     if not target:
         return RemediationAction.TRY_RESTART
-    if _CONTAINER_ID_RE.match(target):
+    if is_container_id(target):
         if _ids_match(target, gluetun_id):
             return RemediationAction.RESTART
         return RemediationAction.RECREATE

--- a/gluetun_monitor/dependents.py
+++ b/gluetun_monitor/dependents.py
@@ -64,7 +64,16 @@ def get_dependents(client: DockerClient, config: Config, logger: Logger) -> list
         else:
             logger.warn("No dependent containers discovered")
         return discovered
-    return [d for d in (trim(x) for x in config.dependent_containers.split(",")) if d]
+    return parse_csv_names(config.dependent_containers)
+
+
+def parse_csv_names(value: str) -> list[str]:
+    """Parse a comma-separated container-name list into trimmed, non-empty names.
+
+    Shared by the manual ``DEPENDENT_CONTAINERS`` list and ``EXCLUDE_CONTAINERS``
+    so both interpret the value identically.
+    """
+    return [n for n in (trim(x) for x in value.split(",")) if n]
 
 
 def interface_check(client: DockerClient, dep_name: str) -> InterfaceStatus:

--- a/gluetun_monitor/dependents.py
+++ b/gluetun_monitor/dependents.py
@@ -83,19 +83,30 @@ def parse_csv_names(value: str) -> list[str]:
     return [n for n in (trim(x) for x in value.split(",")) if n]
 
 
-def interface_check(client: DockerClient, dep_name: str) -> InterfaceStatus:
-    """Classify a dependent by its network interfaces (ADR-0004, node 7)."""
+def list_interfaces(client: DockerClient, dep_name: str) -> set[str] | None:
+    """Return the dependent's network interfaces (``ls /sys/class/net``), or None
+    if it couldn't be determined (exec failed / no shell / empty output)."""
     try:
         result = client.exec_run(dep_name, ["ls", "/sys/class/net"])
     except Exception:
-        return InterfaceStatus.UNKNOWN
+        return None
     if result.exit_code != 0:
-        return InterfaceStatus.UNKNOWN
+        return None
     interfaces = {tok for tok in result.output.split() if tok}
+    return interfaces or None
+
+
+def classify_interfaces(interfaces: set[str] | None) -> InterfaceStatus:
+    """LIVE if a non-loopback interface is present, STRANDED if only ``lo``,
+    UNKNOWN if we couldn't read them (ADR-0004, node 7)."""
     if not interfaces:
         return InterfaceStatus.UNKNOWN
-    non_loopback = interfaces - {"lo"}
-    return InterfaceStatus.LIVE if non_loopback else InterfaceStatus.STRANDED
+    return InterfaceStatus.LIVE if (interfaces - {"lo"}) else InterfaceStatus.STRANDED
+
+
+def interface_check(client: DockerClient, dep_name: str) -> InterfaceStatus:
+    """Classify a dependent by its network interfaces (ADR-0004, node 7)."""
+    return classify_interfaces(list_interfaces(client, dep_name))
 
 
 def remediation_action(dep_info: ContainerInfo, gluetun_id: str) -> RemediationAction:

--- a/gluetun_monitor/dependents.py
+++ b/gluetun_monitor/dependents.py
@@ -1,0 +1,102 @@
+"""Dependent discovery, interface classification, and the remediation decision.
+
+* **Discovery** (v1.x ``discover_dependent_containers``): containers whose
+  ``NetworkMode`` points at gluetun (by name, full id, or short id prefix).
+* **Interface check** (ADR-0004, node 7): ``ls /sys/class/net`` -> live vs
+  stranded-loopback-only vs unknown (distroless/exec-failed).
+* **Remediation decision** (ADR-0004, nodes 14-17): compare a dependent's
+  resolved ``NetworkMode`` target to gluetun's current id — same id => restart,
+  different id => recreate, name-form/unreadable => try-restart-then-escalate.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import TYPE_CHECKING
+
+from .sites import trim
+from .state import InterfaceStatus, RemediationAction
+
+if TYPE_CHECKING:
+    from .config import Config
+    from .docker_client import ContainerInfo, DockerClient
+    from .logging_setup import Logger
+
+_CONTAINER_ID_RE = re.compile(r"^[0-9a-f]{12,64}$")
+
+
+def _ids_match(a: str, b: str) -> bool:
+    """True if two container ids refer to the same container (short/full prefix)."""
+    if not a or not b:
+        return False
+    return a == b or a.startswith(b) or b.startswith(a)
+
+
+def discover_dependents(client: DockerClient, gluetun_container: str) -> list[str]:
+    """Names of running containers sharing gluetun's network namespace."""
+    gluetun = client.inspect(gluetun_container)
+    if gluetun is None:
+        return []
+    gluetun_id = gluetun.id
+    short_id = gluetun_id[:12]
+
+    name_form = f"container:{gluetun_container}"
+    id_form = f"container:{gluetun_id}"
+    short_prefix = f"container:{short_id}"
+
+    found: list[str] = []
+    for cid in client.list_running_ids():
+        info = client.inspect(cid)
+        if info is None or info.name == gluetun_container:
+            continue
+        nm = info.network_mode
+        if nm in (name_form, id_form) or nm.startswith(short_prefix):
+            found.append(info.name)
+    return found
+
+
+def get_dependents(client: DockerClient, config: Config, logger: Logger) -> list[str]:
+    """Resolve the dependent set: auto-discovery or the configured manual list."""
+    if config.dependent_containers == "auto":
+        discovered = discover_dependents(client, config.gluetun_container)
+        if discovered:
+            logger.info(f"Discovered dependent containers: {','.join(discovered)}")
+        else:
+            logger.warn("No dependent containers discovered")
+        return discovered
+    return [d for d in (trim(x) for x in config.dependent_containers.split(",")) if d]
+
+
+def interface_check(client: DockerClient, dep_name: str) -> InterfaceStatus:
+    """Classify a dependent by its network interfaces (ADR-0004, node 7)."""
+    try:
+        result = client.exec_run(dep_name, ["ls", "/sys/class/net"])
+    except Exception:
+        return InterfaceStatus.UNKNOWN
+    if result.exit_code != 0:
+        return InterfaceStatus.UNKNOWN
+    interfaces = {tok for tok in result.output.split() if tok}
+    if not interfaces:
+        return InterfaceStatus.UNKNOWN
+    non_loopback = interfaces - {"lo"}
+    return InterfaceStatus.LIVE if non_loopback else InterfaceStatus.STRANDED
+
+
+def remediation_action(dep_info: ContainerInfo, gluetun_id: str) -> RemediationAction:
+    """Decide restart vs recreate for a failing dependent (ADR-0004 decision tree).
+
+    Compose's ``network_mode: service:gluetun`` resolves to ``container:<full-id>``;
+    that id moving is exactly the recreate trigger.
+    """
+    nm = dep_info.network_mode
+    if not nm.startswith("container:"):
+        return RemediationAction.TRY_RESTART
+    target = nm.split(":", 1)[1]
+    if not target:
+        return RemediationAction.TRY_RESTART
+    if _CONTAINER_ID_RE.match(target):
+        if _ids_match(target, gluetun_id):
+            return RemediationAction.RESTART
+        return RemediationAction.RECREATE
+    # Name form (e.g. container:gluetun): can't tell — try restart, escalate on fail.
+    return RemediationAction.TRY_RESTART

--- a/gluetun_monitor/dependents.py
+++ b/gluetun_monitor/dependents.py
@@ -35,7 +35,8 @@ def _ids_match(a: str, b: str) -> bool:
 def is_container_id(value: str) -> bool:
     """True if ``value`` looks like a Docker container id (12-64 hex chars), as
     opposed to a container *name* (used to tell id-form NetworkMode targets apart
-    from name-form ones)."""
+    from name-form ones).
+    """
     return bool(_CONTAINER_ID_RE.match(value))
 
 
@@ -88,7 +89,8 @@ def parse_csv_names(value: str) -> list[str]:
 
 def list_interfaces(client: DockerClient, dep_name: str) -> set[str] | None:
     """Return the dependent's network interfaces (``ls /sys/class/net``), or None
-    if it couldn't be determined (exec failed / no shell / empty output)."""
+    if it couldn't be determined (exec failed / no shell / empty output).
+    """
     try:
         result = client.exec_run(dep_name, ["ls", "/sys/class/net"])
     except Exception:
@@ -101,7 +103,8 @@ def list_interfaces(client: DockerClient, dep_name: str) -> set[str] | None:
 
 def classify_interfaces(interfaces: set[str] | None) -> InterfaceStatus:
     """LIVE if a non-loopback interface is present, STRANDED if only ``lo``,
-    UNKNOWN if we couldn't read them (ADR-0004, node 7)."""
+    UNKNOWN if we couldn't read them (ADR-0004, node 7).
+    """
     if not interfaces:
         return InterfaceStatus.UNKNOWN
     return InterfaceStatus.LIVE if (interfaces - {"lo"}) else InterfaceStatus.STRANDED

--- a/gluetun_monitor/dns_check.py
+++ b/gluetun_monitor/dns_check.py
@@ -82,15 +82,20 @@ def validate_dns(
     wget = probe_site(client, container, url, timeout)
     if wget.exit_code not in _ABSENT_EXIT_CODES:
         if wget.dns_failed:
-            return DnsResult(DnsStatus.BROKEN, "wget", wget.reason)
-        return DnsResult(DnsStatus.OK, "wget", wget.reason)
+            return DnsResult(DnsStatus.BROKEN, "wget", f"DNS resolution failed ({wget.reason})")
+        if wget.http_code != "N/A":
+            # Full round-trip: resolved DNS + TCP-connected + got an HTTP response.
+            return DnsResult(DnsStatus.OK, "wget", f"resolved + connected (HTTP {wget.http_code})")
+        # DNS resolved but no HTTP response (connect refused / timeout / TLS).
+        # Still viable (DNS is the only per-container fault), but say so honestly.
+        return DnsResult(DnsStatus.OK, "wget", f"resolved, no HTTP response ({wget.reason})")
 
     # Tool 2 — getent hosts (nsswitch-faithful; glibc images). 0 = resolved,
-    # 2 = name not found.
+    # 2 = name not found. DNS-only (no connection attempt).
     getent = _try(client, container, ["getent", "hosts", host])
     if getent is not None and not _absent(getent):
         if getent.exit_code == 0 and getent.output.strip():
-            return DnsResult(DnsStatus.OK, "getent", "resolved")
+            return DnsResult(DnsStatus.OK, "getent", "resolved (DNS lookup only)")
         if getent.exit_code == 2:
             return DnsResult(DnsStatus.BROKEN, "getent", "name not found")
 
@@ -109,6 +114,6 @@ def validate_dns(
             or "(" in ping.output  # "PING host (1.2.3.4)" — name resolved to an address
         )
         if resolved:
-            return DnsResult(DnsStatus.OK, "ping", "resolved")
+            return DnsResult(DnsStatus.OK, "ping", "resolved (DNS lookup only)")
 
     return DnsResult(DnsStatus.UNVALIDATED, "", "no usable DNS tool (wget/getent/ping)")

--- a/gluetun_monitor/dns_check.py
+++ b/gluetun_monitor/dns_check.py
@@ -1,0 +1,114 @@
+"""Faithful, portable DNS-resolution validation inside a dependent container.
+
+Because dependents share gluetun's netns (egress is gluetun's, already proven;
+strands are caught upstream by the interface check), the only per-container fault
+left to detect is the container's **own DNS resolution** (its `resolv.conf` /
+`nsswitch.conf`). This module validates exactly that, with a cascade of
+**getaddrinfo-faithful** tools — ones that resolve the way the application itself
+does (libc `getaddrinfo` / nsswitch): ``wget`` (resolves before connecting),
+``getent hosts``, and ``ping`` (resolves before pinging). We deliberately do
+**not** use ``nslookup``/``dig``/``host``: those query DNS servers directly,
+bypassing nsswitch/`/etc/hosts`/libc, so they can report "resolves" when the
+app's `getaddrinfo` does not — a false-OK we must avoid.
+
+Three outcomes, not two (Tenet 1 — don't guess):
+- **OK** — a tool resolved the name.
+- **BROKEN** — a tool ran and resolution positively failed (the fault we act on).
+- **UNVALIDATED** — no usable tool exists in the container; we can't tell, so we
+  don't guess. The caller logs it and falls back to the interface check.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum, auto
+
+from .connectivity import _is_dns_failure, probe_site
+from .docker_client import DockerClient, ExecResult
+
+# Exit codes / output that mean the tool itself isn't present in the container.
+_ABSENT_EXIT_CODES = frozenset({-1, 126, 127})
+_ABSENT_HINTS = ("executable file not found", "not found in $path", "no such file",
+                 "applet not found")
+
+
+class DnsStatus(Enum):
+    """Outcome of a dependent DNS-resolution check."""
+
+    OK = auto()
+    BROKEN = auto()
+    UNVALIDATED = auto()
+
+
+@dataclass(frozen=True, slots=True)
+class DnsResult:
+    """A DNS check result: the verdict, the tool that produced it, and why."""
+
+    status: DnsStatus
+    tool: str
+    reason: str
+
+
+def _absent(result: ExecResult) -> bool:
+    """True if the exec indicates the command isn't present in the container."""
+    if result.exit_code in _ABSENT_EXIT_CODES:
+        return True
+    low = result.output.lower()
+    return any(hint in low for hint in _ABSENT_HINTS)
+
+
+def _try(client: DockerClient, container: str, cmd: list[str]) -> ExecResult | None:
+    """Run ``cmd``; return its result, or None if the exec itself raised."""
+    try:
+        return client.exec_run(container, cmd)
+    except Exception:
+        return None
+
+
+def validate_dns(
+    client: DockerClient,
+    container: str,
+    url: str,
+    host: str,
+    timeout: int,
+) -> DnsResult:
+    """Validate that ``container`` can resolve ``host`` (the host part of ``url``).
+
+    Cascades wget → getent → ping, stopping at the first tool that's actually
+    present (gives OK or BROKEN). If none are present, returns UNVALIDATED.
+    """
+    # Tool 1 — wget (reuses the connectivity probe: it resolves via getaddrinfo
+    # before connecting, so its result already tells us OK vs DNS-broken).
+    wget = probe_site(client, container, url, timeout)
+    if wget.exit_code not in _ABSENT_EXIT_CODES:
+        if wget.dns_failed:
+            return DnsResult(DnsStatus.BROKEN, "wget", wget.reason)
+        return DnsResult(DnsStatus.OK, "wget", wget.reason)
+
+    # Tool 2 — getent hosts (nsswitch-faithful; glibc images). 0 = resolved,
+    # 2 = name not found.
+    getent = _try(client, container, ["getent", "hosts", host])
+    if getent is not None and not _absent(getent):
+        if getent.exit_code == 0 and getent.output.strip():
+            return DnsResult(DnsStatus.OK, "getent", "resolved")
+        if getent.exit_code == 2:
+            return DnsResult(DnsStatus.BROKEN, "getent", "name not found")
+
+    # Tool 3 — ping (resolves via getaddrinfo before sending; we only care that
+    # resolution happened, not that ICMP succeeded — packets may be blocked).
+    ping = _try(client, container, ["ping", "-c", "1", "-W", str(max(1, timeout)), host])
+    if ping is not None and not _absent(ping):
+        if _is_dns_failure(ping.output):
+            return DnsResult(DnsStatus.BROKEN, "ping", "resolution failed")
+        low = ping.output.lower()
+        resolved = (
+            ping.exit_code == 0
+            or "bytes from" in low
+            or "transmitted" in low
+            or "permission denied" in low  # resolved, then couldn't send (no CAP_NET_RAW)
+            or "(" in ping.output  # "PING host (1.2.3.4)" — name resolved to an address
+        )
+        if resolved:
+            return DnsResult(DnsStatus.OK, "ping", "resolved")
+
+    return DnsResult(DnsStatus.UNVALIDATED, "", "no usable DNS tool (wget/getent/ping)")

--- a/gluetun_monitor/dns_check.py
+++ b/gluetun_monitor/dns_check.py
@@ -82,23 +82,25 @@ def validate_dns(
     """
     # Tool 1 — wget (reuses the connectivity probe: it resolves via getaddrinfo
     # before connecting, so its result already tells us OK vs DNS-broken).
+    # ``reason`` carries only the *detail*; the caller supplies the verb + verdict
+    # ("reach ok/fail"), so we don't repeat "resolved"/"DNS FAILED" here.
     wget = probe_site(client, container, url, timeout, tries)
     if wget.exit_code not in _ABSENT_EXIT_CODES:
         if wget.dns_failed:
-            return DnsResult(DnsStatus.BROKEN, "wget", f"DNS resolution failed ({wget.reason})")
+            return DnsResult(DnsStatus.BROKEN, "wget", wget.reason)
         if wget.http_code != "N/A":
             # Full round-trip: resolved DNS + TCP-connected + got an HTTP response.
-            return DnsResult(DnsStatus.OK, "wget", f"resolved + connected (HTTP {wget.http_code})")
+            return DnsResult(DnsStatus.OK, "wget", f"HTTP {wget.http_code}")
         # DNS resolved but no HTTP response (connect refused / timeout / TLS).
         # Still viable (DNS is the only per-container fault), but say so honestly.
-        return DnsResult(DnsStatus.OK, "wget", f"resolved, no HTTP response ({wget.reason})")
+        return DnsResult(DnsStatus.OK, "wget", f"no HTTP: {wget.reason}")
 
     # Tool 2 — getent hosts (nsswitch-faithful; glibc images). 0 = resolved,
     # 2 = name not found. DNS-only (no connection attempt).
     getent = _try(client, container, ["getent", "hosts", "--", host])
     if getent is not None and not _absent(getent):
         if getent.exit_code == 0 and getent.output.strip():
-            return DnsResult(DnsStatus.OK, "getent", "resolved (DNS lookup only)")
+            return DnsResult(DnsStatus.OK, "getent", "lookup only")
         if getent.exit_code == 2:
             return DnsResult(DnsStatus.BROKEN, "getent", "name not found")
 
@@ -117,6 +119,6 @@ def validate_dns(
             or "(" in ping.output  # "PING host (1.2.3.4)" — name resolved to an address
         )
         if resolved:
-            return DnsResult(DnsStatus.OK, "ping", "resolved (DNS lookup only)")
+            return DnsResult(DnsStatus.OK, "ping", "lookup only")
 
-    return DnsResult(DnsStatus.UNVALIDATED, "", "no usable DNS tool (wget/getent/ping)")
+    return DnsResult(DnsStatus.UNVALIDATED, "", "no resolver tool")

--- a/gluetun_monitor/dns_check.py
+++ b/gluetun_monitor/dns_check.py
@@ -95,7 +95,7 @@ def validate_dns(
 
     # Tool 2 — getent hosts (nsswitch-faithful; glibc images). 0 = resolved,
     # 2 = name not found. DNS-only (no connection attempt).
-    getent = _try(client, container, ["getent", "hosts", host])
+    getent = _try(client, container, ["getent", "hosts", "--", host])
     if getent is not None and not _absent(getent):
         if getent.exit_code == 0 and getent.output.strip():
             return DnsResult(DnsStatus.OK, "getent", "resolved (DNS lookup only)")
@@ -104,7 +104,7 @@ def validate_dns(
 
     # Tool 3 — ping (resolves via getaddrinfo before sending; we only care that
     # resolution happened, not that ICMP succeeded — packets may be blocked).
-    ping = _try(client, container, ["ping", "-c", "1", "-W", str(max(1, timeout)), host])
+    ping = _try(client, container, ["ping", "-c", "1", "-W", str(max(1, timeout)), "--", host])
     if ping is not None and not _absent(ping):
         if _is_dns_failure(ping.output):
             return DnsResult(DnsStatus.BROKEN, "ping", "resolution failed")

--- a/gluetun_monitor/dns_check.py
+++ b/gluetun_monitor/dns_check.py
@@ -71,15 +71,18 @@ def validate_dns(
     url: str,
     host: str,
     timeout: int,
+    tries: int = 1,
 ) -> DnsResult:
     """Validate that ``container`` can resolve ``host`` (the host part of ``url``).
 
     Cascades wget → getent → ping, stopping at the first tool that's actually
     present (gives OK or BROKEN). If none are present, returns UNVALIDATED.
+    ``timeout``/``tries`` are the standardized per-request knobs (wget --timeout/
+    --tries; ping -W).
     """
     # Tool 1 — wget (reuses the connectivity probe: it resolves via getaddrinfo
     # before connecting, so its result already tells us OK vs DNS-broken).
-    wget = probe_site(client, container, url, timeout)
+    wget = probe_site(client, container, url, timeout, tries)
     if wget.exit_code not in _ABSENT_EXIT_CODES:
         if wget.dns_failed:
             return DnsResult(DnsStatus.BROKEN, "wget", f"DNS resolution failed ({wget.reason})")

--- a/gluetun_monitor/docker_client.py
+++ b/gluetun_monitor/docker_client.py
@@ -56,7 +56,12 @@ class DockerClient(Protocol):
     """The minimal Docker surface the monitor depends on."""
 
     def ping(self) -> bool:
-        """True if the daemon/proxy is reachable."""
+        """True if the daemon/proxy is reachable.
+
+        Uses Docker's ``/_ping`` (docker-py ``ping()``); validated to be permitted
+        by the default tecnativa socket-proxy config (CONTAINERS/POST/EXEC) — only
+        ``/info`` is gated there (ADR-0002), not ``/_ping``.
+        """
         ...
 
     def list_running_ids(self) -> list[str]:

--- a/gluetun_monitor/docker_client.py
+++ b/gluetun_monitor/docker_client.py
@@ -1,0 +1,144 @@
+"""The Docker seam (ADR-0007).
+
+Everything the monitor needs from Docker goes through the ``DockerClient``
+Protocol. ``DockerPyClient`` implements it over docker-py's low-level API
+(which speaks the same HTTP endpoints the tecnativa socket-proxy gates:
+CONTAINERS / POST / EXEC). Tests inject a ``FakeDockerClient`` instead, so the
+entire monitor — including the recreate path — is exercised without a daemon.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Protocol
+
+
+@dataclass(frozen=True, slots=True)
+class ExecResult:
+    """Result of an ``exec`` inside a container."""
+
+    exit_code: int
+    output: str
+
+
+@dataclass(frozen=True, slots=True)
+class ContainerInfo:
+    """Normalized view of ``docker inspect`` for one container.
+
+    ``raw`` is the full inspect payload — the recreate path (ADR-0005) reads
+    ``Config``/``HostConfig``/``Mounts`` directly from it.
+    """
+
+    id: str
+    name: str
+    network_mode: str
+    running: bool
+    health: str
+    raw: dict[str, Any] = field(default_factory=dict)
+
+    @classmethod
+    def from_inspect(cls, raw: dict[str, Any]) -> ContainerInfo:
+        state = raw.get("State", {}) or {}
+        health_obj = state.get("Health") or {}
+        host_config = raw.get("HostConfig", {}) or {}
+        return cls(
+            id=raw.get("Id", ""),
+            name=str(raw.get("Name", "")).lstrip("/"),
+            network_mode=str(host_config.get("NetworkMode", "")),
+            running=bool(state.get("Running", False)),
+            health=str(health_obj.get("Status", "unknown")) if health_obj else "unknown",
+            raw=raw,
+        )
+
+
+class DockerClient(Protocol):
+    """The minimal Docker surface the monitor depends on."""
+
+    def ping(self) -> bool:
+        """True if the daemon/proxy is reachable."""
+        ...
+
+    def list_running_ids(self) -> list[str]:
+        """IDs of currently running containers."""
+        ...
+
+    def inspect(self, name_or_id: str) -> ContainerInfo | None:
+        """Inspect a container, or None if it does not exist."""
+        ...
+
+    def exec_run(self, name_or_id: str, cmd: list[str]) -> ExecResult:
+        """Run ``cmd`` inside a container; return its exit code + combined output."""
+        ...
+
+    def logs(self, name_or_id: str) -> str:
+        """Fetch a container's logs (stdout+stderr) as text."""
+        ...
+
+    def restart(self, name_or_id: str) -> None:
+        """Restart a container (preserves identity — same container id)."""
+        ...
+
+    def remove(self, name_or_id: str, *, volumes: bool) -> None:
+        """Remove a container. ``volumes=False`` preserves anonymous volumes."""
+        ...
+
+    def create_from_config(self, config: dict[str, Any], name: str) -> str:
+        """Create a container from a raw API create body; return the new id."""
+        ...
+
+    def start(self, name_or_id: str) -> None:
+        """Start an existing (created) container."""
+        ...
+
+
+class DockerPyClient:
+    """``DockerClient`` over docker-py's low-level API (honors DOCKER_HOST)."""
+
+    def __init__(self, timeout: int = 60) -> None:
+        import docker  # imported lazily so the fake-only test path needs no daemon
+
+        self._client = docker.from_env(timeout=timeout)
+        self._api = self._client.api
+
+    def ping(self) -> bool:
+        try:
+            return bool(self._api.ping())
+        except Exception:
+            return False
+
+    def list_running_ids(self) -> list[str]:
+        return [c["Id"] for c in self._api.containers(all=False)]
+
+    def inspect(self, name_or_id: str) -> ContainerInfo | None:
+        import docker.errors
+
+        try:
+            raw = self._api.inspect_container(name_or_id)
+        except docker.errors.NotFound:
+            return None
+        return ContainerInfo.from_inspect(raw)
+
+    def exec_run(self, name_or_id: str, cmd: list[str]) -> ExecResult:
+        exec_id = self._api.exec_create(name_or_id, cmd)["Id"]
+        raw_output = self._api.exec_start(exec_id)
+        output = raw_output.decode("utf-8", errors="replace") if raw_output else ""
+        exit_code = self._api.exec_inspect(exec_id).get("ExitCode")
+        # A still-running/unknown exec reports None; treat as a generic failure.
+        return ExecResult(exit_code=exit_code if exit_code is not None else 1, output=output)
+
+    def logs(self, name_or_id: str) -> str:
+        raw = self._api.logs(name_or_id, stdout=True, stderr=True)
+        return raw.decode("utf-8", errors="replace") if raw else ""
+
+    def restart(self, name_or_id: str) -> None:
+        self._api.restart(name_or_id)
+
+    def remove(self, name_or_id: str, *, volumes: bool) -> None:
+        self._api.remove_container(name_or_id, v=volumes, force=True)
+
+    def create_from_config(self, config: dict[str, Any], name: str) -> str:
+        result = self._api.create_container_from_config(config, name=name)
+        return str(result["Id"])
+
+    def start(self, name_or_id: str) -> None:
+        self._api.start(name_or_id)

--- a/gluetun_monitor/docker_client.py
+++ b/gluetun_monitor/docker_client.py
@@ -38,6 +38,7 @@ class ContainerInfo:
 
     @classmethod
     def from_inspect(cls, raw: dict[str, Any]) -> ContainerInfo:
+        """Build a ContainerInfo from a full ``docker inspect`` payload."""
         state = raw.get("State", {}) or {}
         health_obj = state.get("Health") or {}
         host_config = raw.get("HostConfig", {}) or {}
@@ -92,24 +93,31 @@ class DockerClient(Protocol):
 
 
 class DockerPyClient:
-    """``DockerClient`` over docker-py's low-level API (honors DOCKER_HOST)."""
+    """``DockerClient`` over docker-py's low-level API (honors DOCKER_HOST).
 
-    def __init__(self, timeout: int = 60) -> None:
+    Method contracts are the ones declared on the ``DockerClient`` Protocol; the
+    docstrings here note how each maps onto a docker-py API call.
+    """
+
+    def __init__(self, timeout: int = 60) -> None:  # pragma: no cover - needs a live daemon
         import docker  # imported lazily so the fake-only test path needs no daemon
 
         self._client = docker.from_env(timeout=timeout)
         self._api = self._client.api
 
     def ping(self) -> bool:
+        """``GET /_ping`` — swallow any transport error and report unreachable."""
         try:
             return bool(self._api.ping())
         except Exception:
             return False
 
     def list_running_ids(self) -> list[str]:
+        """``GET /containers/json`` (running only) → their ids."""
         return [c["Id"] for c in self._api.containers(all=False)]
 
     def inspect(self, name_or_id: str) -> ContainerInfo | None:
+        """``GET /containers/{id}/json`` → ContainerInfo, or None if not found."""
         import docker.errors
 
         try:
@@ -119,6 +127,7 @@ class DockerPyClient:
         return ContainerInfo.from_inspect(raw)
 
     def exec_run(self, name_or_id: str, cmd: list[str]) -> ExecResult:
+        """exec_create + exec_start + exec_inspect → exit code + combined output."""
         exec_id = self._api.exec_create(name_or_id, cmd)["Id"]
         raw_output = self._api.exec_start(exec_id)
         output = raw_output.decode("utf-8", errors="replace") if raw_output else ""
@@ -127,18 +136,23 @@ class DockerPyClient:
         return ExecResult(exit_code=exit_code if exit_code is not None else 1, output=output)
 
     def logs(self, name_or_id: str) -> str:
+        """``GET /containers/{id}/logs`` (stdout+stderr) decoded to text."""
         raw = self._api.logs(name_or_id, stdout=True, stderr=True)
         return raw.decode("utf-8", errors="replace") if raw else ""
 
     def restart(self, name_or_id: str) -> None:
+        """``POST /containers/{id}/restart``."""
         self._api.restart(name_or_id)
 
     def remove(self, name_or_id: str, *, volumes: bool) -> None:
+        """``DELETE /containers/{id}`` (force); ``v=volumes`` controls volume removal."""
         self._api.remove_container(name_or_id, v=volumes, force=True)
 
     def create_from_config(self, config: dict[str, Any], name: str) -> str:
+        """``POST /containers/create`` from a raw API body → the new container id."""
         result = self._api.create_container_from_config(config, name=name)
         return str(result["Id"])
 
     def start(self, name_or_id: str) -> None:
+        """``POST /containers/{id}/start``."""
         self._api.start(name_or_id)

--- a/gluetun_monitor/endpoint.py
+++ b/gluetun_monitor/endpoint.py
@@ -1,0 +1,85 @@
+"""Parse gluetun's own logs for the active VPN endpoint (IP / location / server).
+
+Mirrors v1.x ``log_endpoint_info``. The location parse is deliberately
+quote-safe (issue #17): a region like ``Provence-Alpes-Cote-d'Azur`` must parse
+cleanly and never crash.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+
+from .docker_client import DockerClient
+
+_PUBLIC_IP_RE = re.compile(r"Public IP address is ([0-9.]+)")
+_LOCATION_RE = re.compile(r"\(([^)]+)\)")
+_WG_SERVER_RE = re.compile(r"Connecting to ([0-9.]+)")
+
+
+@dataclass(frozen=True, slots=True)
+class EndpointInfo:
+    """The VPN endpoint as reported by gluetun's logs."""
+
+    public_ip: str = "unknown"
+    country: str = "unknown"
+    city: str = "unknown"
+    wg_server: str = "unknown"
+
+    def format(self, status: str, reason: str = "") -> str:
+        """Render the v1.x ENDPOINT log message body."""
+        return (
+            f"Status: {status} | IP: {self.public_ip} | Country: {self.country} | "
+            f"City: {self.city} | VPN Server: {self.wg_server} | Reason: {reason}"
+        )
+
+
+def _last_match(pattern: re.Pattern[str], lines: list[str]) -> str | None:
+    """The capture group of the last line matching ``pattern``, or None."""
+    for line in reversed(lines):
+        m = pattern.search(line)
+        if m:
+            return m.group(1)
+    return None
+
+
+def parse_endpoint(logs: str) -> EndpointInfo:
+    """Extract endpoint info from raw gluetun log text."""
+    ip_getter_lines = [
+        ln for ln in logs.splitlines() if "ip getter" in ln.lower() and "Public IP address" in ln
+    ]
+    wireguard_lines = [
+        ln for ln in logs.splitlines() if "wireguard" in ln.lower() and "Connecting to" in ln
+    ]
+
+    public_ip = "unknown"
+    country = "unknown"
+    city = "unknown"
+
+    if ip_getter_lines:
+        line = ip_getter_lines[-1]
+        ip_match = _PUBLIC_IP_RE.search(line)
+        if ip_match:
+            public_ip = ip_match.group(1)
+        loc_match = _LOCATION_RE.search(line)
+        if loc_match:
+            # Drop the trailing " - source: ..." annotation, then split fields.
+            location = loc_match.group(1).split(" - source:")[0]
+            fields = [f.strip() for f in location.split(",")]
+            if fields and fields[0]:
+                country = fields[0]
+            if len(fields) > 1 and fields[1]:
+                city = fields[1]
+
+    wg_server = _last_match(_WG_SERVER_RE, wireguard_lines) or "unknown"
+
+    return EndpointInfo(public_ip=public_ip, country=country, city=city, wg_server=wg_server)
+
+
+def get_endpoint_info(client: DockerClient, container: str) -> EndpointInfo:
+    """Fetch and parse the current endpoint from ``container``'s logs."""
+    try:
+        logs = client.logs(container)
+    except Exception:
+        return EndpointInfo()
+    return parse_endpoint(logs)

--- a/gluetun_monitor/histogram.py
+++ b/gluetun_monitor/histogram.py
@@ -35,7 +35,8 @@ def _bucket_key(value: int) -> int:
 
 def _bucket_value(key: int) -> int:
     """Representative value for a bucket — the midpoint that bounds the relative
-    error of every value in the bucket at ALPHA (2*gamma**k / (gamma+1))."""
+    error of every value in the bucket at ALPHA (2*gamma**k / (gamma+1)).
+    """
     return round(2 * _GAMMA**key / (_GAMMA + 1))
 
 
@@ -51,7 +52,8 @@ class LatencyHistogram:
 
     def add(self, ms: int) -> None:
         """Record one latency sample (ms). Values < 1 ms are clamped to 1 ms
-        (sub-millisecond resolution is meaningless for this monitor)."""
+        (sub-millisecond resolution is meaningless for this monitor).
+        """
         v = max(1, int(ms))
         key = _bucket_key(v)
         self.buckets[key] = self.buckets.get(key, 0) + 1
@@ -76,7 +78,7 @@ class LatencyHistogram:
         return _bucket_value(max(self.buckets))  # unreachable; defensive
 
     def summary(self) -> dict[str, int]:
-        """samples + exact avg/min/max + approximate p50/p90/p99 (ms)."""
+        """Samples + exact avg/min/max + approximate p50/p90/p99 (ms)."""
         if self.count == 0:
             return {"samples": 0, "avg": 0, "min": 0, "max": 0, "p50": 0, "p90": 0, "p99": 0}
         return {
@@ -113,7 +115,8 @@ class LatencyHistogram:
     @classmethod
     def from_dict(cls, data: object) -> LatencyHistogram:
         """Rebuild from :meth:`to_dict` output; anything malformed yields empty
-        (the stats sidecar is best-effort — a bad file must never crash startup)."""
+        (the stats sidecar is best-effort — a bad file must never crash startup).
+        """
         if not isinstance(data, dict):
             return cls()
         try:

--- a/gluetun_monitor/histogram.py
+++ b/gluetun_monitor/histogram.py
@@ -1,0 +1,134 @@
+"""Bounded-memory, all-time latency percentiles via a DDSketch-style histogram.
+
+The recent-latency ring (``SiteStat.recent_latencies``) answers "how is this site
+doing *now*" over the last N samples. This sketch answers the complementary
+"how has it behaved over its *whole life*" — without storing every sample.
+
+Exact all-time percentiles can't be kept in bounded memory (percentiles are order
+statistics; you'd need all the data). So we approximate, with a guarantee: values
+are bucketed on a logarithmic scale where consecutive bucket boundaries differ by
+a factor gamma = (1+a)/(1-a), and each bucket is represented by a single value.
+That makes every reported percentile **within `a` (relative) of the true value** —
+the DDSketch property (Dunning/Ertl). For latencies spanning ~1 ms to ~100 s at
+a = 5%, that's only a few dozen populated buckets per site (a sparse
+``{bucket: count}`` dict), it survives restarts, and it's **mergeable** (bucket
+counts simply add). Exact ``count``/``sum``/``min``/``max`` are tracked alongside,
+so only the percentiles are approximate.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass, field
+
+# Relative accuracy: every reported percentile is within this fraction of the true
+# value. 5% is far tighter than latency decisions need, at a few dozen buckets/site.
+ALPHA = 0.05
+_GAMMA = (1 + ALPHA) / (1 - ALPHA)
+_LOG_GAMMA = math.log(_GAMMA)
+
+
+def _bucket_key(value: int) -> int:
+    """Log-scale bucket index for a positive value (ceil(log_gamma(value)))."""
+    return math.ceil(math.log(value) / _LOG_GAMMA)
+
+
+def _bucket_value(key: int) -> int:
+    """Representative value for a bucket — the midpoint that bounds the relative
+    error of every value in the bucket at ALPHA (2*gamma**k / (gamma+1))."""
+    return round(2 * _GAMMA**key / (_GAMMA + 1))
+
+
+@dataclass
+class LatencyHistogram:
+    """A sparse log-bucketed histogram of latencies (ms) for all-time percentiles."""
+
+    count: int = 0
+    sum_ms: int = 0
+    min_ms: int = 0
+    max_ms: int = 0
+    buckets: dict[int, int] = field(default_factory=dict)
+
+    def add(self, ms: int) -> None:
+        """Record one latency sample (ms). Values < 1 ms are clamped to 1 ms
+        (sub-millisecond resolution is meaningless for this monitor)."""
+        v = max(1, int(ms))
+        key = _bucket_key(v)
+        self.buckets[key] = self.buckets.get(key, 0) + 1
+        if self.count == 0:
+            self.min_ms = self.max_ms = v
+        else:
+            self.min_ms = min(self.min_ms, v)
+            self.max_ms = max(self.max_ms, v)
+        self.count += 1
+        self.sum_ms += v
+
+    def quantile(self, q: float) -> int:
+        """Approximate q-quantile (0..1) in ms, within ALPHA relative error; 0 if empty."""
+        if self.count == 0:
+            return 0
+        rank = max(1, math.ceil(q * self.count))  # nearest-rank
+        cumulative = 0
+        for key in sorted(self.buckets):
+            cumulative += self.buckets[key]
+            if cumulative >= rank:
+                return _bucket_value(key)
+        return _bucket_value(max(self.buckets))  # unreachable; defensive
+
+    def summary(self) -> dict[str, int]:
+        """samples + exact avg/min/max + approximate p50/p90/p99 (ms)."""
+        if self.count == 0:
+            return {"samples": 0, "avg": 0, "min": 0, "max": 0, "p50": 0, "p90": 0, "p99": 0}
+        return {
+            "samples": self.count,
+            "avg": round(self.sum_ms / self.count),
+            "min": self.min_ms,
+            "max": self.max_ms,
+            "p50": self.quantile(0.50),
+            "p90": self.quantile(0.90),
+            "p99": self.quantile(0.99),
+        }
+
+    def merge(self, other: LatencyHistogram) -> None:
+        """Fold ``other`` into this one (the mergeable property — counts add)."""
+        if other.count == 0:
+            return
+        for key, cnt in other.buckets.items():
+            self.buckets[key] = self.buckets.get(key, 0) + cnt
+        self.min_ms = other.min_ms if self.count == 0 else min(self.min_ms, other.min_ms)
+        self.max_ms = max(self.max_ms, other.max_ms)
+        self.count += other.count
+        self.sum_ms += other.sum_ms
+
+    def to_dict(self) -> dict[str, object]:
+        """JSON-friendly form (bucket keys as strings, since JSON object keys are)."""
+        return {
+            "count": self.count,
+            "sum_ms": self.sum_ms,
+            "min_ms": self.min_ms,
+            "max_ms": self.max_ms,
+            "buckets": {str(k): v for k, v in self.buckets.items()},
+        }
+
+    @classmethod
+    def from_dict(cls, data: object) -> LatencyHistogram:
+        """Rebuild from :meth:`to_dict` output; anything malformed yields empty
+        (the stats sidecar is best-effort — a bad file must never crash startup)."""
+        if not isinstance(data, dict):
+            return cls()
+        try:
+            raw_buckets = data.get("buckets") or {}
+            buckets = {
+                int(k): int(v)
+                for k, v in raw_buckets.items()
+                if isinstance(v, int | float)
+            }
+            return cls(
+                count=int(data.get("count", 0)),
+                sum_ms=int(data.get("sum_ms", 0)),
+                min_ms=int(data.get("min_ms", 0)),
+                max_ms=int(data.get("max_ms", 0)),
+                buckets=buckets,
+            )
+        except (ValueError, TypeError, AttributeError):
+            return cls()

--- a/gluetun_monitor/logging_setup.py
+++ b/gluetun_monitor/logging_setup.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import itertools
 import logging
 import sys
+from logging.handlers import RotatingFileHandler
 from pathlib import Path
 from typing import TextIO
 
@@ -72,6 +73,8 @@ class Logger:
         level: str = "INFO",
         *,
         stream: TextIO | None = None,
+        max_bytes: int = 10 * 1024 * 1024,
+        backup_count: int = 5,
     ) -> None:
         # A private, non-propagating logger per instance keeps handlers isolated
         # (no duplicate lines, no interference with docker-py's own loggers).
@@ -89,7 +92,16 @@ class Logger:
         if log_file:
             try:
                 Path(log_file).parent.mkdir(parents=True, exist_ok=True)
-                file_handler = logging.FileHandler(log_file, encoding="utf-8")
+                file_handler: logging.Handler
+                if max_bytes > 0:
+                    # Size-capped rotation so the watchdog never fills its own disk
+                    # (Tenet 7). ~max_bytes x backup_count total.
+                    file_handler = RotatingFileHandler(
+                        log_file, maxBytes=max_bytes, backupCount=backup_count,
+                        encoding="utf-8",
+                    )
+                else:
+                    file_handler = logging.FileHandler(log_file, encoding="utf-8")
                 file_handler.setFormatter(formatter)
                 self._logger.addHandler(file_handler)
             except OSError:

--- a/gluetun_monitor/logging_setup.py
+++ b/gluetun_monitor/logging_setup.py
@@ -1,0 +1,100 @@
+"""Logging via stdlib ``logging``, formatted to match the v1.x bash output.
+
+Format: ``[YYYY-MM-DD HH:MM:SS] [LEVEL] message`` to stderr and (best-effort) the
+log file. The v1.x ``CHECK`` and ``ENDPOINT`` markers are registered as custom
+levels just above INFO so they survive the default LOG_LEVEL=INFO threshold;
+``WARNING`` renders as ``WARN`` to match v1.x. DEBUG is gated by LOG_LEVEL (new
+in v2 — bash always emitted it).
+"""
+
+from __future__ import annotations
+
+import itertools
+import logging
+import sys
+from pathlib import Path
+from typing import TextIO
+
+# Custom levels between INFO (20) and WARNING (30) so they're never suppressed
+# at the default INFO threshold but read as informational.
+CHECK_LEVEL = 21
+ENDPOINT_LEVEL = 22
+logging.addLevelName(CHECK_LEVEL, "CHECK")
+logging.addLevelName(ENDPOINT_LEVEL, "ENDPOINT")
+
+_LEVEL_BY_NAME: dict[str, int] = {
+    "DEBUG": logging.DEBUG,
+    "INFO": logging.INFO,
+    "CHECK": CHECK_LEVEL,
+    "ENDPOINT": ENDPOINT_LEVEL,
+    "WARN": logging.WARNING,
+    "WARNING": logging.WARNING,
+    "ERROR": logging.ERROR,
+}
+
+_TIMESTAMP_FMT = "%Y-%m-%d %H:%M:%S"
+_instance_counter = itertools.count()
+
+
+class _BashFormatter(logging.Formatter):
+    """Render ``[ts] [LEVEL] msg``, displaying WARNING as WARN (v1.x parity)."""
+
+    def format(self, record: logging.LogRecord) -> str:
+        if record.levelname == "WARNING":
+            record.levelname = "WARN"
+        return super().format(record)
+
+
+class Logger:
+    """Thin wrapper over a stdlib logger, with the v1.x convenience methods."""
+
+    def __init__(
+        self,
+        log_file: str | None = None,
+        level: str = "INFO",
+        *,
+        stream: TextIO | None = None,
+    ) -> None:
+        # A private, non-propagating logger per instance keeps handlers isolated
+        # (no duplicate lines, no interference with docker-py's own loggers).
+        self._logger = logging.getLogger(f"gluetun_monitor.{next(_instance_counter)}")
+        self._logger.setLevel(_LEVEL_BY_NAME.get(level.upper(), logging.INFO))
+        self._logger.propagate = False
+        self._logger.handlers.clear()
+
+        formatter = _BashFormatter("[%(asctime)s] [%(levelname)s] %(message)s", _TIMESTAMP_FMT)
+
+        stream_handler = logging.StreamHandler(stream if stream is not None else sys.stderr)
+        stream_handler.setFormatter(formatter)
+        self._logger.addHandler(stream_handler)
+
+        if log_file:
+            try:
+                Path(log_file).parent.mkdir(parents=True, exist_ok=True)
+                file_handler = logging.FileHandler(log_file, encoding="utf-8")
+                file_handler.setFormatter(formatter)
+                self._logger.addHandler(file_handler)
+            except OSError:
+                # Unwritable path: degrade to stderr-only rather than crash.
+                pass
+
+    def log(self, level: str, message: str) -> None:
+        self._logger.log(_LEVEL_BY_NAME.get(level.upper(), logging.INFO), message)
+
+    def debug(self, message: str) -> None:
+        self._logger.debug(message)
+
+    def info(self, message: str) -> None:
+        self._logger.info(message)
+
+    def warn(self, message: str) -> None:
+        self._logger.warning(message)
+
+    def error(self, message: str) -> None:
+        self._logger.error(message)
+
+    def check(self, message: str) -> None:
+        self._logger.log(CHECK_LEVEL, message)
+
+    def endpoint(self, message: str) -> None:
+        self._logger.log(ENDPOINT_LEVEL, message)

--- a/gluetun_monitor/logging_setup.py
+++ b/gluetun_monitor/logging_setup.py
@@ -54,7 +54,8 @@ def install_bash_format_on_root(level: str = "WARNING") -> None:
     """Route stray third-party logs (docker-py / urllib3) through the bash format
     too, so the container's stderr is uniform — not a mix of our
     ``[ts] [LEVEL] msg`` and Python's default ``WARNING:urllib3...``. Our own
-    Logger doesn't propagate, so this only affects library logging."""
+    Logger doesn't propagate, so this only affects library logging.
+    """
     root = logging.getLogger()
     root.setLevel(_LEVEL_BY_NAME.get(level.upper(), logging.WARNING))
     for handler in list(root.handlers):

--- a/gluetun_monitor/logging_setup.py
+++ b/gluetun_monitor/logging_setup.py
@@ -36,6 +36,9 @@ _TIMESTAMP_FMT = "%Y-%m-%d %H:%M:%S"
 _instance_counter = itertools.count()
 
 
+_BASH_FORMAT = "[%(asctime)s] [%(levelname)s] %(message)s"
+
+
 class _BashFormatter(logging.Formatter):
     """Render ``[ts] [LEVEL] msg``, displaying WARNING as WARN (v1.x parity)."""
 
@@ -44,6 +47,20 @@ class _BashFormatter(logging.Formatter):
         if record.levelname == "WARNING":
             record.levelname = "WARN"
         return super().format(record)
+
+
+def install_bash_format_on_root(level: str = "WARNING") -> None:
+    """Route stray third-party logs (docker-py / urllib3) through the bash format
+    too, so the container's stderr is uniform — not a mix of our
+    ``[ts] [LEVEL] msg`` and Python's default ``WARNING:urllib3...``. Our own
+    Logger doesn't propagate, so this only affects library logging."""
+    root = logging.getLogger()
+    root.setLevel(_LEVEL_BY_NAME.get(level.upper(), logging.WARNING))
+    for handler in list(root.handlers):
+        root.removeHandler(handler)
+    handler = logging.StreamHandler(sys.stderr)
+    handler.setFormatter(_BashFormatter(_BASH_FORMAT, _TIMESTAMP_FMT))
+    root.addHandler(handler)
 
 
 class Logger:
@@ -63,7 +80,7 @@ class Logger:
         self._logger.propagate = False
         self._logger.handlers.clear()
 
-        formatter = _BashFormatter("[%(asctime)s] [%(levelname)s] %(message)s", _TIMESTAMP_FMT)
+        formatter = _BashFormatter(_BASH_FORMAT, _TIMESTAMP_FMT)
 
         stream_handler = logging.StreamHandler(stream if stream is not None else sys.stderr)
         stream_handler.setFormatter(formatter)

--- a/gluetun_monitor/logging_setup.py
+++ b/gluetun_monitor/logging_setup.py
@@ -40,6 +40,7 @@ class _BashFormatter(logging.Formatter):
     """Render ``[ts] [LEVEL] msg``, displaying WARNING as WARN (v1.x parity)."""
 
     def format(self, record: logging.LogRecord) -> str:
+        """Format a record, displaying WARNING as WARN for v1.x parity."""
         if record.levelname == "WARNING":
             record.levelname = "WARN"
         return super().format(record)
@@ -79,22 +80,29 @@ class Logger:
                 pass
 
     def log(self, level: str, message: str) -> None:
+        """Emit ``message`` at the named level (string token, e.g. "CHECK")."""
         self._logger.log(_LEVEL_BY_NAME.get(level.upper(), logging.INFO), message)
 
     def debug(self, message: str) -> None:
+        """Detail line (suppressed unless LOG_LEVEL=DEBUG)."""
         self._logger.debug(message)
 
     def info(self, message: str) -> None:
+        """Normal operational message."""
         self._logger.info(message)
 
     def warn(self, message: str) -> None:
+        """Non-fatal issue (renders as the v1.x ``WARN`` token)."""
         self._logger.warning(message)
 
     def error(self, message: str) -> None:
+        """Failure / FAILED-state message."""
         self._logger.error(message)
 
     def check(self, message: str) -> None:
+        """Per-loop ``CHECK`` marker (v1.x start/end-of-cycle token)."""
         self._logger.log(CHECK_LEVEL, message)
 
     def endpoint(self, message: str) -> None:
+        """VPN ``ENDPOINT`` line (startup/failing/new)."""
         self._logger.log(ENDPOINT_LEVEL, message)

--- a/gluetun_monitor/monitor.py
+++ b/gluetun_monitor/monitor.py
@@ -116,30 +116,33 @@ class Monitor:
                                           self.config.timeout)
         )
 
+        # Site tests run *inside the gluetun container* (through the tunnel) — tag
+        # each line with that container so it's unambiguous where the test ran.
+        g = self.config.gluetun_container
         failed: list[str] = []
         for result in results:
             if record:
                 self.stats.record_poll(result.url, result.ok)
             if result.ok:
                 self.site_failures.reset(result.url)
-                self.log.debug(f"Site {result.url} passed ({result.duration_ms}ms)")
+                self.log.debug(f"[{g}] site {result.url}: ok ({result.duration_ms}ms)")
                 continue
             count = self.site_failures.fail(result.url)
             if count >= self.config.fail_threshold:
                 failed.append(result.url)
                 self.log.warn(
-                    f"Site {result.url} failed {count} consecutive times - "
+                    f"[{g}] site {result.url}: FAILED {count}x consecutive - "
                     f"THRESHOLD REACHED - {result.reason}"
                 )
             else:
                 remaining = self.config.fail_threshold - count
                 self.log.debug(
-                    f"Site {result.url} failed ({count}/{self.config.fail_threshold}) - "
-                    f"{remaining} more to trigger restart - {result.reason}"
+                    f"[{g}] site {result.url}: failed ({count}/{self.config.fail_threshold}, "
+                    f"{remaining} more to restart) - {result.reason}"
                 )
 
         if failed:
-            self.log.error(f"Failed sites (exceeded threshold): {' '.join(failed)}")
+            self.log.error(f"[{g}] failed sites (exceeded threshold): {' '.join(failed)}")
         return failed
 
     # ----- dependent phase (nodes 6-19) -----
@@ -228,7 +231,10 @@ class Monitor:
             return DependentProbe(dep, status, True, None, f"{host}: {dns.reason}",
                                   dns_unvalidated=True, interfaces=ifs)
         viable = dns.status is DnsStatus.OK
-        detail = f"{host}: DNS ok ({dns.tool})" if viable else f"{host}: DNS FAILED ({dns.reason})"
+        if viable:
+            detail = f"{host}: {dns.reason} [{dns.tool}]"  # what was actually validated
+        else:
+            detail = f"{host}: DNS FAILED — {dns.reason} [{dns.tool}]"
         return DependentProbe(dep, status, True, viable, detail, interfaces=ifs)
 
     def _resolve_dependents(self) -> list[str]:
@@ -276,54 +282,52 @@ class Monitor:
             dependents, lambda d: self._probe_dependent(d, gluetun_id, resolvable, ips)
         )
 
-        # State mutation + remediation decisions are single-threaded. Every
-        # dependent logs its L3 interface check (which interfaces / can it route)
-        # at DEBUG each loop, plus the L7 viability detail when applicable.
+        # State mutation + remediation decisions are single-threaded. Each
+        # dependent logs two ordered DEBUG lines: first the L3 network-path check
+        # (which interfaces / can it route out), THEN the L7 viability result —
+        # so the logs show the path was validated before the DNS/connect test.
         to_remediate: list[tuple[str, str]] = []
         for probe in probes:
-            iface = f"interface={probe.status.name.lower()} [{probe.interfaces}]"
+            dep = probe.name
+            self.log.debug(
+                f"[{dep}] interface check: {probe.status.name.lower()} [{probe.interfaces}]"
+            )
             if probe.status is InterfaceStatus.STRANDED:
-                self.log.debug(f"Dependent {probe.name}: {iface} -> {probe.reason}")
-                to_remediate.append((probe.name, probe.reason))
+                to_remediate.append((dep, probe.reason))
                 continue
             if probe.status is InterfaceStatus.UNKNOWN:
-                self.log.debug(
-                    f"Dependent {probe.name}: {iface}, running={probe.running} — {probe.reason}"
-                )
+                self.log.debug(f"[{dep}] {probe.reason} (running={probe.running})")
                 if not probe.running:
-                    to_remediate.append((probe.name, "not running (interface check unavailable)"))
+                    to_remediate.append((dep, "not running (interface check unavailable)"))
                 continue
             if probe.viability_ok is None:
-                if probe.dns_unvalidated and probe.name not in self._warned_dns_unvalidated:
+                if probe.dns_unvalidated and dep not in self._warned_dns_unvalidated:
                     # Can't run any DNS tool in this container — say so loudly once,
                     # and rely on the interface check (don't guess; Tenet 1).
                     self.log.warn(
-                        f"Cannot validate DNS for {probe.name} ({probe.reason}); "
+                        f"[{dep}] cannot validate DNS ({probe.reason}); "
                         f"relying on interface check only"
                     )
-                    self._warned_dns_unvalidated.add(probe.name)
+                    self._warned_dns_unvalidated.add(dep)
                 else:
-                    self.log.debug(f"Dependent {probe.name}: {iface}, {probe.reason}")
+                    self.log.debug(f"[{dep}] viability: {probe.reason}")
                 continue  # not tested -> no counter change
             # A validated result (ok or broken): re-arm the unvalidated warning.
-            self._warned_dns_unvalidated.discard(probe.name)
+            self._warned_dns_unvalidated.discard(dep)
             if probe.viability_ok:
-                self.dependent_failures.reset(probe.name)
-                self.log.debug(f"Dependent {probe.name}: {iface}, {probe.reason} [fails 0]")
+                self.dependent_failures.reset(dep)
+                self.log.debug(f"[{dep}] viability: {probe.reason} [fails 0]")
                 continue
-            count = self.dependent_failures.fail(probe.name)
+            count = self.dependent_failures.fail(dep)
             threshold = self.config.dependent_container_failures
             if count >= threshold:
-                to_remediate.append(
-                    (probe.name, f"{count} consecutive viability failures")
-                )
+                to_remediate.append((dep, f"{count} consecutive viability failures"))
                 self.log.warn(
-                    f"Dependent {probe.name}: {iface}, {probe.reason} "
-                    f"[fails {count}/{threshold} -> remediate]"
+                    f"[{dep}] viability: {probe.reason} [fails {count}/{threshold} -> remediate]"
                 )
             else:
                 self.log.debug(
-                    f"Dependent {probe.name}: {iface}, {probe.reason} [fails {count}/{threshold}]"
+                    f"[{dep}] viability: {probe.reason} [fails {count}/{threshold}]"
                 )
 
         for dep, reason in to_remediate:

--- a/gluetun_monitor/monitor.py
+++ b/gluetun_monitor/monitor.py
@@ -21,6 +21,7 @@ from .dependents import (
     discover_dependents,
     get_dependents,
     interface_check,
+    is_container_id,
     parse_csv_names,
     remediation_action,
 )
@@ -75,6 +76,8 @@ class Monitor:
         self._known_dependents: set[str] = set()
         # Dedup so a missing explicitly-listed dependent warns once, not per loop.
         self._warned_missing: set[str] = set()
+        # Dedup for the dangling-orphan warning (see _warn_dangling_orphans).
+        self._warned_orphans: set[str] = set()
 
     # ----- gluetun root test (nodes 2-3) -----
 
@@ -327,8 +330,50 @@ class Monitor:
         excluded = parse_csv_names(self.config.exclude_containers)
         if excluded:
             self.log.info(f"Excluded from management (EXCLUDE_CONTAINERS): {','.join(excluded)}")
+        self._warn_dangling_orphans()
         startup = get_endpoint_info(self.client, self.config.gluetun_container)
         self.log.endpoint(startup.format("STARTUP", "Monitor starting"))
+
+    def _warn_dangling_orphans(self) -> None:
+        """Surface a running container stranded on a *dead* netns parent that we
+        are not managing — most likely a gluetun dependent that was recreate-
+        stranded before the monitor started (its NetworkMode still points at
+        gluetun's old, now-gone id, so current-id discovery can't see it).
+
+        We *warn and suggest* DEPENDENT_CONTAINERS rather than recreate it: an
+        orphan whose parent is gone can't be confidently attributed to *this*
+        gluetun (it might belong to some other netns owner), and acting on that
+        guess could re-home or churn the wrong container (Tenet 1 — first, do no
+        harm). Names already listed or excluded are skipped (we either manage them
+        or were told not to touch them).
+        """
+        gluetun = self.config.gluetun_container
+        listed = (
+            set()
+            if self.config.dependent_containers == "auto"
+            else set(parse_csv_names(self.config.dependent_containers))
+        )
+        skip = listed | set(parse_csv_names(self.config.exclude_containers)) | {gluetun}
+        for cid in self.client.list_running_ids():
+            info = self.client.inspect(cid)
+            if info is None or info.name in skip:
+                continue
+            nm = info.network_mode
+            if not nm.startswith("container:"):
+                continue
+            target = nm.split(":", 1)[1]
+            if not is_container_id(target):
+                continue  # name-form target resolves normally; not a dangling id
+            if self.client.inspect(target) is not None:
+                continue  # the netns parent still exists — not stranded
+            if info.name not in self._warned_orphans:
+                self.log.warn(
+                    f"Container '{info.name}' is running but its network parent "
+                    f"({target[:12]}) no longer exists; if it depends on gluetun, add it "
+                    f"to DEPENDENT_CONTAINERS so it can be healed (not auto-recreated — "
+                    f"its parent can't be confirmed as gluetun)"
+                )
+                self._warned_orphans.add(info.name)
 
     def run(self) -> None:
         """Run forever: loop run_once + sleep CHECK_INTERVAL."""

--- a/gluetun_monitor/monitor.py
+++ b/gluetun_monitor/monitor.py
@@ -21,6 +21,7 @@ from .dependents import (
     discover_dependents,
     get_dependents,
     interface_check,
+    parse_csv_names,
     remediation_action,
 )
 from .endpoint import get_endpoint_info
@@ -175,12 +176,13 @@ class Monitor:
 
     def _resolve_dependents(self) -> list[str]:
         """Current dependent set: discovery (or manual list) unioned with the
-        remembered set, pruned to containers that still exist.
+        remembered set, pruned to containers that still exist, minus EXCLUDE.
 
         A name that came from an explicit ``DEPENDENT_CONTAINERS`` list but does
         not exist is a likely misconfiguration — warn loudly (deduped) rather
         than silently dropping it. Auto-discovery never yields a missing name, so
-        this only fires on the manual override.
+        this only fires on the manual override. ``EXCLUDE_CONTAINERS`` is then
+        subtracted: an excluded container is never managed, whatever the source.
         """
         current = get_dependents(self.client, self.config, self.log)
         present = {name: self.client.inspect(name) is not None for name in current}
@@ -196,7 +198,8 @@ class Monitor:
         self._known_dependents = {
             d for d in self._known_dependents if self.client.inspect(d) is not None
         }
-        return sorted(self._known_dependents)
+        excluded = set(parse_csv_names(self.config.exclude_containers))
+        return sorted(self._known_dependents - excluded)
 
     def run_dependent_phase(self, gluetun_id: str, sites: list[str]) -> None:
         """Probe every dependent and remediate those that fail (nodes 6-19)."""
@@ -309,6 +312,9 @@ class Monitor:
                 self.log.info("Dependent containers: auto-discovery enabled (none found currently)")
         else:
             self.log.info(f"Dependent containers (manual): {self.config.dependent_containers}")
+        excluded = parse_csv_names(self.config.exclude_containers)
+        if excluded:
+            self.log.info(f"Excluded from management (EXCLUDE_CONTAINERS): {','.join(excluded)}")
         startup = get_endpoint_info(self.client, self.config.gluetun_container)
         self.log.endpoint(startup.format("STARTUP", "Monitor starting"))
 

--- a/gluetun_monitor/monitor.py
+++ b/gluetun_monitor/monitor.py
@@ -165,6 +165,24 @@ class Monitor:
 
         if failed:
             self.log.error(f"[{gw}] restart triggered by: {' '.join(failed)}")
+
+        # One-line INFO heartbeat so the default log level explains each loop
+        # without the per-site DEBUG detail. Only on the primary poll (not the
+        # post-restart re-verify, which has its own "verified" line).
+        if record:
+            ok_results = [r for r in results if r.ok]
+            failing = [hostname_of(r.url) for r in results if not r.ok]
+            if failing:
+                self.log.info(
+                    f"[{gw}] sites: {len(ok_results)}/{len(results)} ok — "
+                    f"failing: {', '.join(failing)}"
+                )
+            else:
+                slowest = max(results, key=lambda r: r.duration_ms)
+                self.log.info(
+                    f"[{gw}] sites: {len(ok_results)}/{len(results)} ok "
+                    f"(slowest {slowest.duration_ms}ms: {hostname_of(slowest.url)})"
+                )
         return failed
 
     # ----- dependent phase (nodes 6-19) -----
@@ -381,6 +399,16 @@ class Monitor:
                 )
             else:
                 self.log.debug(f"[{tag}] reach fail: {probe.reason} [{count}/{threshold}]")
+
+        # INFO heartbeat for the dependent phase (mirrors the gateway summary).
+        healthy = len(probes) - len(to_remediate)
+        if to_remediate:
+            self.log.info(
+                f"dependents: {healthy}/{len(probes)} ok — "
+                f"remediating: {', '.join(dep for dep, _ in to_remediate)}"
+            )
+        else:
+            self.log.info(f"dependents: {healthy}/{len(probes)} ok")
 
         for dep, reason in to_remediate:
             if self.config.dry_run:

--- a/gluetun_monitor/monitor.py
+++ b/gluetun_monitor/monitor.py
@@ -1,0 +1,279 @@
+"""The monitor loop — the ADR-0006 per-loop state machine (nodes 1-22).
+
+Each loop: test gluetun's full URL set (root signal); restart + re-verify gluetun
+if it breaches threshold; then — every loop, the core #20 fix — probe each
+dependent (interface check + one shuffled viability name) and remediate the ones
+that fail. All counter/state mutation is single-threaded; only the per-dependent
+exec fan-out runs concurrently (bounded by MAX_PARALLEL_CHECKS).
+"""
+
+from __future__ import annotations
+
+import random
+import time
+from collections.abc import Callable
+from concurrent.futures import ThreadPoolExecutor
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from .connectivity import probe_site
+from .dependents import get_dependents, interface_check
+from .endpoint import get_endpoint_info
+from .recovery import remediate_dependent, restart_gluetun
+from .sites import ip_pool, parse_sites_conf, resolvable_pool
+from .state import Counter, InterfaceStatus
+
+if TYPE_CHECKING:
+    from .config import Config
+    from .docker_client import DockerClient
+    from .logging_setup import Logger
+
+Sleep = Callable[[float], None]
+
+
+@dataclass(frozen=True, slots=True)
+class DependentProbe:
+    """Read-only outcome of probing one dependent (no state mutation)."""
+
+    name: str
+    status: InterfaceStatus
+    running: bool
+    viability_ok: bool | None  # None = not tested (no pool / not live)
+    reason: str
+
+
+class Monitor:
+    """Owns the loop, the failure counters, and the shuffle RNG."""
+
+    def __init__(
+        self,
+        client: DockerClient,
+        config: Config,
+        logger: Logger,
+        *,
+        rng: random.Random | None = None,
+        sleep: Sleep = time.sleep,
+    ) -> None:
+        self.client = client
+        self.config = config
+        self.log = logger
+        self._rng = rng if rng is not None else random.Random()
+        self._sleep = sleep
+        self.site_failures = Counter()
+        self.dependent_failures = Counter()
+        self._last_site_count: int | None = None
+        # Dependents seen at least once. A dependent stranded by a gluetun
+        # *recreate* still points at the dead old id, so current-id discovery no
+        # longer matches it — but we remember it from before the recreate and
+        # keep checking it (ADR-0004: track across cycles). Pruned to existing.
+        self._known_dependents: set[str] = set()
+
+    # ----- gluetun root test (nodes 2-3) -----
+
+    def check_gluetun_sites(self, sites: list[str]) -> bool:
+        """Test the full URL set from inside gluetun. True if none breached threshold."""
+        if not sites:
+            self.log.warn("No sites configured to test")
+            return True
+
+        if self._last_site_count != len(sites):
+            if self._last_site_count is None:
+                self.log.info(f"Loaded {len(sites)} sites from {self.config.config_file}")
+            else:
+                self.log.info(
+                    f"Site count changed from {self._last_site_count} to {len(sites)}"
+                )
+            self._last_site_count = len(sites)
+
+        results = self._fan_out(
+            sites, lambda url: probe_site(self.client, self.config.gluetun_container, url,
+                                          self.config.timeout)
+        )
+
+        failed: list[str] = []
+        for result in results:
+            if result.ok:
+                self.site_failures.reset(result.url)
+                self.log.debug(f"Site {result.url} passed ({result.duration_ms}ms)")
+                continue
+            count = self.site_failures.fail(result.url)
+            if count >= self.config.fail_threshold:
+                failed.append(result.url)
+                self.log.warn(
+                    f"Site {result.url} failed {count} consecutive times - "
+                    f"THRESHOLD REACHED - {result.reason}"
+                )
+            else:
+                remaining = self.config.fail_threshold - count
+                self.log.debug(
+                    f"Site {result.url} failed ({count}/{self.config.fail_threshold}) - "
+                    f"{remaining} more to trigger restart - {result.reason}"
+                )
+
+        if failed:
+            self.log.error(f"Failed sites (exceeded threshold): {' '.join(failed)}")
+            return False
+        return True
+
+    # ----- dependent phase (nodes 6-19) -----
+
+    def _probe_dependent(
+        self, dep: str, resolvable: list[str], ips: list[str]
+    ) -> DependentProbe:
+        """Classify + viability-test one dependent. Pure I/O, no state mutation."""
+        status = interface_check(self.client, dep)
+
+        if status is InterfaceStatus.STRANDED:
+            # Node 10: re-check once — a real strand won't self-heal.
+            if interface_check(self.client, dep) is InterfaceStatus.STRANDED:
+                return DependentProbe(dep, status, False, None, "stranded loopback-only")
+            return DependentProbe(dep, InterfaceStatus.LIVE, True, None, "recovered on re-check")
+
+        if status is InterfaceStatus.UNKNOWN:
+            # Distroless / no shell: fall back to the running check (ADR-0006).
+            info = self.client.inspect(dep)
+            running = bool(info and info.running)
+            return DependentProbe(dep, status, running, None, "interface check unavailable")
+
+        # LIVE: one shuffled name per loop (the shuffle is load-bearing, ADR-0006).
+        pool = resolvable or ips
+        if not pool:
+            return DependentProbe(dep, status, True, None, "no test URLs")
+        url = self._rng.choice(pool)
+        result = probe_site(self.client, dep, url, self.config.timeout)
+        return DependentProbe(dep, status, True, result.ok, f"{url}: {result.reason}")
+
+    def _resolve_dependents(self) -> list[str]:
+        """Current dependent set: discovery (or manual list) unioned with the
+        remembered set, pruned to containers that still exist."""
+        current = get_dependents(self.client, self.config, self.log)
+        self._known_dependents.update(current)
+        self._known_dependents = {
+            d for d in self._known_dependents if self.client.inspect(d) is not None
+        }
+        return sorted(self._known_dependents)
+
+    def run_dependent_phase(self, gluetun_id: str, sites: list[str]) -> None:
+        """Probe every dependent and remediate those that fail (nodes 6-19)."""
+        dependents = self._resolve_dependents()
+        if not dependents:
+            return
+
+        resolvable = resolvable_pool(sites)
+        ips = ip_pool(sites)
+        if not resolvable and ips:
+            self.log.warn(
+                "No resolvable (hostname) test URLs — dependent DNS cannot be validated; "
+                "testing connectivity only against IP literals"
+            )
+
+        probes = self._fan_out(dependents, lambda d: self._probe_dependent(d, resolvable, ips))
+
+        # State mutation + remediation decisions are single-threaded.
+        to_remediate: list[tuple[str, str]] = []
+        for probe in probes:
+            if probe.status is InterfaceStatus.STRANDED:
+                to_remediate.append((probe.name, probe.reason))
+                continue
+            if probe.status is InterfaceStatus.UNKNOWN:
+                if not probe.running:
+                    to_remediate.append((probe.name, "not running (interface check unavailable)"))
+                continue
+            if probe.viability_ok is None:
+                continue  # nothing to test
+            if probe.viability_ok:
+                self.dependent_failures.reset(probe.name)
+                self.log.debug(f"Dependent {probe.name}: {probe.reason} [fails 0]")
+                continue
+            count = self.dependent_failures.fail(probe.name)
+            threshold = self.config.dependent_container_failures
+            if count >= threshold:
+                to_remediate.append(
+                    (probe.name, f"{count} consecutive distinct-name failures")
+                )
+                self.log.warn(
+                    f"Dependent {probe.name}: {probe.reason} "
+                    f"[fails {count}/{threshold} -> remediate]"
+                )
+            else:
+                self.log.debug(
+                    f"Dependent {probe.name}: {probe.reason} [fails {count}/{threshold}]"
+                )
+
+        for dep, reason in to_remediate:
+            self.log.warn(f"Remediating dependent {dep}: {reason}")
+            if remediate_dependent(
+                self.client, dep, gluetun_id, self.config, self.log, sleep=self._sleep
+            ):
+                self.dependent_failures.reset(dep)
+
+    # ----- one full loop iteration (node 1 -> 22, minus the sleep) -----
+
+    def run_once(self) -> None:
+        """Execute one monitoring cycle (no inter-loop sleep)."""
+        self.log.check("Start")
+
+        gluetun = self.client.inspect(self.config.gluetun_container)
+        if gluetun is None or not gluetun.running:
+            self.log.error("Gluetun container is not running!")
+            return
+        if gluetun.health != "healthy":
+            self.log.warn(f"Gluetun health status: {gluetun.health}")
+
+        try:
+            sites = parse_sites_conf(self.config.config_file)
+        except FileNotFoundError:
+            self.log.error(f"Sites config file not found: {self.config.config_file}")
+            return
+
+        if self.check_gluetun_sites(sites):
+            # Gluetun is up — proceed straight to the dependent phase (the #20 fix:
+            # dependents are checked every loop, not only after a gluetun failure).
+            self.run_dependent_phase(gluetun.id, sites)
+            return
+
+        # Gluetun breached threshold: restart + re-verify before touching dependents.
+        self.log.warn("Health check failed, initiating recovery...")
+        if not restart_gluetun(self.client, self.config, self.log, sleep=self._sleep):
+            self.log.error("Recovery failed - manual intervention may be required")
+            return
+
+        if not self.check_gluetun_sites(sites):
+            self.log.warn("Connectivity still failing after restart; leaving dependents untouched")
+            self.site_failures.reset_all()
+            return
+
+        self.log.info("Connectivity verified after restart")
+        self.site_failures.reset_all()
+        # Re-inspect: a restart keeps the same id, but be robust if it was recreated.
+        gluetun = self.client.inspect(self.config.gluetun_container) or gluetun
+        self.run_dependent_phase(gluetun.id, sites)
+
+    def announce(self) -> None:
+        """Log the post-prerequisite startup context (connection + endpoint)."""
+        if self.config.docker_host:
+            self.log.info(f"Docker connection: socket proxy ({self.config.docker_host})")
+        else:
+            self.log.info("Docker connection: local socket")
+        startup = get_endpoint_info(self.client, self.config.gluetun_container)
+        self.log.endpoint(startup.format("STARTUP", "Monitor starting"))
+
+    def run(self) -> None:
+        """Run forever: loop run_once + sleep CHECK_INTERVAL."""
+        while True:
+            try:
+                self.run_once()
+            except Exception as exc:  # never let one bad loop kill the monitor (ROC)
+                self.log.error(f"Unhandled error in monitor loop: {exc}")
+            self.log.check(f"End - Sleeping {self.config.check_interval}s")
+            self._sleep(self.config.check_interval)
+
+    # ----- helpers -----
+
+    def _fan_out[T, R](self, items: list[T], fn: Callable[[T], R]) -> list[R]:
+        """Run ``fn`` over ``items`` with a bounded thread pool, preserving order."""
+        workers = max(1, min(self.config.max_parallel_checks, len(items)))
+        if workers == 1:
+            return [fn(item) for item in items]
+        with ThreadPoolExecutor(max_workers=workers) as pool:
+            return list(pool.map(fn, items))

--- a/gluetun_monitor/monitor.py
+++ b/gluetun_monitor/monitor.py
@@ -187,7 +187,14 @@ class Monitor:
             return DependentProbe(dep, status, True, None, "no test URLs")
         url = self._rng.choice(pool)
         result = probe_site(self.client, dep, url, self.config.timeout)
-        return DependentProbe(dep, status, True, result.ok, f"{url}: {result.reason}")
+        # Viability fails ONLY on a DNS resolution failure. Because dependents
+        # share gluetun's (already-verified) netns, a non-DNS hiccup — a 4xx/5xx,
+        # a flaky site refusing the connection, a TLS quirk — is the remote's
+        # business, not a dependent fault (the strand case is caught upstream by
+        # the interface check). So any HTTP response *or* a resolved-but-unreached
+        # site counts as viable; only "couldn't resolve the name" does not.
+        viable = not result.dns_failed
+        return DependentProbe(dep, status, True, viable, f"{url}: {result.reason}")
 
     def _resolve_dependents(self) -> list[str]:
         """Current dependent set: discovery (or manual list) unioned with the

--- a/gluetun_monitor/monitor.py
+++ b/gluetun_monitor/monitor.py
@@ -266,6 +266,14 @@ class Monitor:
                 )
 
         for dep, reason in to_remediate:
+            if self.config.dry_run:
+                # Observe-only: report the decision + the action we'd take, but
+                # don't mutate. Counters are left intact (we didn't fix anything),
+                # so persistent intent keeps surfacing each loop.
+                info = self.client.inspect(dep)
+                action = remediation_action(info, gluetun_id).name if info else "UNKNOWN"
+                self.log.warn(f"[DRY-RUN] would remediate {dep}: {reason} (action={action})")
+                continue
             self.log.warn(f"Remediating dependent {dep}: {reason}")
             if remediate_dependent(
                 self.client, dep, gluetun_id, self.config, self.log, sleep=self._sleep
@@ -298,6 +306,15 @@ class Monitor:
 
         # Gluetun breached threshold: restart + re-verify before touching dependents.
         self.log.warn("Health check failed, initiating recovery...")
+        if self.config.dry_run:
+            # Observe-only: don't restart gluetun (can't, without mutating). Log
+            # the intent and still probe dependents so their decisions are visible.
+            self.log.warn(
+                "[DRY-RUN] would restart gluetun and re-verify before touching "
+                "dependents; skipping (observe-only)"
+            )
+            self.run_dependent_phase(gluetun.id, sites)
+            return
         if not restart_gluetun(self.client, self.config, self.log, sleep=self._sleep):
             self.log.error("Recovery failed - manual intervention may be required")
             return

--- a/gluetun_monitor/monitor.py
+++ b/gluetun_monitor/monitor.py
@@ -365,6 +365,7 @@ class Monitor:
                 self.log.warn(f"[DRY-RUN] would remediate {dep}: {reason} (action={action})")
                 continue
             self.log.warn(f"Remediating dependent {dep}: {reason}")
+            self.stats.record_dependent_remediation()
             if remediate_dependent(
                 self.client, dep, gluetun_id, self.config, self.log, sleep=self._sleep
             ):
@@ -375,6 +376,7 @@ class Monitor:
     def run_once(self) -> None:
         """Execute one monitoring cycle (no inter-loop sleep)."""
         self.log.check("Start")
+        self.stats.record_loop()  # monitor-wide: loop count + accumulated runtime
 
         gluetun = self.client.inspect(self.config.gluetun_container)
         if gluetun is None or not gluetun.running:
@@ -415,6 +417,7 @@ class Monitor:
             )
             self.run_dependent_phase(gluetun.id, sites)
             return
+        self.stats.record_gluetun_restart()  # monitor-wide count of actual restarts
         if not restart_gluetun(self.client, self.config, self.log, sleep=self._sleep):
             self.log.error("Recovery failed - manual intervention may be required")
             return
@@ -450,6 +453,7 @@ class Monitor:
         if adv.site == self._advised_site:
             return  # already warned about this site this episode
         self._advised_site = adv.site
+        self.stats.record_advisory()
         self.log.warn(
             f"FLAKY SITE: {adv.site} caused {adv.site_restarts} of the last "
             f"{adv.total_restarts} gluetun restarts over the last "

--- a/gluetun_monitor/monitor.py
+++ b/gluetun_monitor/monitor.py
@@ -306,9 +306,15 @@ class Monitor:
         self._warned_missing &= {name for name, exists in present.items() if not exists}
 
         self._known_dependents.update(name for name, exists in present.items() if exists)
-        self._known_dependents = {
-            d for d in self._known_dependents if self.client.inspect(d) is not None
-        }
+        # Prune the remembered set to containers that still exist. Reuse the
+        # existence we already learned for the current names; only inspect a
+        # remembered name we haven't already checked this loop (e.g. one stranded
+        # by a gluetun recreate, so current-id discovery no longer surfaces it).
+        existence = dict(present)
+        for d in self._known_dependents:
+            if d not in existence:
+                existence[d] = self.client.inspect(d) is not None
+        self._known_dependents = {d for d in self._known_dependents if existence.get(d, False)}
         excluded = set(parse_csv_names(self.config.exclude_containers))
         return sorted(self._known_dependents - excluded)
 

--- a/gluetun_monitor/monitor.py
+++ b/gluetun_monitor/monitor.py
@@ -131,6 +131,12 @@ class Monitor:
         ``gluetun_id`` is the current gluetun container id, needed for the
         inspect-based fallback below.
         """
+        # Optional per-dispatch jitter (default 0 = no-op) to de-sync the burst
+        # of execs across live dependents (ADR-0006). The concurrency cap is the
+        # primary bound; this only spreads start times when explicitly enabled.
+        if self.config.max_jitter_ms > 0:
+            self._sleep(self._rng.uniform(0, self.config.max_jitter_ms) / 1000.0)
+
         status = interface_check(self.client, dep)
 
         if status is InterfaceStatus.STRANDED:
@@ -166,7 +172,13 @@ class Monitor:
                 )
             return DependentProbe(dep, status, running, None, "interface check unavailable")
 
-        # LIVE: one shuffled name per loop (the shuffle is load-bearing, ADR-0006).
+        # LIVE. The viability layer (L7 DNS + connectivity probe) is opt-out: with
+        # it off, a live, non-stranded dependent is judged healthy on the interface
+        # check alone — no URL fetch (ADR-0006; the interface check stays mandatory).
+        if not self.config.dependent_viability:
+            return DependentProbe(dep, status, True, None, "viability disabled (interface only)")
+
+        # one shuffled name per loop (the shuffle is load-bearing, ADR-0006).
         pool = resolvable or ips
         if not pool:
             return DependentProbe(dep, status, True, None, "no test URLs")

--- a/gluetun_monitor/monitor.py
+++ b/gluetun_monitor/monitor.py
@@ -148,7 +148,7 @@ class Monitor:
             # (dead) gluetun is stranded exactly as in #20, just invisible to the
             # interface check. A matching id (RESTART) or an unresolvable name-form
             # target (TRY_RESTART) is left alone: we can't prove a strand there and
-            # must not churn a healthy container (Tenet 2). The id comparison is
+            # must not churn a healthy container (Tenet 3). The id comparison is
             # stable (no flap), so unlike the interface path it needs no re-check.
             info = self.client.inspect(dep)
             running = bool(info and info.running)

--- a/gluetun_monitor/monitor.py
+++ b/gluetun_monitor/monitor.py
@@ -25,9 +25,10 @@ from .dependents import (
     parse_csv_names,
     remediation_action,
 )
+from .dns_check import DnsStatus, validate_dns
 from .endpoint import get_endpoint_info
 from .recovery import remediate_dependent, restart_gluetun
-from .sites import ip_pool, load_sites, resolvable_pool
+from .sites import hostname_of, ip_pool, is_ip_literal, load_sites, resolvable_pool
 from .state import Counter, InterfaceStatus, RemediationAction
 
 if TYPE_CHECKING:
@@ -45,8 +46,9 @@ class DependentProbe:
     name: str
     status: InterfaceStatus
     running: bool
-    viability_ok: bool | None  # None = not tested (no pool / not live)
+    viability_ok: bool | None  # None = not tested (no pool / not live / unvalidatable)
     reason: str
+    dns_unvalidated: bool = False  # True = no usable DNS tool in the container
 
 
 class Monitor:
@@ -78,6 +80,8 @@ class Monitor:
         self._warned_missing: set[str] = set()
         # Dedup for the dangling-orphan warning (see _warn_dangling_orphans).
         self._warned_orphans: set[str] = set()
+        # Dedup for "can't validate DNS (no usable tool)" — re-armed if it later validates.
+        self._warned_dns_unvalidated: set[str] = set()
 
     # ----- gluetun root test (nodes 2-3) -----
 
@@ -186,15 +190,23 @@ class Monitor:
         if not pool:
             return DependentProbe(dep, status, True, None, "no test URLs")
         url = self._rng.choice(pool)
-        result = probe_site(self.client, dep, url, self.config.timeout)
-        # Viability fails ONLY on a DNS resolution failure. Because dependents
-        # share gluetun's (already-verified) netns, a non-DNS hiccup — a 4xx/5xx,
-        # a flaky site refusing the connection, a TLS quirk — is the remote's
-        # business, not a dependent fault (the strand case is caught upstream by
-        # the interface check). So any HTTP response *or* a resolved-but-unreached
-        # site counts as viable; only "couldn't resolve the name" does not.
-        viable = not result.dns_failed
-        return DependentProbe(dep, status, True, viable, f"{url}: {result.reason}")
+        host = hostname_of(url)
+        if is_ip_literal(host):
+            # An IP literal has nothing to resolve; the phase already WARNed that
+            # dependent DNS can't be validated in an IP-only config.
+            return DependentProbe(dep, status, True, None, f"{url}: IP literal (DNS not validated)")
+
+        # Validate the dependent's OWN DNS resolution (the only per-container
+        # fault — see dns_check). Three outcomes: OK -> viable; BROKEN -> the
+        # fault we act on; UNVALIDATED -> can't tell (no tool), don't guess.
+        dns = validate_dns(self.client, dep, url, host, self.config.timeout)
+        if dns.status is DnsStatus.UNVALIDATED:
+            return DependentProbe(
+                dep, status, True, None, f"{host}: {dns.reason}", dns_unvalidated=True
+            )
+        viable = dns.status is DnsStatus.OK
+        detail = f"{host}: DNS ok ({dns.tool})" if viable else f"{host}: DNS FAILED ({dns.reason})"
+        return DependentProbe(dep, status, True, viable, detail)
 
     def _resolve_dependents(self) -> list[str]:
         """Current dependent set: discovery (or manual list) unioned with the
@@ -252,7 +264,17 @@ class Monitor:
                     to_remediate.append((probe.name, "not running (interface check unavailable)"))
                 continue
             if probe.viability_ok is None:
-                continue  # nothing to test
+                if probe.dns_unvalidated and probe.name not in self._warned_dns_unvalidated:
+                    # Can't run any DNS tool in this container — say so loudly once,
+                    # and rely on the interface check (don't guess; Tenet 1).
+                    self.log.warn(
+                        f"Cannot validate DNS for {probe.name} ({probe.reason}); "
+                        f"relying on interface check only"
+                    )
+                    self._warned_dns_unvalidated.add(probe.name)
+                continue  # not tested -> no counter change
+            # A validated result (ok or broken): re-arm the unvalidated warning.
+            self._warned_dns_unvalidated.discard(probe.name)
             if probe.viability_ok:
                 self.dependent_failures.reset(probe.name)
                 self.log.debug(f"Dependent {probe.name}: {probe.reason} [fails 0]")

--- a/gluetun_monitor/monitor.py
+++ b/gluetun_monitor/monitor.py
@@ -28,6 +28,7 @@ from .dependents import (
 from .dns_check import DnsStatus, validate_dns
 from .endpoint import get_endpoint_info
 from .recovery import remediate_dependent, restart_gluetun
+from .site_stats import SiteStatsStore, format_window
 from .sites import hostname_of, ip_pool, is_ip_literal, load_sites, resolvable_pool
 from .state import Counter, InterfaceStatus, RemediationAction
 
@@ -62,12 +63,17 @@ class Monitor:
         *,
         rng: random.Random | None = None,
         sleep: Sleep = time.sleep,
+        stats: SiteStatsStore | None = None,
     ) -> None:
         self.client = client
         self.config = config
         self.log = logger
         self._rng = rng if rng is not None else random.Random()
         self._sleep = sleep
+        # Persistent per-site stats (ADR-0008). Injectable for tests.
+        self.stats = stats if stats is not None else SiteStatsStore(config.stats_file)
+        self._loops_since_save = 0
+        self._advised_site: str | None = None  # dedup the flaky-site advisory
         self.site_failures = Counter()
         self.dependent_failures = Counter()
         self._last_site_count: int | None = None
@@ -85,11 +91,17 @@ class Monitor:
 
     # ----- gluetun root test (nodes 2-3) -----
 
-    def check_gluetun_sites(self, sites: list[str]) -> bool:
-        """Test the full URL set from inside gluetun. True if none breached threshold."""
+    def check_gluetun_sites(self, sites: list[str], *, record: bool = True) -> list[str]:
+        """Test the full URL set from inside gluetun. Return the sites that have
+        breached FAIL_THRESHOLD (empty = healthy).
+
+        ``record`` updates the persistent per-site stats (ADR-0008); it's True for
+        the primary loop test and False for the post-restart re-verify (so a loop
+        counts as one poll per site, not two).
+        """
         if not sites:
             self.log.warn("No sites configured to test")
-            return True
+            return []
 
         if self._last_site_count != len(sites):
             if self._last_site_count is None:
@@ -105,6 +117,8 @@ class Monitor:
 
         failed: list[str] = []
         for result in results:
+            if record:
+                self.stats.record_poll(result.url, result.ok)
             if result.ok:
                 self.site_failures.reset(result.url)
                 self.log.debug(f"Site {result.url} passed ({result.duration_ms}ms)")
@@ -125,8 +139,7 @@ class Monitor:
 
         if failed:
             self.log.error(f"Failed sites (exceeded threshold): {' '.join(failed)}")
-            return False
-        return True
+        return failed
 
     # ----- dependent phase (nodes 6-19) -----
 
@@ -327,14 +340,24 @@ class Monitor:
         # non-empty set; a runtime edit down to empty just tests nothing this loop.
         sites = load_sites(self.config.config_file, self.config.sites_env)
 
-        if self.check_gluetun_sites(sites):
+        breached = self.check_gluetun_sites(sites)
+        if not breached:
             # Gluetun is up — proceed straight to the dependent phase (the #20 fix:
             # dependents are checked every loop, not only after a gluetun failure).
             self.run_dependent_phase(gluetun.id, sites)
+            self._maybe_save_stats()
             return
 
         # Gluetun breached threshold: restart + re-verify before touching dependents.
         self.log.warn("Health check failed, initiating recovery...")
+        # Attribute the restart to the breached site(s) and surface a flaky-site
+        # advisory if one site keeps causing them (ADR-0008). Persist now — a
+        # restart is an important, infrequent event worth not losing.
+        for site in breached:
+            self.stats.record_restart(site)
+        self._emit_advisory()
+        self.stats.save()
+
         if self.config.dry_run:
             # Observe-only: don't restart gluetun (can't, without mutating). Log
             # the intent and still probe dependents so their decisions are visible.
@@ -348,7 +371,8 @@ class Monitor:
             self.log.error("Recovery failed - manual intervention may be required")
             return
 
-        if not self.check_gluetun_sites(sites):
+        # Re-verify without recording (so the loop counts one poll per site, not two).
+        if self.check_gluetun_sites(sites, record=False):
             self.log.warn("Connectivity still failing after restart; leaving dependents untouched")
             self.site_failures.reset_all()
             return
@@ -358,6 +382,34 @@ class Monitor:
         # Re-inspect: a restart keeps the same id, but be robust if it was recreated.
         gluetun = self.client.inspect(self.config.gluetun_container) or gluetun
         self.run_dependent_phase(gluetun.id, sites)
+        self._maybe_save_stats()
+
+    def _emit_advisory(self) -> None:
+        """Warn (deduped) when one site dominates recent gluetun restarts."""
+        adv = self.stats.advisory(
+            self.config.advisory_window,
+            self.config.advisory_min_restarts,
+            self.config.advisory_dominance,
+        )
+        if adv is None:
+            self._advised_site = None
+            return
+        if adv.site == self._advised_site:
+            return  # already warned about this site this episode
+        self._advised_site = adv.site
+        self.log.warn(
+            f"FLAKY SITE: {adv.site} caused {adv.site_restarts} of the last "
+            f"{adv.total_restarts} gluetun restarts over the last "
+            f"{format_window(adv.window_seconds)} — it may be flaky; consider "
+            f"reviewing or removing it from sites.conf"
+        )
+
+    def _maybe_save_stats(self) -> None:
+        """Persist stats every STATS_SAVE_EVERY loops (best-effort)."""
+        self._loops_since_save += 1
+        if self._loops_since_save >= self.config.stats_save_every:
+            self.stats.save()
+            self._loops_since_save = 0
 
     def announce(self) -> None:
         """Log the post-prerequisite startup context (connection, dependents, endpoint)."""

--- a/gluetun_monitor/monitor.py
+++ b/gluetun_monitor/monitor.py
@@ -213,31 +213,53 @@ class Monitor:
             return DependentProbe(dep, status, True, None, "viability disabled (interface only)",
                                   interfaces=ifs)
 
-        # one shuffled name per loop (the shuffle is load-bearing, ADR-0006).
+        # Sample one (default) or more shuffled names per loop. The shuffle is
+        # load-bearing (ADR-0006); DEPENDENT_VIABILITY_SAMPLES lets an operator
+        # widen it (N, or -1 = all), at N execs/dependent/loop — usually redundant
+        # since dependents share gluetun's netns (only DNS differs).
         pool = resolvable or ips
         if not pool:
             return DependentProbe(dep, status, True, None, "no test URLs", interfaces=ifs)
-        url = self._rng.choice(pool)
-        host = hostname_of(url)
-        if is_ip_literal(host):
-            # An IP literal has nothing to resolve; the phase already WARNed that
-            # dependent DNS can't be validated in an IP-only config.
-            return DependentProbe(dep, status, True, None,
-                                  f"{url}: IP literal (DNS not validated)", interfaces=ifs)
+        n = self.config.dependent_viability_samples
+        k = len(pool) if (n < 0 or n >= len(pool)) else max(1, n)
+        chosen = self._rng.sample(pool, k)
 
-        # Validate the dependent's OWN DNS resolution (the only per-container
-        # fault — see dns_check). Three outcomes: OK -> viable; BROKEN -> the
-        # fault we act on; UNVALIDATED -> can't tell (no tool), don't guess.
-        dns = validate_dns(self.client, dep, url, host, self.config.timeout)
-        if dns.status is DnsStatus.UNVALIDATED:
-            return DependentProbe(dep, status, True, None, f"{host}: {dns.reason}",
-                                  dns_unvalidated=True, interfaces=ifs)
-        viable = dns.status is DnsStatus.OK
-        if viable:
-            detail = f"{host}: {dns.reason} [{dns.tool}]"  # what was actually validated
-        else:
-            detail = f"{host}: DNS FAILED — {dns.reason} [{dns.tool}]"
-        return DependentProbe(dep, status, True, viable, detail, interfaces=ifs)
+        # Only hostnames exercise DNS; IP literals have nothing to resolve.
+        resolvable_chosen = [
+            (u, hostname_of(u)) for u in chosen if not is_ip_literal(hostname_of(u))
+        ]
+        if not resolvable_chosen:
+            return DependentProbe(dep, status, True, None,
+                                  f"{chosen[0]}: IP literal (DNS not validated)", interfaces=ifs)
+
+        # Validate the dependent's OWN DNS resolution (the only per-container fault
+        # — dns_check). Viable if ANY sampled site resolves; not-viable only if
+        # ALL sampled resolvable sites fail DNS; unvalidated if no tool exists.
+        results = [
+            (h, validate_dns(self.client, dep, u, h, self.config.timeout))
+            for (u, h) in resolvable_chosen
+        ]
+        oks = [(h, r) for (h, r) in results if r.status is DnsStatus.OK]
+        broken = [(h, r) for (h, r) in results if r.status is DnsStatus.BROKEN]
+        if oks:
+            h, r = oks[0]
+            detail = (
+                f"{h}: {r.reason} [{r.tool}]" if len(results) == 1
+                else f"{len(oks)}/{len(results)} sampled sites resolved "
+                     f"(e.g. {h}: {r.reason} [{r.tool}])"
+            )
+            return DependentProbe(dep, status, True, True, detail, interfaces=ifs)
+        if broken:
+            h, r = broken[0]
+            detail = (
+                f"{h}: DNS FAILED — {r.reason} [{r.tool}]" if len(results) == 1
+                else f"all {len(results)} sampled sites failed DNS (e.g. {h}: {r.reason})"
+            )
+            return DependentProbe(dep, status, True, False, detail, interfaces=ifs)
+        # All sampled sites were UNVALIDATED (no usable DNS tool in the container).
+        h, r = results[0]
+        return DependentProbe(dep, status, True, None, f"{h}: {r.reason}",
+                              dns_unvalidated=True, interfaces=ifs)
 
     def _resolve_dependents(self) -> list[str]:
         """Current dependent set: discovery (or manual list) unioned with the

--- a/gluetun_monitor/monitor.py
+++ b/gluetun_monitor/monitor.py
@@ -385,6 +385,17 @@ class Monitor:
         if gluetun.health != "healthy":
             self.log.warn(f"Gluetun health status: {gluetun.health}")
 
+        # Observability before the site curls: log the gateway's own L3 interfaces
+        # (symmetry with the dependent checks; presence of tun0 = tunnel up at L3).
+        # We do NOT gate on this — the site tests are the authoritative tunnel
+        # check (ADR-0001); this is just visibility.
+        gw_ifaces = list_interfaces(self.client, self.config.gluetun_container)
+        self.log.debug(
+            f"[gateway:{self.config.gluetun_container}] interface check: "
+            f"{classify_interfaces(gw_ifaces).name.lower()} "
+            f"[{','.join(sorted(gw_ifaces)) if gw_ifaces else 'unknown'}]"
+        )
+
         # Re-read every loop so editing sites.conf is picked up live (the SITES
         # env contribution is fixed at startup). Startup validation guarantees a
         # non-empty set; a runtime edit down to empty just tests nothing this loop.

--- a/gluetun_monitor/monitor.py
+++ b/gluetun_monitor/monitor.py
@@ -116,33 +116,35 @@ class Monitor:
                                           self.config.timeout)
         )
 
-        # Site tests run *inside the gluetun container* (through the tunnel) — tag
-        # each line with that container so it's unambiguous where the test ran.
-        g = self.config.gluetun_container
+        # Site tests run *inside the gluetun container* (the VPN gateway, through
+        # the tunnel). Tag each line with the role + container — "[gateway:<name>]"
+        # — so it's unambiguous what kind of container and which one (cf.
+        # "[dependent:<name>]" below). Greppable: `grep gateway:` / `grep dependent:`.
+        gw = f"gateway:{self.config.gluetun_container}"
         failed: list[str] = []
         for result in results:
             if record:
                 self.stats.record_poll(result.url, result.ok)
             if result.ok:
                 self.site_failures.reset(result.url)
-                self.log.debug(f"[{g}] site {result.url}: ok ({result.duration_ms}ms)")
+                self.log.debug(f"[{gw}] site {result.url}: ok ({result.duration_ms}ms)")
                 continue
             count = self.site_failures.fail(result.url)
             if count >= self.config.fail_threshold:
                 failed.append(result.url)
                 self.log.warn(
-                    f"[{g}] site {result.url}: FAILED {count}x consecutive - "
+                    f"[{gw}] site {result.url}: FAILED {count}x consecutive - "
                     f"THRESHOLD REACHED - {result.reason}"
                 )
             else:
                 remaining = self.config.fail_threshold - count
                 self.log.debug(
-                    f"[{g}] site {result.url}: failed ({count}/{self.config.fail_threshold}, "
+                    f"[{gw}] site {result.url}: failed ({count}/{self.config.fail_threshold}, "
                     f"{remaining} more to restart) - {result.reason}"
                 )
 
         if failed:
-            self.log.error(f"[{g}] failed sites (exceeded threshold): {' '.join(failed)}")
+            self.log.error(f"[{gw}] failed sites (exceeded threshold): {' '.join(failed)}")
         return failed
 
     # ----- dependent phase (nodes 6-19) -----
@@ -289,14 +291,15 @@ class Monitor:
         to_remediate: list[tuple[str, str]] = []
         for probe in probes:
             dep = probe.name
+            tag = f"dependent:{dep}"  # role + name, mirrors "[gateway:<name>]"
             self.log.debug(
-                f"[{dep}] interface check: {probe.status.name.lower()} [{probe.interfaces}]"
+                f"[{tag}] interface check: {probe.status.name.lower()} [{probe.interfaces}]"
             )
             if probe.status is InterfaceStatus.STRANDED:
                 to_remediate.append((dep, probe.reason))
                 continue
             if probe.status is InterfaceStatus.UNKNOWN:
-                self.log.debug(f"[{dep}] {probe.reason} (running={probe.running})")
+                self.log.debug(f"[{tag}] {probe.reason} (running={probe.running})")
                 if not probe.running:
                     to_remediate.append((dep, "not running (interface check unavailable)"))
                 continue
@@ -305,29 +308,29 @@ class Monitor:
                     # Can't run any DNS tool in this container — say so loudly once,
                     # and rely on the interface check (don't guess; Tenet 1).
                     self.log.warn(
-                        f"[{dep}] cannot validate DNS ({probe.reason}); "
+                        f"[{tag}] cannot validate DNS ({probe.reason}); "
                         f"relying on interface check only"
                     )
                     self._warned_dns_unvalidated.add(dep)
                 else:
-                    self.log.debug(f"[{dep}] viability: {probe.reason}")
+                    self.log.debug(f"[{tag}] viability: {probe.reason}")
                 continue  # not tested -> no counter change
             # A validated result (ok or broken): re-arm the unvalidated warning.
             self._warned_dns_unvalidated.discard(dep)
             if probe.viability_ok:
                 self.dependent_failures.reset(dep)
-                self.log.debug(f"[{dep}] viability: {probe.reason} [fails 0]")
+                self.log.debug(f"[{tag}] viability: {probe.reason} [fails 0]")
                 continue
             count = self.dependent_failures.fail(dep)
             threshold = self.config.dependent_container_failures
             if count >= threshold:
                 to_remediate.append((dep, f"{count} consecutive viability failures"))
                 self.log.warn(
-                    f"[{dep}] viability: {probe.reason} [fails {count}/{threshold} -> remediate]"
+                    f"[{tag}] viability: {probe.reason} [fails {count}/{threshold} -> remediate]"
                 )
             else:
                 self.log.debug(
-                    f"[{dep}] viability: {probe.reason} [fails {count}/{threshold}]"
+                    f"[{tag}] viability: {probe.reason} [fails {count}/{threshold}]"
                 )
 
         for dep, reason in to_remediate:

--- a/gluetun_monitor/monitor.py
+++ b/gluetun_monitor/monitor.py
@@ -63,7 +63,8 @@ def _fmt_reach(host: str, r: DnsResult) -> str:
 
 def _link_line(status: str, interfaces: str) -> str:
     """L3 link verdict + interface list: ``live: eth0,lo,tun0`` / ``stranded: lo``
-    / ``unknown`` (no list when the interfaces couldn't be read)."""
+    / ``unknown`` (no list when the interfaces couldn't be read).
+    """
     return f"{status}: {interfaces}" if interfaces and interfaces != "unknown" else status
 
 
@@ -545,7 +546,8 @@ class Monitor:
 
     def _save_stats(self) -> None:
         """Prune stale sites (retention), then persist — every loop (best-effort;
-        a few-KB atomic write, so no throttle needed)."""
+        a few-KB atomic write, so no throttle needed).
+        """
         pruned = self.stats.prune_stale(self.config.stats_retention_days * 86400)
         if pruned:
             self.log.info(

--- a/gluetun_monitor/monitor.py
+++ b/gluetun_monitor/monitor.py
@@ -216,8 +216,8 @@ class Monitor:
             info = self.client.inspect(dep)
             running = bool(info and info.running)
             if (
-                running
-                and info is not None
+                info is not None
+                and info.running
                 and remediation_action(info, gluetun_id) is RemediationAction.RECREATE
             ):
                 return DependentProbe(

--- a/gluetun_monitor/monitor.py
+++ b/gluetun_monitor/monitor.py
@@ -17,11 +17,16 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 from .connectivity import probe_site
-from .dependents import get_dependents, interface_check
+from .dependents import (
+    discover_dependents,
+    get_dependents,
+    interface_check,
+    remediation_action,
+)
 from .endpoint import get_endpoint_info
 from .recovery import remediate_dependent, restart_gluetun
-from .sites import ip_pool, parse_sites_conf, resolvable_pool
-from .state import Counter, InterfaceStatus
+from .sites import ip_pool, load_sites, resolvable_pool
+from .state import Counter, InterfaceStatus, RemediationAction
 
 if TYPE_CHECKING:
     from .config import Config
@@ -67,6 +72,8 @@ class Monitor:
         # longer matches it — but we remember it from before the recreate and
         # keep checking it (ADR-0004: track across cycles). Pruned to existing.
         self._known_dependents: set[str] = set()
+        # Dedup so a missing explicitly-listed dependent warns once, not per loop.
+        self._warned_missing: set[str] = set()
 
     # ----- gluetun root test (nodes 2-3) -----
 
@@ -78,11 +85,9 @@ class Monitor:
 
         if self._last_site_count != len(sites):
             if self._last_site_count is None:
-                self.log.info(f"Loaded {len(sites)} sites from {self.config.config_file}")
+                self.log.info(f"Loaded {len(sites)} sites (sites.conf + SITES env)")
             else:
-                self.log.info(
-                    f"Site count changed from {self._last_site_count} to {len(sites)}"
-                )
+                self.log.info(f"Site count changed from {self._last_site_count} to {len(sites)}")
             self._last_site_count = len(sites)
 
         results = self._fan_out(
@@ -118,9 +123,13 @@ class Monitor:
     # ----- dependent phase (nodes 6-19) -----
 
     def _probe_dependent(
-        self, dep: str, resolvable: list[str], ips: list[str]
+        self, dep: str, gluetun_id: str, resolvable: list[str], ips: list[str]
     ) -> DependentProbe:
-        """Classify + viability-test one dependent. Pure I/O, no state mutation."""
+        """Classify + viability-test one dependent. Pure I/O, no state mutation.
+
+        ``gluetun_id`` is the current gluetun container id, needed for the
+        inspect-based fallback below.
+        """
         status = interface_check(self.client, dep)
 
         if status is InterfaceStatus.STRANDED:
@@ -130,9 +139,30 @@ class Monitor:
             return DependentProbe(dep, InterfaceStatus.LIVE, True, None, "recovered on re-check")
 
         if status is InterfaceStatus.UNKNOWN:
-            # Distroless / no shell: fall back to the running check (ADR-0006).
+            # No shell to exec (distroless/scratch), so `ls /sys/class/net` can't
+            # tell us anything. ADR-0004 designates inspect as the fallback signal
+            # here: compare the dependent's NetworkMode target to gluetun's current
+            # id. We act ONLY on the unambiguous moved-id verdict (RECREATE) — a
+            # container that is Running but whose netns parent is a *different*
+            # (dead) gluetun is stranded exactly as in #20, just invisible to the
+            # interface check. A matching id (RESTART) or an unresolvable name-form
+            # target (TRY_RESTART) is left alone: we can't prove a strand there and
+            # must not churn a healthy container (Tenet 2). The id comparison is
+            # stable (no flap), so unlike the interface path it needs no re-check.
             info = self.client.inspect(dep)
             running = bool(info and info.running)
+            if (
+                running
+                and info is not None
+                and remediation_action(info, gluetun_id) is RemediationAction.RECREATE
+            ):
+                return DependentProbe(
+                    dep,
+                    InterfaceStatus.STRANDED,
+                    True,
+                    None,
+                    "inspect: netns id moved (gluetun recreated), container not exec'able",
+                )
             return DependentProbe(dep, status, running, None, "interface check unavailable")
 
         # LIVE: one shuffled name per loop (the shuffle is load-bearing, ADR-0006).
@@ -145,9 +175,24 @@ class Monitor:
 
     def _resolve_dependents(self) -> list[str]:
         """Current dependent set: discovery (or manual list) unioned with the
-        remembered set, pruned to containers that still exist."""
+        remembered set, pruned to containers that still exist.
+
+        A name that came from an explicit ``DEPENDENT_CONTAINERS`` list but does
+        not exist is a likely misconfiguration — warn loudly (deduped) rather
+        than silently dropping it. Auto-discovery never yields a missing name, so
+        this only fires on the manual override.
+        """
         current = get_dependents(self.client, self.config, self.log)
-        self._known_dependents.update(current)
+        present = {name: self.client.inspect(name) is not None for name in current}
+
+        for name, exists in present.items():
+            if not exists and name not in self._warned_missing:
+                self.log.warn(f"Configured dependent '{name}' not found (DEPENDENT_CONTAINERS)")
+                self._warned_missing.add(name)
+        # Re-arm the warning for any name that has since reappeared.
+        self._warned_missing &= {name for name, exists in present.items() if not exists}
+
+        self._known_dependents.update(name for name, exists in present.items() if exists)
         self._known_dependents = {
             d for d in self._known_dependents if self.client.inspect(d) is not None
         }
@@ -167,7 +212,9 @@ class Monitor:
                 "testing connectivity only against IP literals"
             )
 
-        probes = self._fan_out(dependents, lambda d: self._probe_dependent(d, resolvable, ips))
+        probes = self._fan_out(
+            dependents, lambda d: self._probe_dependent(d, gluetun_id, resolvable, ips)
+        )
 
         # State mutation + remediation decisions are single-threaded.
         to_remediate: list[tuple[str, str]] = []
@@ -220,11 +267,10 @@ class Monitor:
         if gluetun.health != "healthy":
             self.log.warn(f"Gluetun health status: {gluetun.health}")
 
-        try:
-            sites = parse_sites_conf(self.config.config_file)
-        except FileNotFoundError:
-            self.log.error(f"Sites config file not found: {self.config.config_file}")
-            return
+        # Re-read every loop so editing sites.conf is picked up live (the SITES
+        # env contribution is fixed at startup). Startup validation guarantees a
+        # non-empty set; a runtime edit down to empty just tests nothing this loop.
+        sites = load_sites(self.config.config_file, self.config.sites_env)
 
         if self.check_gluetun_sites(sites):
             # Gluetun is up — proceed straight to the dependent phase (the #20 fix:
@@ -250,11 +296,19 @@ class Monitor:
         self.run_dependent_phase(gluetun.id, sites)
 
     def announce(self) -> None:
-        """Log the post-prerequisite startup context (connection + endpoint)."""
+        """Log the post-prerequisite startup context (connection, dependents, endpoint)."""
         if self.config.docker_host:
             self.log.info(f"Docker connection: socket proxy ({self.config.docker_host})")
         else:
             self.log.info("Docker connection: local socket")
+        if self.config.dependent_containers == "auto":
+            discovered = discover_dependents(self.client, self.config.gluetun_container)
+            if discovered:
+                self.log.info(f"Dependent containers (auto-discovery): {','.join(discovered)}")
+            else:
+                self.log.info("Dependent containers: auto-discovery enabled (none found currently)")
+        else:
+            self.log.info(f"Dependent containers (manual): {self.config.dependent_containers}")
         startup = get_endpoint_info(self.client, self.config.gluetun_container)
         self.log.endpoint(startup.format("STARTUP", "Monitor starting"))
 

--- a/gluetun_monitor/monitor.py
+++ b/gluetun_monitor/monitor.py
@@ -124,7 +124,7 @@ class Monitor:
         failed: list[str] = []
         for result in results:
             if record:
-                self.stats.record_poll(result.url, result.ok)
+                self.stats.record_poll(result.url, result.ok, result.duration_ms, result.reason)
             if result.ok:
                 self.site_failures.reset(result.url)
                 self.log.debug(f"[{gw}] site {result.url}: ok ({result.duration_ms}ms)")
@@ -420,7 +420,12 @@ class Monitor:
             return
 
         # Re-verify without recording (so the loop counts one poll per site, not two).
-        if self.check_gluetun_sites(sites, record=False):
+        reverify_breached = self.check_gluetun_sites(sites, record=False)
+        # Restart effectiveness: did each site that triggered this restart recover?
+        still = set(reverify_breached)
+        for site in breached:
+            self.stats.record_restart_outcome(site, cleared=site not in still)
+        if reverify_breached:
             self.log.warn("Connectivity still failing after restart; leaving dependents untouched")
             self.site_failures.reset_all()
             return

--- a/gluetun_monitor/monitor.py
+++ b/gluetun_monitor/monitor.py
@@ -251,7 +251,7 @@ class Monitor:
             threshold = self.config.dependent_container_failures
             if count >= threshold:
                 to_remediate.append(
-                    (probe.name, f"{count} consecutive distinct-name failures")
+                    (probe.name, f"{count} consecutive viability failures")
                 )
                 self.log.warn(
                     f"Dependent {probe.name}: {probe.reason} "

--- a/gluetun_monitor/monitor.py
+++ b/gluetun_monitor/monitor.py
@@ -18,10 +18,11 @@ from typing import TYPE_CHECKING
 
 from .connectivity import probe_site
 from .dependents import (
+    classify_interfaces,
     discover_dependents,
     get_dependents,
-    interface_check,
     is_container_id,
+    list_interfaces,
     parse_csv_names,
     remediation_action,
 )
@@ -50,6 +51,7 @@ class DependentProbe:
     viability_ok: bool | None  # None = not tested (no pool / not live / unvalidatable)
     reason: str
     dns_unvalidated: bool = False  # True = no usable DNS tool in the container
+    interfaces: str = "?"  # the dependent's net interfaces, for DEBUG visibility
 
 
 class Monitor:
@@ -72,7 +74,6 @@ class Monitor:
         self._sleep = sleep
         # Persistent per-site stats (ADR-0008). Injectable for tests.
         self.stats = stats if stats is not None else SiteStatsStore(config.stats_file)
-        self._loops_since_save = 0
         self._advised_site: str | None = None  # dedup the flaky-site advisory
         self.site_failures = Counter()
         self.dependent_failures = Counter()
@@ -157,13 +158,22 @@ class Monitor:
         if self.config.max_jitter_ms > 0:
             self._sleep(self._rng.uniform(0, self.config.max_jitter_ms) / 1000.0)
 
-        status = interface_check(self.client, dep)
+        # L3/L4 interface check (node 7): which interfaces does the dependent have?
+        # The set is captured (not just the verdict) so it's visible in DEBUG —
+        # "can it route out" is exactly the eth0/tun0-vs-lo-only question.
+        ifaces = list_interfaces(self.client, dep)
+        status = classify_interfaces(ifaces)
+        ifs = ",".join(sorted(ifaces)) if ifaces else "unknown"
 
         if status is InterfaceStatus.STRANDED:
             # Node 10: re-check once — a real strand won't self-heal.
-            if interface_check(self.client, dep) is InterfaceStatus.STRANDED:
-                return DependentProbe(dep, status, False, None, "stranded loopback-only")
-            return DependentProbe(dep, InterfaceStatus.LIVE, True, None, "recovered on re-check")
+            ifaces2 = list_interfaces(self.client, dep)
+            if classify_interfaces(ifaces2) is InterfaceStatus.STRANDED:
+                return DependentProbe(dep, status, False, None, "stranded loopback-only",
+                                      interfaces=ifs)
+            ifs2 = ",".join(sorted(ifaces2)) if ifaces2 else "unknown"
+            return DependentProbe(dep, InterfaceStatus.LIVE, True, None, "recovered on re-check",
+                                  interfaces=ifs2)
 
         if status is InterfaceStatus.UNKNOWN:
             # No shell to exec (distroless/scratch), so `ls /sys/class/net` can't
@@ -184,42 +194,42 @@ class Monitor:
                 and remediation_action(info, gluetun_id) is RemediationAction.RECREATE
             ):
                 return DependentProbe(
-                    dep,
-                    InterfaceStatus.STRANDED,
-                    True,
-                    None,
+                    dep, InterfaceStatus.STRANDED, True, None,
                     "inspect: netns id moved (gluetun recreated), container not exec'able",
+                    interfaces=ifs,
                 )
-            return DependentProbe(dep, status, running, None, "interface check unavailable")
+            return DependentProbe(dep, status, running, None, "interface check unavailable",
+                                  interfaces=ifs)
 
         # LIVE. The viability layer (L7 DNS + connectivity probe) is opt-out: with
         # it off, a live, non-stranded dependent is judged healthy on the interface
         # check alone — no URL fetch (ADR-0006; the interface check stays mandatory).
         if not self.config.dependent_viability:
-            return DependentProbe(dep, status, True, None, "viability disabled (interface only)")
+            return DependentProbe(dep, status, True, None, "viability disabled (interface only)",
+                                  interfaces=ifs)
 
         # one shuffled name per loop (the shuffle is load-bearing, ADR-0006).
         pool = resolvable or ips
         if not pool:
-            return DependentProbe(dep, status, True, None, "no test URLs")
+            return DependentProbe(dep, status, True, None, "no test URLs", interfaces=ifs)
         url = self._rng.choice(pool)
         host = hostname_of(url)
         if is_ip_literal(host):
             # An IP literal has nothing to resolve; the phase already WARNed that
             # dependent DNS can't be validated in an IP-only config.
-            return DependentProbe(dep, status, True, None, f"{url}: IP literal (DNS not validated)")
+            return DependentProbe(dep, status, True, None,
+                                  f"{url}: IP literal (DNS not validated)", interfaces=ifs)
 
         # Validate the dependent's OWN DNS resolution (the only per-container
         # fault — see dns_check). Three outcomes: OK -> viable; BROKEN -> the
         # fault we act on; UNVALIDATED -> can't tell (no tool), don't guess.
         dns = validate_dns(self.client, dep, url, host, self.config.timeout)
         if dns.status is DnsStatus.UNVALIDATED:
-            return DependentProbe(
-                dep, status, True, None, f"{host}: {dns.reason}", dns_unvalidated=True
-            )
+            return DependentProbe(dep, status, True, None, f"{host}: {dns.reason}",
+                                  dns_unvalidated=True, interfaces=ifs)
         viable = dns.status is DnsStatus.OK
         detail = f"{host}: DNS ok ({dns.tool})" if viable else f"{host}: DNS FAILED ({dns.reason})"
-        return DependentProbe(dep, status, True, viable, detail)
+        return DependentProbe(dep, status, True, viable, detail, interfaces=ifs)
 
     def _resolve_dependents(self) -> list[str]:
         """Current dependent set: discovery (or manual list) unioned with the
@@ -266,13 +276,20 @@ class Monitor:
             dependents, lambda d: self._probe_dependent(d, gluetun_id, resolvable, ips)
         )
 
-        # State mutation + remediation decisions are single-threaded.
+        # State mutation + remediation decisions are single-threaded. Every
+        # dependent logs its L3 interface check (which interfaces / can it route)
+        # at DEBUG each loop, plus the L7 viability detail when applicable.
         to_remediate: list[tuple[str, str]] = []
         for probe in probes:
+            iface = f"interface={probe.status.name.lower()} [{probe.interfaces}]"
             if probe.status is InterfaceStatus.STRANDED:
+                self.log.debug(f"Dependent {probe.name}: {iface} -> {probe.reason}")
                 to_remediate.append((probe.name, probe.reason))
                 continue
             if probe.status is InterfaceStatus.UNKNOWN:
+                self.log.debug(
+                    f"Dependent {probe.name}: {iface}, running={probe.running} — {probe.reason}"
+                )
                 if not probe.running:
                     to_remediate.append((probe.name, "not running (interface check unavailable)"))
                 continue
@@ -285,12 +302,14 @@ class Monitor:
                         f"relying on interface check only"
                     )
                     self._warned_dns_unvalidated.add(probe.name)
+                else:
+                    self.log.debug(f"Dependent {probe.name}: {iface}, {probe.reason}")
                 continue  # not tested -> no counter change
             # A validated result (ok or broken): re-arm the unvalidated warning.
             self._warned_dns_unvalidated.discard(probe.name)
             if probe.viability_ok:
                 self.dependent_failures.reset(probe.name)
-                self.log.debug(f"Dependent {probe.name}: {probe.reason} [fails 0]")
+                self.log.debug(f"Dependent {probe.name}: {iface}, {probe.reason} [fails 0]")
                 continue
             count = self.dependent_failures.fail(probe.name)
             threshold = self.config.dependent_container_failures
@@ -299,12 +318,12 @@ class Monitor:
                     (probe.name, f"{count} consecutive viability failures")
                 )
                 self.log.warn(
-                    f"Dependent {probe.name}: {probe.reason} "
+                    f"Dependent {probe.name}: {iface}, {probe.reason} "
                     f"[fails {count}/{threshold} -> remediate]"
                 )
             else:
                 self.log.debug(
-                    f"Dependent {probe.name}: {probe.reason} [fails {count}/{threshold}]"
+                    f"Dependent {probe.name}: {iface}, {probe.reason} [fails {count}/{threshold}]"
                 )
 
         for dep, reason in to_remediate:
@@ -345,7 +364,7 @@ class Monitor:
             # Gluetun is up — proceed straight to the dependent phase (the #20 fix:
             # dependents are checked every loop, not only after a gluetun failure).
             self.run_dependent_phase(gluetun.id, sites)
-            self._maybe_save_stats()
+            self._save_stats()
             return
 
         # Gluetun breached threshold: restart + re-verify before touching dependents.
@@ -356,7 +375,7 @@ class Monitor:
         for site in breached:
             self.stats.record_restart(site)
         self._emit_advisory()
-        self.stats.save()
+        self._save_stats()
 
         if self.config.dry_run:
             # Observe-only: don't restart gluetun (can't, without mutating). Log
@@ -382,7 +401,7 @@ class Monitor:
         # Re-inspect: a restart keeps the same id, but be robust if it was recreated.
         gluetun = self.client.inspect(self.config.gluetun_container) or gluetun
         self.run_dependent_phase(gluetun.id, sites)
-        self._maybe_save_stats()
+        self._save_stats()
 
     def _emit_advisory(self) -> None:
         """Warn (deduped) when one site dominates recent gluetun restarts."""
@@ -404,12 +423,16 @@ class Monitor:
             f"reviewing or removing it from sites.conf"
         )
 
-    def _maybe_save_stats(self) -> None:
-        """Persist stats every STATS_SAVE_EVERY loops (best-effort)."""
-        self._loops_since_save += 1
-        if self._loops_since_save >= self.config.stats_save_every:
-            self.stats.save()
-            self._loops_since_save = 0
+    def _save_stats(self) -> None:
+        """Prune stale sites (retention), then persist — every loop (best-effort;
+        a few-KB atomic write, so no throttle needed)."""
+        pruned = self.stats.prune_stale(self.config.stats_retention_days * 86400)
+        if pruned:
+            self.log.info(
+                f"Pruned {len(pruned)} stale site stat(s) not seen in "
+                f"{self.config.stats_retention_days}d: {', '.join(pruned)}"
+            )
+        self.stats.save()
 
     def announce(self) -> None:
         """Log the post-prerequisite startup context (connection, dependents, endpoint)."""

--- a/gluetun_monitor/monitor.py
+++ b/gluetun_monitor/monitor.py
@@ -96,7 +96,7 @@ class Monitor:
         self._advised_site: str | None = None  # dedup the flaky-site advisory
         self.site_failures = Counter()
         self.dependent_failures = Counter()
-        self._last_site_count: int | None = None
+        self._last_sites: set[str] | None = None
         # Dependents seen at least once. A dependent stranded by a gluetun
         # *recreate* still points at the dead old id, so current-id discovery no
         # longer matches it — but we remember it from before the recreate and
@@ -123,12 +123,28 @@ class Monitor:
             self.log.warn("No sites configured to test")
             return []
 
-        if self._last_site_count != len(sites):
-            if self._last_site_count is None:
-                self.log.info(f"Loaded {len(sites)} sites (sites.conf + SITES env)")
-            else:
-                self.log.info(f"Site count changed from {self._last_site_count} to {len(sites)}")
-            self._last_site_count = len(sites)
+        # Track the site *set* (not just the count) so a runtime sites.conf edit is
+        # logged with the actual names — including a same-count swap, which a
+        # count-only check would miss entirely. record=False is the post-restart
+        # re-verify (same set), so skip the diff there.
+        current = set(sites)
+        if record and self._last_sites is None:
+            self.log.info(f"Loaded {len(sites)} sites (sites.conf + SITES env)")
+            self._last_sites = current
+        elif record and current != self._last_sites:
+            added = sorted(current - self._last_sites) if self._last_sites else sorted(current)
+            removed = sorted(self._last_sites - current) if self._last_sites else []
+            parts = []
+            if added:
+                parts.append(f"added {', '.join(added)}")
+            if removed:
+                parts.append(f"removed {', '.join(removed)}")
+            self.log.info(f"Sites changed: {'; '.join(parts)} (now {len(sites)})")
+            # A removed site keeps no live failure counter — a later re-add starts
+            # clean rather than resuming near the threshold.
+            for site in removed:
+                self.site_failures.discard(site)
+            self._last_sites = current
 
         results = self._fan_out(
             sites, lambda url: probe_site(self.client, self.config.gluetun_container, url,

--- a/gluetun_monitor/monitor.py
+++ b/gluetun_monitor/monitor.py
@@ -113,7 +113,7 @@ class Monitor:
 
         results = self._fan_out(
             sites, lambda url: probe_site(self.client, self.config.gluetun_container, url,
-                                          self.config.timeout)
+                                          self.config.timeout, self.config.wget_tries)
         )
 
         # Site tests run *inside the gluetun container* (the VPN gateway, through
@@ -236,7 +236,7 @@ class Monitor:
         # — dns_check). Viable if ANY sampled site resolves; not-viable only if
         # ALL sampled resolvable sites fail DNS; unvalidated if no tool exists.
         results = [
-            (h, validate_dns(self.client, dep, u, h, self.config.timeout))
+            (h, validate_dns(self.client, dep, u, h, self.config.timeout, self.config.wget_tries))
             for (u, h) in resolvable_chosen
         ]
         oks = [(h, r) for (h, r) in results if r.status is DnsStatus.OK]

--- a/gluetun_monitor/monitor.py
+++ b/gluetun_monitor/monitor.py
@@ -27,7 +27,7 @@ from .dependents import (
     parse_csv_names,
     remediation_action,
 )
-from .dns_check import DnsStatus, validate_dns
+from .dns_check import DnsResult, DnsStatus, validate_dns
 from .endpoint import get_endpoint_info
 from .recovery import remediate_dependent, restart_gluetun
 from .site_stats import SiteStatsStore, format_window
@@ -53,6 +53,18 @@ class DependentProbe:
     reason: str
     dns_unvalidated: bool = False  # True = no usable DNS tool in the container
     interfaces: str = "?"  # the dependent's net interfaces, for DEBUG visibility
+
+
+def _fmt_reach(host: str, r: DnsResult) -> str:
+    """Bare reach detail: ``<host> (<why>) [<tool>]`` (tool omitted if unknown)."""
+    tool = f" [{r.tool}]" if r.tool else ""
+    return f"{host} ({r.reason}){tool}"
+
+
+def _link_line(status: str, interfaces: str) -> str:
+    """L3 link verdict + interface list: ``live: eth0,lo,tun0`` / ``stranded: lo``
+    / ``unknown`` (no list when the interfaces couldn't be read)."""
+    return f"{status}: {interfaces}" if interfaces and interfaces != "unknown" else status
 
 
 class Monitor:
@@ -134,24 +146,25 @@ class Monitor:
                 self.stats.record_poll(result.url, result.ok, result.duration_ms, result.reason)
             if result.ok:
                 self.site_failures.reset(result.url)
-                self.log.debug(f"[{gw}] site {result.url}: ok ({result.duration_ms}ms)")
+                self.log.debug(
+                    f"[{gw}] reach ok: {result.url} ({result.reason}, {result.duration_ms}ms)"
+                )
                 continue
             count = self.site_failures.fail(result.url)
-            if count >= self.config.fail_threshold:
+            threshold = self.config.fail_threshold
+            if count >= threshold:
                 failed.append(result.url)
                 self.log.warn(
-                    f"[{gw}] site {result.url}: FAILED {count}x consecutive - "
-                    f"THRESHOLD REACHED - {result.reason}"
+                    f"[{gw}] reach fail: {result.url} ({result.reason}) "
+                    f"[{count}/{threshold} → restart]"
                 )
             else:
-                remaining = self.config.fail_threshold - count
                 self.log.debug(
-                    f"[{gw}] site {result.url}: failed ({count}/{self.config.fail_threshold}, "
-                    f"{remaining} more to restart) - {result.reason}"
+                    f"[{gw}] reach fail: {result.url} ({result.reason}) [{count}/{threshold}]"
                 )
 
         if failed:
-            self.log.error(f"[{gw}] failed sites (exceeded threshold): {' '.join(failed)}")
+            self.log.error(f"[{gw}] restart triggered by: {' '.join(failed)}")
         return failed
 
     # ----- dependent phase (nodes 6-19) -----
@@ -212,14 +225,14 @@ class Monitor:
                     "inspect: netns id moved (gluetun recreated), container not exec'able",
                     interfaces=ifs,
                 )
-            return DependentProbe(dep, status, running, None, "interface check unavailable",
+            return DependentProbe(dep, status, running, None, "link check unavailable",
                                   interfaces=ifs)
 
         # LIVE. The viability layer (L7 DNS + connectivity probe) is opt-out: with
         # it off, a live, non-stranded dependent is judged healthy on the interface
         # check alone — no URL fetch (ADR-0006; the interface check stays mandatory).
         if not self.config.dependent_viability:
-            return DependentProbe(dep, status, True, None, "viability disabled (interface only)",
+            return DependentProbe(dep, status, True, None, "disabled (link check only)",
                                   interfaces=ifs)
 
         # Sample one (default) or more shuffled names per loop. The shuffle is
@@ -240,11 +253,13 @@ class Monitor:
         ]
         if not resolvable_chosen:
             return DependentProbe(dep, status, True, None,
-                                  f"{chosen[0]}: IP literal (DNS not validated)", interfaces=ifs)
+                                  f"{chosen[0]} (IP literal — DNS not tested)", interfaces=ifs)
 
         # Validate the dependent's OWN DNS resolution (the only per-container fault
         # — dns_check). Viable if ANY sampled site resolves; not-viable only if
         # ALL sampled resolvable sites fail DNS; unvalidated if no tool exists.
+        # ``reason`` is the bare detail — "<host> (<why>) [<tool>]" — because the
+        # caller prefixes the verb + verdict ("reach ok/fail/?").
         results = [
             (h, validate_dns(self.client, dep, u, h, self.config.timeout, self.config.wget_tries))
             for (u, h) in resolvable_chosen
@@ -254,21 +269,20 @@ class Monitor:
         if oks:
             h, r = oks[0]
             detail = (
-                f"{h}: {r.reason} [{r.tool}]" if len(results) == 1
-                else f"{len(oks)}/{len(results)} sampled sites resolved "
-                     f"(e.g. {h}: {r.reason} [{r.tool}])"
+                _fmt_reach(h, r) if len(results) == 1
+                else f"{len(oks)}/{len(results)} sampled ok (e.g. {_fmt_reach(h, r)})"
             )
             return DependentProbe(dep, status, True, True, detail, interfaces=ifs)
         if broken:
             h, r = broken[0]
             detail = (
-                f"{h}: DNS FAILED — {r.reason} [{r.tool}]" if len(results) == 1
-                else f"all {len(results)} sampled sites failed DNS (e.g. {h}: {r.reason})"
+                _fmt_reach(h, r) if len(results) == 1
+                else f"all {len(results)} sampled failed (e.g. {_fmt_reach(h, r)})"
             )
             return DependentProbe(dep, status, True, False, detail, interfaces=ifs)
         # All sampled sites were UNVALIDATED (no usable DNS tool in the container).
         h, r = results[0]
-        return DependentProbe(dep, status, True, None, f"{h}: {r.reason}",
+        return DependentProbe(dep, status, True, None, _fmt_reach(h, r),
                               dns_unvalidated=True, interfaces=ifs)
 
     def _resolve_dependents(self) -> list[str]:
@@ -324,46 +338,43 @@ class Monitor:
         for probe in probes:
             dep = probe.name
             tag = f"dependent:{dep}"  # role + name, mirrors "[gateway:<name>]"
-            self.log.debug(
-                f"[{tag}] interface check: {probe.status.name.lower()} [{probe.interfaces}]"
-            )
+            link = _link_line(probe.status.name.lower(), probe.interfaces)
+            self.log.debug(f"[{tag}] link {link}")
             if probe.status is InterfaceStatus.STRANDED:
                 to_remediate.append((dep, probe.reason))
                 continue
             if probe.status is InterfaceStatus.UNKNOWN:
                 self.log.debug(f"[{tag}] {probe.reason} (running={probe.running})")
                 if not probe.running:
-                    to_remediate.append((dep, "not running (interface check unavailable)"))
+                    to_remediate.append((dep, "not running (link check unavailable)"))
                 continue
             if probe.viability_ok is None:
-                if probe.dns_unvalidated and dep not in self._warned_dns_unvalidated:
-                    # Can't run any DNS tool in this container — say so loudly once,
-                    # and rely on the interface check (don't guess; Tenet 1).
-                    self.log.warn(
-                        f"[{tag}] cannot validate DNS ({probe.reason}); "
-                        f"relying on interface check only"
-                    )
-                    self._warned_dns_unvalidated.add(dep)
+                if probe.dns_unvalidated:
+                    # Can't run any DNS tool in this container — say so loudly once
+                    # (re-armed when it later validates), then rely on the link check.
+                    if dep not in self._warned_dns_unvalidated:
+                        self.log.warn(f"[{tag}] reach ?: {probe.reason}; using link check only")
+                        self._warned_dns_unvalidated.add(dep)
+                    else:
+                        self.log.debug(f"[{tag}] reach ?: {probe.reason}")
                 else:
-                    self.log.debug(f"[{tag}] viability: {probe.reason}")
+                    self.log.debug(f"[{tag}] reach skip: {probe.reason}")
                 continue  # not tested -> no counter change
             # A validated result (ok or broken): re-arm the unvalidated warning.
             self._warned_dns_unvalidated.discard(dep)
             if probe.viability_ok:
                 self.dependent_failures.reset(dep)
-                self.log.debug(f"[{tag}] viability: {probe.reason} [fails 0]")
+                self.log.debug(f"[{tag}] reach ok: {probe.reason}")
                 continue
             count = self.dependent_failures.fail(dep)
             threshold = self.config.dependent_container_failures
             if count >= threshold:
                 to_remediate.append((dep, f"{count} consecutive viability failures"))
                 self.log.warn(
-                    f"[{tag}] viability: {probe.reason} [fails {count}/{threshold} -> remediate]"
+                    f"[{tag}] reach fail: {probe.reason} [{count}/{threshold} → remediate]"
                 )
             else:
-                self.log.debug(
-                    f"[{tag}] viability: {probe.reason} [fails {count}/{threshold}]"
-                )
+                self.log.debug(f"[{tag}] reach fail: {probe.reason} [{count}/{threshold}]")
 
         for dep, reason in to_remediate:
             if self.config.dry_run:
@@ -400,10 +411,10 @@ class Monitor:
         # We do NOT gate on this — the site tests are the authoritative tunnel
         # check (ADR-0001); this is just visibility.
         gw_ifaces = list_interfaces(self.client, self.config.gluetun_container)
+        gw_ifs = ",".join(sorted(gw_ifaces)) if gw_ifaces else "unknown"
         self.log.debug(
-            f"[gateway:{self.config.gluetun_container}] interface check: "
-            f"{classify_interfaces(gw_ifaces).name.lower()} "
-            f"[{','.join(sorted(gw_ifaces)) if gw_ifaces else 'unknown'}]"
+            f"[gateway:{self.config.gluetun_container}] link "
+            f"{_link_line(classify_interfaces(gw_ifaces).name.lower(), gw_ifs)}"
         )
 
         # Re-read every loop so editing sites.conf is picked up live (the SITES
@@ -420,7 +431,7 @@ class Monitor:
             return
 
         # Gluetun breached threshold: restart + re-verify before touching dependents.
-        self.log.warn("Health check failed, initiating recovery...")
+        self.log.warn("Gluetun unhealthy → restarting")
         # Attribute the restart to the breached site(s) and surface a flaky-site
         # advisory if one site keeps causing them (ADR-0008). Persist now — a
         # restart is an important, infrequent event worth not losing.

--- a/gluetun_monitor/monitor.py
+++ b/gluetun_monitor/monitor.py
@@ -10,6 +10,7 @@ exec fan-out runs concurrently (bounded by MAX_PARALLEL_CHECKS).
 from __future__ import annotations
 
 import random
+import threading
 import time
 from collections.abc import Callable
 from concurrent.futures import ThreadPoolExecutor
@@ -71,6 +72,12 @@ class Monitor:
         self.config = config
         self.log = logger
         self._rng = rng if rng is not None else random.Random()
+        # _probe_dependent runs across a ThreadPoolExecutor (_fan_out), and a
+        # random.Random instance is not thread-safe — concurrent sample()/uniform()
+        # calls can interleave and corrupt its state, biasing the load-bearing site
+        # shuffle (ADR-0006). All draws go through this lock so the shuffle stays
+        # sound under fan-out. The lock is held only for the draw, never across I/O.
+        self._rng_lock = threading.Lock()
         self._sleep = sleep
         # Persistent per-site stats (ADR-0008). Injectable for tests.
         self.stats = stats if stats is not None else SiteStatsStore(config.stats_file)
@@ -161,7 +168,9 @@ class Monitor:
         # of execs across live dependents (ADR-0006). The concurrency cap is the
         # primary bound; this only spreads start times when explicitly enabled.
         if self.config.max_jitter_ms > 0:
-            self._sleep(self._rng.uniform(0, self.config.max_jitter_ms) / 1000.0)
+            with self._rng_lock:
+                jitter = self._rng.uniform(0, self.config.max_jitter_ms) / 1000.0
+            self._sleep(jitter)
 
         # L3/L4 interface check (node 7): which interfaces does the dependent have?
         # The set is captured (not just the verdict) so it's visible in DEBUG —
@@ -222,7 +231,8 @@ class Monitor:
             return DependentProbe(dep, status, True, None, "no test URLs", interfaces=ifs)
         n = self.config.dependent_viability_samples
         k = len(pool) if (n < 0 or n >= len(pool)) else max(1, n)
-        chosen = self._rng.sample(pool, k)
+        with self._rng_lock:
+            chosen = self._rng.sample(pool, k)
 
         # Only hostnames exercise DNS; IP literals have nothing to resolve.
         resolvable_chosen = [

--- a/gluetun_monitor/recovery.py
+++ b/gluetun_monitor/recovery.py
@@ -27,6 +27,7 @@ Sleep = Callable[[float], None]
 
 
 def get_health(client: DockerClient, container: str) -> str:
+    """Health status string for ``container`` ('healthy'/'starting'/.../'unknown')."""
     info = client.inspect(container)
     return info.health if info else "unknown"
 

--- a/gluetun_monitor/recovery.py
+++ b/gluetun_monitor/recovery.py
@@ -119,6 +119,9 @@ def restart_gluetun(
         logger.error("Gluetun failed to become healthy after restart")
         return False
 
+    # Best-effort settle: a DNS timeout here logs but does not abort recovery
+    # (we proceed and let the post-restart re-verify be the authority), so the
+    # bool return is intentionally not consumed.
     wait_for_dns(client, config.gluetun_container, config.dns_wait_timeout, logger,
                  request_timeout=config.timeout, tries=config.wget_tries, sleep=sleep)
     new = get_endpoint_info(client, config.gluetun_container)

--- a/gluetun_monitor/recovery.py
+++ b/gluetun_monitor/recovery.py
@@ -178,17 +178,17 @@ def remediate_dependent(
     action = remediation_action(info, gluetun_id)
 
     if action is RemediationAction.RESTART:
-        logger.info(f"Restarting {dep_name} (shares current gluetun netns id)")
+        logger.info(f"Restarting {dep_name} (same netns id)")
         if not _do_restart(client, dep_name, logger, sleep=sleep):
             return False
     elif action is RemediationAction.TRY_RESTART:
-        logger.info(f"Restarting {dep_name} (name-form netns target)")
+        logger.info(f"Restarting {dep_name} (name-form netns)")
         if not _do_restart(client, dep_name, logger, sleep=sleep):
             logger.warn(f"{dep_name} restart failed; escalating to recreate")
             if not _maybe_recreate(client, dep_name, gluetun_id, config, logger):
                 return False
     elif action is RemediationAction.RECREATE:
-        logger.warn(f"{dep_name} netns target moved (gluetun recreated) — recreate required")
+        logger.warn(f"{dep_name} netns moved (gluetun recreated) → recreate")
         if not _maybe_recreate(client, dep_name, gluetun_id, config, logger):
             return False
 

--- a/gluetun_monitor/recovery.py
+++ b/gluetun_monitor/recovery.py
@@ -1,0 +1,189 @@
+"""Recovery actions: gluetun restart + dependent remediation.
+
+Gluetun recovery is the v1.x path (restart, wait healthy, wait DNS, re-verify).
+Dependent remediation applies the ADR-0004 decision: restart for a same-id
+strand, recreate for a moved-id strand, try-restart-then-escalate for a
+name-form target. Every action ends in a verify (node 19); a disabled/denied
+recreate is a FAILED outcome (node 21).
+"""
+
+from __future__ import annotations
+
+import time
+from collections.abc import Callable
+from typing import TYPE_CHECKING
+
+from .dependents import interface_check, remediation_action
+from .endpoint import get_endpoint_info
+from .recreate import recreate_dependent
+from .state import InterfaceStatus, RemediationAction
+
+if TYPE_CHECKING:
+    from .config import Config
+    from .docker_client import DockerClient
+    from .logging_setup import Logger
+
+Sleep = Callable[[float], None]
+
+
+def get_health(client: DockerClient, container: str) -> str:
+    info = client.inspect(container)
+    return info.health if info else "unknown"
+
+
+def wait_for_healthy(
+    client: DockerClient,
+    container: str,
+    max_wait: int,
+    logger: Logger,
+    *,
+    sleep: Sleep = time.sleep,
+) -> bool:
+    """Poll until ``container`` reports healthy, or ``max_wait`` seconds elapse."""
+    logger.info(f"Waiting for {container} to become healthy (max {max_wait}s)...")
+    waited = 0
+    while waited < max_wait:
+        health = get_health(client, container)
+        if health == "healthy":
+            logger.info(f"{container} is healthy after {waited}s")
+            return True
+        sleep(5)
+        waited += 5
+        logger.debug(f"Waiting... ({waited}/{max_wait}s) - current status: {health}")
+    logger.error(f"{container} did not become healthy within {max_wait}s")
+    return False
+
+
+def wait_for_dns(
+    client: DockerClient,
+    container: str,
+    max_wait: int,
+    logger: Logger,
+    *,
+    sleep: Sleep = time.sleep,
+) -> bool:
+    """Wait for gluetun DNS + connectivity to stabilize after a restart."""
+    logger.info("Waiting for DNS to stabilize...")
+    waited = 0
+    while waited < max_wait:
+        try:
+            ns = client.exec_run(container, ["nslookup", "google.com", "127.0.0.1"])
+            if ns.exit_code == 0:
+                probe = client.exec_run(
+                    container,
+                    ["wget", "--spider", "--timeout=5", "--tries=1", "-q", "https://1.1.1.1"],
+                )
+                if probe.exit_code == 0:
+                    logger.info(f"DNS and connectivity verified after {waited}s")
+                    return True
+        except Exception:
+            pass
+        sleep(2)
+        waited += 2
+        logger.debug(f"Waiting for DNS... ({waited}/{max_wait}s)")
+    logger.warn(f"DNS stabilization timeout after {max_wait}s - proceeding anyway")
+    return False
+
+
+def restart_gluetun(
+    client: DockerClient,
+    config: Config,
+    logger: Logger,
+    *,
+    sleep: Sleep = time.sleep,
+) -> bool:
+    """Restart gluetun to force a new endpoint, then wait for it to recover."""
+    logger.info(f"Restarting {config.gluetun_container} to force new endpoint...")
+    failing = get_endpoint_info(client, config.gluetun_container)
+    logger.endpoint(failing.format("FAILING", "Site connectivity test failed"))
+
+    try:
+        client.restart(config.gluetun_container)
+    except Exception as exc:
+        logger.error(f"Failed to restart {config.gluetun_container}: {exc}")
+        return False
+
+    if not wait_for_healthy(
+        client, config.gluetun_container, config.healthy_wait_timeout, logger, sleep=sleep
+    ):
+        logger.error("Gluetun failed to become healthy after restart")
+        return False
+
+    wait_for_dns(client, config.gluetun_container, config.dns_wait_timeout, logger, sleep=sleep)
+    new = get_endpoint_info(client, config.gluetun_container)
+    logger.endpoint(new.format("NEW", "After restart"))
+    return True
+
+
+def verify_dependent(client: DockerClient, dep_name: str) -> bool:
+    """A dependent is healthy if it is running and not loopback-stranded (node 19)."""
+    info = client.inspect(dep_name)
+    if info is None or not info.running:
+        return False
+    return interface_check(client, dep_name) != InterfaceStatus.STRANDED
+
+
+def _do_restart(client: DockerClient, dep_name: str, logger: Logger, *, sleep: Sleep) -> bool:
+    try:
+        client.restart(dep_name)
+    except Exception as exc:
+        logger.error(f"{dep_name} restart raised: {exc}")
+        return False
+    sleep(2)  # brief settle before the verify, as v1.x did
+    return True
+
+
+def _maybe_recreate(
+    client: DockerClient,
+    dep_name: str,
+    gluetun_id: str,
+    config: Config,
+    logger: Logger,
+) -> bool:
+    if not config.auto_recreate:
+        logger.error(
+            f"{dep_name} needs recreate (gluetun id changed) but AUTO_RECREATE is "
+            f"disabled — FAILED, manual intervention required"
+        )
+        return False
+    return recreate_dependent(client, dep_name, gluetun_id, logger)
+
+
+def remediate_dependent(
+    client: DockerClient,
+    dep_name: str,
+    gluetun_id: str,
+    config: Config,
+    logger: Logger,
+    *,
+    sleep: Sleep = time.sleep,
+) -> bool:
+    """Remediate a failing dependent and verify recovery. Returns success."""
+    info = client.inspect(dep_name)
+    if info is None:
+        logger.error(f"Cannot remediate {dep_name}: container not found")
+        return False
+
+    action = remediation_action(info, gluetun_id)
+
+    if action is RemediationAction.RESTART:
+        logger.info(f"Restarting {dep_name} (shares current gluetun netns id)")
+        if not _do_restart(client, dep_name, logger, sleep=sleep):
+            return False
+    elif action is RemediationAction.TRY_RESTART:
+        logger.info(f"Restarting {dep_name} (name-form netns target)")
+        if not _do_restart(client, dep_name, logger, sleep=sleep):
+            logger.warn(f"{dep_name} restart failed; escalating to recreate")
+            if not _maybe_recreate(client, dep_name, gluetun_id, config, logger):
+                return False
+    elif action is RemediationAction.RECREATE:
+        logger.warn(f"{dep_name} netns target moved (gluetun recreated) — recreate required")
+        if not _maybe_recreate(client, dep_name, gluetun_id, config, logger):
+            return False
+
+    ok = verify_dependent(client, dep_name)
+    if ok:
+        logger.info(f"{dep_name} verified healthy after remediation")
+    else:
+        logger.error(f"{dep_name} still unhealthy after remediation — FAILED")
+    return ok

--- a/gluetun_monitor/recovery.py
+++ b/gluetun_monitor/recovery.py
@@ -61,9 +61,17 @@ def wait_for_dns(
     max_wait: int,
     logger: Logger,
     *,
+    request_timeout: int = 10,
+    tries: int = 1,
     sleep: Sleep = time.sleep,
 ) -> bool:
-    """Wait for gluetun DNS + connectivity to stabilize after a restart."""
+    """Wait for gluetun DNS + connectivity to stabilize after a restart.
+
+    The per-request probe uses the same standardized TIMEOUT/WGET_TRIES as every
+    other wget in the monitor (``request_timeout``/``tries``) — not a hardcoded
+    value — so one knob governs them all. ``max_wait`` (DNS_WAIT_TIMEOUT) is the
+    separate overall poll budget.
+    """
     logger.info("Waiting for DNS to stabilize...")
     waited = 0
     while waited < max_wait:
@@ -72,7 +80,8 @@ def wait_for_dns(
             if ns.exit_code == 0:
                 probe = client.exec_run(
                     container,
-                    ["wget", "--spider", "--timeout=5", "--tries=1", "-q", "https://1.1.1.1"],
+                    ["wget", "--spider", f"--timeout={request_timeout}", f"--tries={tries}",
+                     "-q", "https://1.1.1.1"],
                 )
                 if probe.exit_code == 0:
                     logger.info(f"DNS and connectivity verified after {waited}s")
@@ -110,7 +119,8 @@ def restart_gluetun(
         logger.error("Gluetun failed to become healthy after restart")
         return False
 
-    wait_for_dns(client, config.gluetun_container, config.dns_wait_timeout, logger, sleep=sleep)
+    wait_for_dns(client, config.gluetun_container, config.dns_wait_timeout, logger,
+                 request_timeout=config.timeout, tries=config.wget_tries, sleep=sleep)
     new = get_endpoint_info(client, config.gluetun_container)
     logger.endpoint(new.format("NEW", "After restart"))
     return True

--- a/gluetun_monitor/recreate.py
+++ b/gluetun_monitor/recreate.py
@@ -1,0 +1,149 @@
+"""Non-destructive recreate of a stranded dependent (ADR-0005).
+
+When gluetun is recreated it gets a **new container id**; a dependent whose
+``NetworkMode`` is ``container:<old-id>`` can no longer be restarted into the
+(now absent) namespace — ``NetworkMode`` is immutable, so the dependent must be
+**recreated** pointing at the new id.
+
+``build_create_body`` is the load-bearing transform and is intentionally pure
+(takes an inspect dict, returns an API create body — no Docker calls) so the
+data-loss guards are unit-testable:
+
+* re-point ``NetworkMode`` at the new gluetun id,
+* strip the fields Docker forbids when sharing another container's netns
+  (hostname/dns/ports — they belong to gluetun now),
+* carry every existing mount forward by **source**, including anonymous volumes
+  (bind the existing volume id to its destination) so a subsequent ``rm`` WITHOUT
+  ``-v`` preserves all data; only the ephemeral writable layer is lost.
+"""
+
+from __future__ import annotations
+
+import copy
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from .docker_client import DockerClient
+    from .logging_setup import Logger
+
+# Config fields the daemon rejects (or that are meaningless) when NetworkMode is
+# container:<id> — the shared netns owns the hostname and the port surface.
+_STRIP_CONFIG_FIELDS = ("Hostname", "Domainname", "ExposedPorts", "MacAddress")
+
+# HostConfig fields tied to an owned network stack; invalid in shared-netns mode.
+_STRIP_HOSTCONFIG_FIELDS = (
+    "PortBindings",
+    "PublishAllPorts",
+    "Dns",
+    "DnsOptions",
+    "DnsSearch",
+    "ExtraHosts",
+    "Links",
+)
+
+
+def _mount_spec(mount: dict[str, Any]) -> dict[str, Any] | None:
+    """Translate one inspect ``Mounts`` entry into a create-body mount spec.
+
+    Volumes are carried by their **existing name** (the same underlying volume,
+    so data survives); binds by host source; tmpfs by target only. Returns None
+    for entries we can't faithfully reproduce.
+    """
+    mtype = mount.get("Type")
+    destination = mount.get("Destination")
+    if not destination:
+        return None
+    read_only = not mount.get("RW", True)
+
+    if mtype == "volume":
+        source = mount.get("Name")
+        if not source:
+            return None
+        return {"Type": "volume", "Source": source, "Target": destination, "ReadOnly": read_only}
+    if mtype == "bind":
+        source = mount.get("Source")
+        if not source:
+            return None
+        return {"Type": "bind", "Source": source, "Target": destination, "ReadOnly": read_only}
+    if mtype == "tmpfs":
+        return {"Type": "tmpfs", "Target": destination}
+    return None
+
+
+def build_create_body(inspect_raw: dict[str, Any], new_gluetun_id: str) -> dict[str, Any]:
+    """Build a Docker API create body that re-homes a dependent into a new netns.
+
+    Pure: no Docker calls. ``inspect_raw`` is a full ``docker inspect`` payload;
+    the return value is suitable for ``create_container_from_config``.
+    """
+    config: dict[str, Any] = copy.deepcopy(inspect_raw.get("Config", {}) or {})
+    host_config: dict[str, Any] = copy.deepcopy(inspect_raw.get("HostConfig", {}) or {})
+
+    # 1. Re-home the netns onto the new gluetun container id.
+    host_config["NetworkMode"] = f"container:{new_gluetun_id}"
+
+    # 2. Strip fields that conflict with sharing another container's network.
+    for f in _STRIP_CONFIG_FIELDS:
+        config.pop(f, None)
+    for f in _STRIP_HOSTCONFIG_FIELDS:
+        host_config.pop(f, None)
+
+    # 3. Carry mounts forward by source (anon volumes included). Mounts is the
+    #    authoritative long-form list, so drop the legacy short forms to avoid
+    #    Docker minting fresh anonymous volumes for the same destinations.
+    mounts: list[dict[str, Any]] = []
+    for m in inspect_raw.get("Mounts", []) or []:
+        spec = _mount_spec(m)
+        if spec is not None:
+            mounts.append(spec)
+    if mounts:
+        host_config["Mounts"] = mounts
+    else:
+        host_config.pop("Mounts", None)
+    host_config.pop("Binds", None)
+    host_config.pop("VolumesFrom", None)
+    # Config.Volumes would otherwise trigger fresh anon volumes for image VOLUMEs
+    # we've already carried via Mounts.
+    config.pop("Volumes", None)
+
+    # 4. Assemble the API create body: Config fields at top level + HostConfig.
+    body: dict[str, Any] = dict(config)
+    body["HostConfig"] = host_config
+    # A shared netns ignores per-container network config; don't send stale data.
+    body.pop("NetworkingConfig", None)
+    return body
+
+
+def recreate_dependent(
+    client: DockerClient,
+    dep_name: str,
+    new_gluetun_id: str,
+    logger: Logger,
+) -> bool:
+    """Recreate ``dep_name`` re-homed onto ``new_gluetun_id``. Returns success.
+
+    Order is remove-then-create because the new container reuses the same name.
+    ``volumes=False`` on remove is the data-preservation guarantee (ROC, ADR-0005).
+    """
+    info = client.inspect(dep_name)
+    if info is None:
+        logger.error(f"Cannot recreate {dep_name}: container not found")
+        return False
+
+    try:
+        body = build_create_body(info.raw, new_gluetun_id)
+    except Exception as exc:
+        logger.error(f"Cannot recreate {dep_name}: failed to build spec: {exc}")
+        return False
+
+    logger.warn(f"Recreating {dep_name} (re-homing netns onto gluetun {new_gluetun_id[:12]})")
+    try:
+        client.remove(dep_name, volumes=False)  # preserve named + anonymous volumes
+        new_id = client.create_from_config(body, name=dep_name)
+        client.start(new_id)
+    except Exception as exc:
+        logger.error(f"Recreate of {dep_name} failed: {exc}")
+        return False
+
+    logger.info(f"{dep_name} recreated as {new_id[:12]} and started")
+    return True

--- a/gluetun_monitor/report.py
+++ b/gluetun_monitor/report.py
@@ -29,7 +29,7 @@ from .site_stats import SiteStatsStore
 
 # Sort keys -> how to extract the sort value from a built site row (descending,
 # except "name" which is ascending alphabetical).
-_SORT_KEYS = ("p90", "p99", "avg", "max", "p50", "rate", "polls", "name")
+_SORT_KEYS = ("p90", "p99", "avg", "max", "p50", "rate", "polls", "eff", "name")
 
 
 def _fmt_ts(value: float | None) -> str:
@@ -85,6 +85,10 @@ def _sort_value(row: dict[str, Any], key: str) -> Any:
         return row["failure_rate"]
     if key == "polls":
         return row["polls"]
+    if key == "eff":
+        # None (no restarts) sorts last under reverse=True via -1.0 sentinel.
+        eff = row["restart_effectiveness"]
+        return eff if eff is not None else -1.0
     return row["latency_ms"][key]  # p50/p90/p99/avg/min/max
 
 

--- a/gluetun_monitor/report.py
+++ b/gluetun_monitor/report.py
@@ -43,7 +43,8 @@ def build_report(store: SiteStatsStore) -> dict[str, Any]:
     """A plain-data snapshot of the store: monitor totals + one row per site.
 
     Pure and JSON-serializable — the table renderer and ``--json`` share it, so
-    the two views can never drift."""
+    the two views can never drift.
+    """
     m = store.monitor
     sites: list[dict[str, Any]] = []
     for url, st in store.sites.items():
@@ -161,6 +162,7 @@ def format_table(report: dict[str, Any], sort: str = "p90", *, lifetime: bool = 
 
 
 def main(argv: list[str] | None = None) -> int:
+    """CLI entry point for ``gluetun-monitor-stats``; returns a process exit code."""
     parser = argparse.ArgumentParser(
         prog="gluetun-monitor-stats",
         description="Render the gluetun-monitor site-stats sidecar (read-only).",

--- a/gluetun_monitor/report.py
+++ b/gluetun_monitor/report.py
@@ -58,7 +58,8 @@ def build_report(store: SiteStatsStore) -> dict[str, Any]:
             "restarts_triggered": st.restarts_triggered,
             "restarts_cleared": st.restarts_cleared,
             "restart_effectiveness": st.restart_effectiveness,  # None = n/a
-            "latency_ms": lat,
+            "latency_ms": lat,  # recent ring ("now")
+            "lifetime_latency_ms": st.lifetime_latency.summary(),  # all-time (DDSketch)
             "failure_reasons": dict(st.failure_reasons),
             "last_success": st.last_success,
             "last_failure": st.last_failure,
@@ -78,7 +79,7 @@ def build_report(store: SiteStatsStore) -> dict[str, Any]:
     }
 
 
-def _sort_value(row: dict[str, Any], key: str) -> Any:
+def _sort_value(row: dict[str, Any], key: str, lat_field: str) -> Any:
     if key == "name":
         return row["site"]
     if key == "rate":
@@ -89,18 +90,23 @@ def _sort_value(row: dict[str, Any], key: str) -> Any:
         # None (no restarts) sorts last under reverse=True via -1.0 sentinel.
         eff = row["restart_effectiveness"]
         return eff if eff is not None else -1.0
-    return row["latency_ms"][key]  # p50/p90/p99/avg/min/max
+    return row[lat_field][key]  # p50/p90/p99/avg/min/max of the active window
 
 
-def _sorted_sites(report: dict[str, Any], key: str) -> list[dict[str, Any]]:
+def _sorted_sites(report: dict[str, Any], key: str, lat_field: str) -> list[dict[str, Any]]:
     rows = list(report["sites"])
     # "name" ascending; every numeric key descending (worst first — the tail you act on).
-    rows.sort(key=lambda r: _sort_value(r, key), reverse=(key != "name"))
+    rows.sort(key=lambda r: _sort_value(r, key, lat_field), reverse=(key != "name"))
     return rows
 
 
-def format_table(report: dict[str, Any], sort: str = "p90") -> str:
-    """Render the report as an aligned, human-readable matrix."""
+def format_table(report: dict[str, Any], sort: str = "p90", *, lifetime: bool = False) -> str:
+    """Render the report as an aligned, human-readable matrix.
+
+    ``lifetime=False`` shows the recent-ring latencies ("now"); ``lifetime=True``
+    shows the all-time histogram percentiles instead.
+    """
+    lat_field = "lifetime_latency_ms" if lifetime else "latency_ms"
     m = report["monitor"]
     out: list[str] = []
     hrs = m["total_runtime_seconds"] / 3600
@@ -112,9 +118,10 @@ def format_table(report: dict[str, Any], sort: str = "p90") -> str:
     started = _fmt_ts(m["first_started"])
     if m["first_started"]:
         out.append(f"tracking since {started}")
+    out.append(f"latency window: {'all-time' if lifetime else 'recent'}")
     out.append("")
 
-    rows = _sorted_sites(report, sort)
+    rows = _sorted_sites(report, sort, lat_field)
     if not rows:
         out.append("(no sites recorded yet)")
         return "\n".join(out)
@@ -123,7 +130,7 @@ def format_table(report: dict[str, Any], sort: str = "p90") -> str:
                "max", "eff%", "last_fail"]
     table: list[list[str]] = [headers]
     for r in rows:
-        lat = r["latency_ms"]
+        lat = r[lat_field]
         eff = r["restart_effectiveness"]
         table.append([
             r["site"],
@@ -165,6 +172,10 @@ def main(argv: list[str] | None = None) -> int:
     )
     parser.add_argument("--json", action="store_true", help="emit JSON instead of a table")
     parser.add_argument(
+        "--lifetime", action="store_true",
+        help="show all-time latency percentiles (histogram) instead of the recent window",
+    )
+    parser.add_argument(
         "--sort", choices=_SORT_KEYS, default="p90",
         help="sort sites by this column (default: p90, worst tail first)",
     )
@@ -185,7 +196,7 @@ def main(argv: list[str] | None = None) -> int:
     if args.json:
         print(json.dumps(report, indent=2, sort_keys=True))
     else:
-        print(format_table(report, sort=args.sort))
+        print(format_table(report, sort=args.sort, lifetime=args.lifetime))
     return 0
 
 

--- a/gluetun_monitor/report.py
+++ b/gluetun_monitor/report.py
@@ -1,0 +1,189 @@
+"""``gluetun-monitor-stats`` — render the persisted site-stats sidecar.
+
+A read-only operator command that ships in the image: it loads the same
+``site-stats.json`` the monitor writes (via the same SiteStatsStore code, so the
+numbers always match what the monitor computes) and prints a per-site matrix
+(latency percentiles, failure rate, restart-effectiveness) plus the monitor-wide
+totals. ``--json`` emits the same data for jq/dashboards.
+
+Usage::
+
+    docker exec gluetun-monitor gluetun-monitor-stats
+    docker exec gluetun-monitor gluetun-monitor-stats --sort avg
+    docker exec gluetun-monitor gluetun-monitor-stats --json | jq .
+
+It touches no Docker API and never mutates state — safe to run any time.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+from .site_stats import SiteStatsStore
+
+# Sort keys -> how to extract the sort value from a built site row (descending,
+# except "name" which is ascending alphabetical).
+_SORT_KEYS = ("p90", "p99", "avg", "max", "p50", "rate", "polls", "name")
+
+
+def _fmt_ts(value: float | None) -> str:
+    """A short local timestamp, or em dash when never seen."""
+    if not value:
+        return "—"
+    return datetime.fromtimestamp(value).strftime("%Y-%m-%d %H:%M")
+
+
+def build_report(store: SiteStatsStore) -> dict[str, Any]:
+    """A plain-data snapshot of the store: monitor totals + one row per site.
+
+    Pure and JSON-serializable — the table renderer and ``--json`` share it, so
+    the two views can never drift."""
+    m = store.monitor
+    sites: list[dict[str, Any]] = []
+    for url, st in store.sites.items():
+        lat = st.latency_summary()
+        sites.append({
+            "site": url,
+            "polls": st.total_polls,
+            "failures": st.total_failures,
+            "failure_rate": round(st.failure_rate, 4),
+            "failure_episodes": st.failure_episodes,
+            "longest_fail_streak": st.longest_fail_streak,
+            "restarts_triggered": st.restarts_triggered,
+            "restarts_cleared": st.restarts_cleared,
+            "restart_effectiveness": st.restart_effectiveness,  # None = n/a
+            "latency_ms": lat,
+            "failure_reasons": dict(st.failure_reasons),
+            "last_success": st.last_success,
+            "last_failure": st.last_failure,
+        })
+    return {
+        "monitor": {
+            "version": m.version,
+            "total_loops": m.total_loops,
+            "total_runtime_seconds": round(m.total_runtime_seconds),
+            "total_gluetun_restarts": m.total_gluetun_restarts,
+            "total_dependent_remediations": m.total_dependent_remediations,
+            "total_advisories": m.total_advisories,
+            "first_started": m.first_started,
+            "last_started": m.last_started,
+        },
+        "sites": sites,
+    }
+
+
+def _sort_value(row: dict[str, Any], key: str) -> Any:
+    if key == "name":
+        return row["site"]
+    if key == "rate":
+        return row["failure_rate"]
+    if key == "polls":
+        return row["polls"]
+    return row["latency_ms"][key]  # p50/p90/p99/avg/min/max
+
+
+def _sorted_sites(report: dict[str, Any], key: str) -> list[dict[str, Any]]:
+    rows = list(report["sites"])
+    # "name" ascending; every numeric key descending (worst first — the tail you act on).
+    rows.sort(key=lambda r: _sort_value(r, key), reverse=(key != "name"))
+    return rows
+
+
+def format_table(report: dict[str, Any], sort: str = "p90") -> str:
+    """Render the report as an aligned, human-readable matrix."""
+    m = report["monitor"]
+    out: list[str] = []
+    hrs = m["total_runtime_seconds"] / 3600
+    out.append(
+        f"monitor v{m['version'] or '?'}  loops={m['total_loops']}  runtime={hrs:.1f}h  "
+        f"gluetun_restarts={m['total_gluetun_restarts']}  "
+        f"remediations={m['total_dependent_remediations']}  advisories={m['total_advisories']}"
+    )
+    started = _fmt_ts(m["first_started"])
+    if m["first_started"]:
+        out.append(f"tracking since {started}")
+    out.append("")
+
+    rows = _sorted_sites(report, sort)
+    if not rows:
+        out.append("(no sites recorded yet)")
+        return "\n".join(out)
+
+    headers = ["site", "polls", "fails", "rate%", "avg", "p50", "p90", "p99",
+               "max", "eff%", "last_fail"]
+    table: list[list[str]] = [headers]
+    for r in rows:
+        lat = r["latency_ms"]
+        eff = r["restart_effectiveness"]
+        table.append([
+            r["site"],
+            str(r["polls"]),
+            str(r["failures"]),
+            f"{r['failure_rate'] * 100:.2f}",
+            str(lat["avg"]),
+            str(lat["p50"]),
+            str(lat["p90"]),
+            str(lat["p99"]),
+            str(lat["max"]),
+            "n/a" if eff is None else f"{eff * 100:.0f}",
+            _fmt_ts(r["last_failure"]),
+        ])
+
+    widths = [max(len(row[i]) for row in table) for i in range(len(headers))]
+    for i, row in enumerate(table):
+        # site left-justified; numeric columns right-justified.
+        cells = [row[0].ljust(widths[0])] + [
+            row[j].rjust(widths[j]) for j in range(1, len(headers))
+        ]
+        out.append("  ".join(cells))
+        if i == 0:
+            out.append("  ".join("-" * widths[j] for j in range(len(headers))))
+    out.append("")
+    out.append("latency in ms; eff% = restart-effectiveness (n/a = no restarts triggered)")
+    return "\n".join(out)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="gluetun-monitor-stats",
+        description="Render the gluetun-monitor site-stats sidecar (read-only).",
+    )
+    parser.add_argument(
+        "--file",
+        default=os.environ.get("STATS_FILE", "/logs/site-stats.json"),
+        help="path to site-stats.json (default: $STATS_FILE or /logs/site-stats.json)",
+    )
+    parser.add_argument("--json", action="store_true", help="emit JSON instead of a table")
+    parser.add_argument(
+        "--sort", choices=_SORT_KEYS, default="p90",
+        help="sort sites by this column (default: p90, worst tail first)",
+    )
+    args = parser.parse_args(argv)
+
+    if not Path(args.file).exists():
+        print(
+            f"No stats file at {args.file} — the monitor writes it once it has run a "
+            f"loop (set STATS_FILE or --file if it lives elsewhere).",
+            file=sys.stderr,
+        )
+        return 1
+
+    # Read-only load (no clock writes, no save). SiteStatsStore tolerates a corrupt
+    # file by starting empty, so a bad file prints an empty report, never crashes.
+    store = SiteStatsStore(args.file)
+    report = build_report(store)
+    if args.json:
+        print(json.dumps(report, indent=2, sort_keys=True))
+    else:
+        print(format_table(report, sort=args.sort))
+    return 0
+
+
+if __name__ == "__main__":  # `python -m gluetun_monitor.report`
+    sys.exit(main())

--- a/gluetun_monitor/site_stats.py
+++ b/gluetun_monitor/site_stats.py
@@ -18,14 +18,40 @@ episode length (in polls) is simply total_failures / failure_episodes.
 from __future__ import annotations
 
 import json
+import math
 import os
 import time
 from collections import Counter
 from collections.abc import Callable
-from dataclasses import asdict, dataclass
+from dataclasses import asdict, dataclass, field
 from pathlib import Path
 
 Clock = Callable[[], float]
+
+
+def categorize_failure(reason: str) -> str:
+    """Bucket a wget failure ``reason`` into a coarse category for the breakdown."""
+    low = reason.lower()
+    if "bad address" in low or "resolve" in low or "name or service" in low or "dns" in low:
+        return "dns"
+    if "ssl" in low or "tls" in low or "certificate" in low:
+        return "tls"
+    if "timed out" in low or "timeout" in low:
+        return "timeout"
+    if "refused" in low or "can't connect" in low or "cannot connect" in low or "connection" in low:
+        return "connection"
+    if "http" in low or "server returned" in low:
+        return "http-error"
+    return "other"
+
+
+def _percentile(values: list[int], p: float) -> int:
+    """Nearest-rank percentile (p in 0..100) of ``values``; 0 if empty."""
+    if not values:
+        return 0
+    s = sorted(values)
+    k = min(len(s) - 1, max(0, math.ceil(p / 100.0 * len(s)) - 1))
+    return s[k]
 
 
 @dataclass
@@ -39,9 +65,14 @@ class SiteStat:
     failure_episodes: int = 0  # count of distinct consecutive-failure runs
     longest_fail_streak: int = 0  # longest run of consecutive failed polls ever
     restarts_triggered: int = 0
+    restarts_cleared: int = 0  # restarts after which this site recovered (effectiveness)
     current_fail_streak: int = 0
     last_failure: float | None = None
     last_success: float | None = None
+    # Latency (ms) of recent *successful* polls — a bounded ring for percentiles.
+    recent_latencies: list[int] = field(default_factory=list)
+    # Failure counts bucketed by category (dns/tls/timeout/connection/http-error/other).
+    failure_reasons: dict[str, int] = field(default_factory=dict)
 
     @property
     def failure_rate(self) -> float:
@@ -50,6 +81,30 @@ class SiteStat:
     @property
     def avg_episode_polls(self) -> float:
         return self.total_failures / self.failure_episodes if self.failure_episodes else 0.0
+
+    @property
+    def restart_effectiveness(self) -> float:
+        """Fraction of this site's restarts after which it recovered on re-verify."""
+        return self.restarts_cleared / self.restarts_triggered if self.restarts_triggered else 0.0
+
+    def latency_summary(self) -> dict[str, int]:
+        """min/avg/max + p50/p90/p99 (ms) over the recent successful-poll samples.
+
+        p90 is the actionable tail; p99 is the robust extreme (unlike max, it
+        ignores the top outliers); p50 is the median (vs the mean in `avg`).
+        """
+        lat = self.recent_latencies
+        if not lat:
+            return {"samples": 0, "avg": 0, "min": 0, "max": 0, "p50": 0, "p90": 0, "p99": 0}
+        return {
+            "samples": len(lat),
+            "avg": round(sum(lat) / len(lat)),
+            "min": min(lat),
+            "max": max(lat),
+            "p50": _percentile(lat, 50),
+            "p90": _percentile(lat, 90),
+            "p99": _percentile(lat, 99),
+        }
 
 
 @dataclass
@@ -71,27 +126,40 @@ class SiteStatsStore:
         *,
         clock: Clock = time.time,
         recent_restarts_max: int = 500,
+        latency_ring_max: int = 200,
     ) -> None:
         self._path = Path(path) if path else None
         self._clock = clock
         self._recent_max = recent_restarts_max
+        self._latency_max = latency_ring_max
         self.sites: dict[str, SiteStat] = {}
         self.recent_restarts: list[dict[str, object]] = []  # {"ts": float, "site": str}
         self._load()
 
-    # ----- recording -----
-
-    def record_poll(self, site: str, ok: bool) -> None:
-        """Record one test of ``site`` (a primary loop poll; not the re-verify)."""
-        now = self._clock()
+    def _stat(self, site: str) -> SiteStat:
         st = self.sites.get(site)
         if st is None:
-            st = self.sites[site] = SiteStat(first_seen=now)
+            st = self.sites[site] = SiteStat(first_seen=self._clock())
+        return st
+
+    # ----- recording -----
+
+    def record_poll(self, site: str, ok: bool, duration_ms: int = 0, reason: str = "") -> None:
+        """Record one test of ``site`` (a primary loop poll; not the re-verify).
+
+        On success the response time feeds the latency ring (for percentiles); on
+        failure the reason is bucketed into the failure-reason breakdown.
+        """
+        now = self._clock()
+        st = self._stat(site)
         st.last_seen = now
         st.total_polls += 1
         if ok:
             st.current_fail_streak = 0
             st.last_success = now
+            st.recent_latencies.append(int(duration_ms))
+            if len(st.recent_latencies) > self._latency_max:
+                del st.recent_latencies[: -self._latency_max]
         else:
             st.total_failures += 1
             if st.current_fail_streak == 0:
@@ -99,17 +167,23 @@ class SiteStatsStore:
             st.current_fail_streak += 1
             st.longest_fail_streak = max(st.longest_fail_streak, st.current_fail_streak)
             st.last_failure = now
+            cat = categorize_failure(reason)
+            st.failure_reasons[cat] = st.failure_reasons.get(cat, 0) + 1
 
     def record_restart(self, site: str) -> None:
         """Record that ``site`` triggered a gluetun restart (attribution)."""
         now = self._clock()
-        st = self.sites.get(site)
-        if st is None:
-            st = self.sites[site] = SiteStat(first_seen=now)
-        st.restarts_triggered += 1
+        self._stat(site).restarts_triggered += 1
         self.recent_restarts.append({"ts": now, "site": site})
         if len(self.recent_restarts) > self._recent_max:
             del self.recent_restarts[: -self._recent_max]
+
+    def record_restart_outcome(self, site: str, cleared: bool) -> None:
+        """Record whether ``site`` recovered after the restart it triggered (the
+        post-restart re-verify). Drives restart-effectiveness — a site whose
+        restarts rarely clear it is the site's fault, not the VPN's."""
+        if cleared:
+            self._stat(site).restarts_cleared += 1
 
     def prune_stale(self, retention_seconds: float) -> list[str]:
         """Drop sites not polled within ``retention_seconds`` (e.g. removed from
@@ -165,9 +239,14 @@ class SiteStatsStore:
                     failure_episodes=raw.get("failure_episodes", 0),
                     longest_fail_streak=raw.get("longest_fail_streak", 0),
                     restarts_triggered=raw.get("restarts_triggered", 0),
+                    restarts_cleared=raw.get("restarts_cleared", 0),
                     current_fail_streak=raw.get("current_fail_streak", 0),
                     last_failure=raw.get("last_failure"),
                     last_success=raw.get("last_success"),
+                    recent_latencies=[int(x) for x in raw.get("recent_latencies", [])
+                                      if isinstance(x, int | float)],
+                    failure_reasons={str(k): int(v) for k, v in
+                                     (raw.get("failure_reasons") or {}).items()},
                 )
             recent = data.get("recent_restarts", [])
             self.recent_restarts = [
@@ -191,10 +270,20 @@ class SiteStatsStore:
         """
         if self._path is None:
             return False
+        # Persist raw counters (asdict) + computed metrics, so the file is both
+        # reloadable and human-readable at a glance.
+        sites_out = {}
+        for url, st in self.sites.items():
+            raw = asdict(st)
+            raw["failure_rate"] = round(st.failure_rate, 4)
+            raw["avg_episode_polls"] = round(st.avg_episode_polls, 2)
+            raw["restart_effectiveness"] = round(st.restart_effectiveness, 4)
+            raw["latency_ms"] = st.latency_summary()
+            sites_out[url] = raw
         payload = {
             "version": 1,
             "updated": self._clock(),
-            "sites": {url: asdict(st) for url, st in self.sites.items()},
+            "sites": sites_out,
             "recent_restarts": self.recent_restarts,
         }
         try:

--- a/gluetun_monitor/site_stats.py
+++ b/gluetun_monitor/site_stats.py
@@ -214,11 +214,13 @@ class SiteStatsStore:
         self.monitor.total_loops += 1
 
     def record_gluetun_restart(self) -> None:
-        """One actual gluetun restart (monitor-wide count)."""
+        """One gluetun restart initiated (monitor-wide count; counted when the
+        action is taken, not gated on it clearing the failure)."""
         self.monitor.total_gluetun_restarts += 1
 
     def record_dependent_remediation(self) -> None:
-        """One actual dependent restart/recreate (monitor-wide count)."""
+        """One dependent remediation initiated — restart/recreate (monitor-wide
+        count; counted when the action is taken, not gated on it succeeding)."""
         self.monitor.total_dependent_remediations += 1
 
     def record_advisory(self) -> None:

--- a/gluetun_monitor/site_stats.py
+++ b/gluetun_monitor/site_stats.py
@@ -302,6 +302,9 @@ class SiteStatsStore:
                 r for r in recent if isinstance(r, dict) and "ts" in r and "site" in r
             ]
             m = data.get("monitor") or {}
+            # `version` and `last_started` are intentionally NOT reloaded: version
+            # is re-stamped from the running build (the persisted one is for human
+            # reading only), and last_started is this process's start, set live.
             self.monitor = MonitorStats(
                 first_started=m.get("first_started", 0.0),
                 total_loops=m.get("total_loops", 0),

--- a/gluetun_monitor/site_stats.py
+++ b/gluetun_monitor/site_stats.py
@@ -27,6 +27,7 @@ from dataclasses import asdict, dataclass, field
 from pathlib import Path
 
 from . import __version__
+from .histogram import LatencyHistogram
 
 Clock = Callable[[], float]
 
@@ -73,6 +74,9 @@ class SiteStat:
     last_success: float | None = None
     # Latency (ms) of recent *successful* polls — a bounded ring for percentiles.
     recent_latencies: list[int] = field(default_factory=list)
+    # All-time latency percentiles in bounded memory (DDSketch-style; complements
+    # the recent ring — "lifetime" vs "now"). See histogram.py.
+    lifetime_latency: LatencyHistogram = field(default_factory=LatencyHistogram)
     # Failure counts bucketed by category (dns/tls/timeout/connection/http-error/other).
     failure_reasons: dict[str, int] = field(default_factory=dict)
 
@@ -187,6 +191,7 @@ class SiteStatsStore:
             st.recent_latencies.append(int(duration_ms))
             if len(st.recent_latencies) > self._latency_max:
                 del st.recent_latencies[: -self._latency_max]
+            st.lifetime_latency.add(int(duration_ms))  # all-time percentiles
         else:
             st.total_failures += 1
             if st.current_fail_streak == 0:
@@ -294,6 +299,7 @@ class SiteStatsStore:
                     last_success=raw.get("last_success"),
                     recent_latencies=[int(x) for x in raw.get("recent_latencies", [])
                                       if isinstance(x, int | float)],
+                    lifetime_latency=LatencyHistogram.from_dict(raw.get("lifetime_latency")),
                     failure_reasons={str(k): int(v) for k, v in
                                      (raw.get("failure_reasons") or {}).items()},
                 )
@@ -345,7 +351,11 @@ class SiteStatsStore:
             raw["avg_episode_polls"] = round(st.avg_episode_polls, 2)
             eff = st.restart_effectiveness
             raw["restart_effectiveness"] = round(eff, 4) if eff is not None else None
-            raw["latency_ms"] = st.latency_summary()
+            raw["latency_ms"] = st.latency_summary()  # recent ring (computed, human view)
+            # All-time histogram: store the reloadable sketch (string bucket keys)
+            # plus a human-readable lifetime summary.
+            raw["lifetime_latency"] = st.lifetime_latency.to_dict()
+            raw["lifetime_latency_ms"] = st.lifetime_latency.summary()
             sites_out[url] = raw
         now = self._clock()
         monitor_out = asdict(self.monitor)

--- a/gluetun_monitor/site_stats.py
+++ b/gluetun_monitor/site_stats.py
@@ -18,6 +18,7 @@ episode length (in polls) is simply total_failures / failure_episodes.
 from __future__ import annotations
 
 import json
+import os
 import time
 from collections import Counter
 from collections.abc import Callable
@@ -32,9 +33,11 @@ class SiteStat:
     """Lifetime counters for one test site."""
 
     first_seen: float
+    last_seen: float = 0.0  # last time this site was polled (for retention pruning)
     total_polls: int = 0
     total_failures: int = 0
     failure_episodes: int = 0  # count of distinct consecutive-failure runs
+    longest_fail_streak: int = 0  # longest run of consecutive failed polls ever
     restarts_triggered: int = 0
     current_fail_streak: int = 0
     last_failure: float | None = None
@@ -84,6 +87,7 @@ class SiteStatsStore:
         st = self.sites.get(site)
         if st is None:
             st = self.sites[site] = SiteStat(first_seen=now)
+        st.last_seen = now
         st.total_polls += 1
         if ok:
             st.current_fail_streak = 0
@@ -93,6 +97,7 @@ class SiteStatsStore:
             if st.current_fail_streak == 0:
                 st.failure_episodes += 1  # a new failure episode begins
             st.current_fail_streak += 1
+            st.longest_fail_streak = max(st.longest_fail_streak, st.current_fail_streak)
             st.last_failure = now
 
     def record_restart(self, site: str) -> None:
@@ -105,6 +110,18 @@ class SiteStatsStore:
         self.recent_restarts.append({"ts": now, "site": site})
         if len(self.recent_restarts) > self._recent_max:
             del self.recent_restarts[: -self._recent_max]
+
+    def prune_stale(self, retention_seconds: float) -> list[str]:
+        """Drop sites not polled within ``retention_seconds`` (e.g. removed from
+        sites.conf 90+ days ago). Returns the pruned site names. A non-positive
+        retention disables pruning (keep forever)."""
+        if retention_seconds <= 0:
+            return []
+        cutoff = self._clock() - retention_seconds
+        stale = [url for url, st in self.sites.items() if st.last_seen < cutoff]
+        for url in stale:
+            del self.sites[url]
+        return stale
 
     # ----- advisory -----
 
@@ -137,11 +154,16 @@ class SiteStatsStore:
         try:
             data = json.loads(self._path.read_text(encoding="utf-8"))
             for url, raw in data.get("sites", {}).items():
+                first_seen = raw.get("first_seen", 0.0)
                 self.sites[url] = SiteStat(
-                    first_seen=raw.get("first_seen", 0.0),
+                    first_seen=first_seen,
+                    # Old files predate last_seen; fall back so they aren't pruned
+                    # as "stale" the moment they load.
+                    last_seen=raw.get("last_seen") or first_seen,
                     total_polls=raw.get("total_polls", 0),
                     total_failures=raw.get("total_failures", 0),
                     failure_episodes=raw.get("failure_episodes", 0),
+                    longest_fail_streak=raw.get("longest_fail_streak", 0),
                     restarts_triggered=raw.get("restarts_triggered", 0),
                     current_fail_streak=raw.get("current_fail_streak", 0),
                     last_failure=raw.get("last_failure"),
@@ -157,8 +179,16 @@ class SiteStatsStore:
             self.recent_restarts = []
 
     def save(self) -> bool:
-        """Write stats to disk atomically. Returns False (and is ignored) on any
-        I/O error — stats must never block the monitor."""
+        """Write stats to disk crash- and power-loss-safely. Returns False (and is
+        ignored) on any I/O error — stats must never block the monitor.
+
+        Pattern: serialize to a temp file, ``fsync`` it, then atomically rename
+        over the target (``rename(2)``), then fsync the directory. A process crash
+        or container restart can only leave the *old* complete file or the *new*
+        complete file — never a partial/corrupt one — and the reader tolerates a
+        bad file regardless (``_load`` falls back to empty). The fsyncs extend that
+        guarantee across a host power loss, not just a process crash.
+        """
         if self._path is None:
             return False
         payload = {
@@ -170,11 +200,27 @@ class SiteStatsStore:
         try:
             self._path.parent.mkdir(parents=True, exist_ok=True)
             tmp = self._path.with_suffix(self._path.suffix + ".tmp")
-            tmp.write_text(json.dumps(payload, indent=2), encoding="utf-8")
-            tmp.replace(self._path)  # atomic
+            with tmp.open("w", encoding="utf-8") as fh:
+                json.dump(payload, fh, indent=2)
+                fh.flush()
+                os.fsync(fh.fileno())  # data is on disk before the rename
+            tmp.replace(self._path)  # atomic rename
+            self._fsync_dir(self._path.parent)  # persist the rename itself
             return True
         except OSError:
             return False
+
+    @staticmethod
+    def _fsync_dir(directory: Path) -> None:
+        """Best-effort fsync of a directory so a rename survives power loss."""
+        try:
+            fd = os.open(str(directory), os.O_RDONLY)
+            try:
+                os.fsync(fd)
+            finally:
+                os.close(fd)
+        except OSError:
+            pass
 
 
 def format_window(seconds: int) -> str:

--- a/gluetun_monitor/site_stats.py
+++ b/gluetun_monitor/site_stats.py
@@ -26,6 +26,8 @@ from collections.abc import Callable
 from dataclasses import asdict, dataclass, field
 from pathlib import Path
 
+from . import __version__
+
 Clock = Callable[[], float]
 
 
@@ -108,6 +110,20 @@ class SiteStat:
 
 
 @dataclass
+class MonitorStats:
+    """Top-level (monitor-wide) counters, persisted across restarts."""
+
+    version: str = ""
+    first_started: float = 0.0  # first ever start (persisted once)
+    last_started: float = 0.0  # this process's start
+    total_loops: int = 0  # check cycles run (cumulative)
+    total_runtime_seconds: float = 0.0  # accumulated running time (excludes downtime)
+    total_gluetun_restarts: int = 0
+    total_dependent_remediations: int = 0
+    total_advisories: int = 0
+
+
+@dataclass
 class Advisory:
     """A flaky-site finding worth surfacing to the operator."""
 
@@ -134,7 +150,14 @@ class SiteStatsStore:
         self._latency_max = latency_ring_max
         self.sites: dict[str, SiteStat] = {}
         self.recent_restarts: list[dict[str, object]] = []  # {"ts": float, "site": str}
+        self.monitor = MonitorStats()
         self._load()
+        # Stamp this process's start; first_started persists from the first ever run.
+        now = self._clock()
+        self.monitor.last_started = now
+        self.monitor.first_started = self.monitor.first_started or now
+        self.monitor.version = __version__
+        self._last_tick = now  # for runtime accumulation
 
     def _stat(self, site: str) -> SiteStat:
         st = self.sites.get(site)
@@ -177,6 +200,26 @@ class SiteStatsStore:
         self.recent_restarts.append({"ts": now, "site": site})
         if len(self.recent_restarts) > self._recent_max:
             del self.recent_restarts[: -self._recent_max]
+
+    def record_loop(self) -> None:
+        """Mark one check cycle: accumulate running time + bump the loop count.
+        Downtime between runs isn't counted (the tick resets on restart)."""
+        now = self._clock()
+        self.monitor.total_runtime_seconds += max(0.0, now - self._last_tick)
+        self._last_tick = now
+        self.monitor.total_loops += 1
+
+    def record_gluetun_restart(self) -> None:
+        """One actual gluetun restart (monitor-wide count)."""
+        self.monitor.total_gluetun_restarts += 1
+
+    def record_dependent_remediation(self) -> None:
+        """One actual dependent restart/recreate (monitor-wide count)."""
+        self.monitor.total_dependent_remediations += 1
+
+    def record_advisory(self) -> None:
+        """One flaky-site advisory raised (monitor-wide count)."""
+        self.monitor.total_advisories += 1
 
     def record_restart_outcome(self, site: str, cleared: bool) -> None:
         """Record whether ``site`` recovered after the restart it triggered (the
@@ -252,10 +295,20 @@ class SiteStatsStore:
             self.recent_restarts = [
                 r for r in recent if isinstance(r, dict) and "ts" in r and "site" in r
             ]
+            m = data.get("monitor") or {}
+            self.monitor = MonitorStats(
+                first_started=m.get("first_started", 0.0),
+                total_loops=m.get("total_loops", 0),
+                total_runtime_seconds=m.get("total_runtime_seconds", 0.0),
+                total_gluetun_restarts=m.get("total_gluetun_restarts", 0),
+                total_dependent_remediations=m.get("total_dependent_remediations", 0),
+                total_advisories=m.get("total_advisories", 0),
+            )
         except (OSError, ValueError, TypeError):
             # Corrupt/unreadable stats are non-fatal — start fresh in memory.
             self.sites = {}
             self.recent_restarts = []
+            self.monitor = MonitorStats()
 
     def save(self) -> bool:
         """Write stats to disk crash- and power-loss-safely. Returns False (and is
@@ -280,9 +333,13 @@ class SiteStatsStore:
             raw["restart_effectiveness"] = round(st.restart_effectiveness, 4)
             raw["latency_ms"] = st.latency_summary()
             sites_out[url] = raw
+        now = self._clock()
+        monitor_out = asdict(self.monitor)
+        monitor_out["current_uptime_seconds"] = round(max(0.0, now - self.monitor.last_started))
         payload = {
             "version": 1,
-            "updated": self._clock(),
+            "updated": now,
+            "monitor": monitor_out,
             "sites": sites_out,
             "recent_restarts": self.recent_restarts,
         }

--- a/gluetun_monitor/site_stats.py
+++ b/gluetun_monitor/site_stats.py
@@ -304,8 +304,12 @@ class SiteStatsStore:
                 total_dependent_remediations=m.get("total_dependent_remediations", 0),
                 total_advisories=m.get("total_advisories", 0),
             )
-        except (OSError, ValueError, TypeError):
-            # Corrupt/unreadable stats are non-fatal — start fresh in memory.
+        except (OSError, ValueError, TypeError, AttributeError, KeyError):
+            # Corrupt/unreadable stats are non-fatal — start fresh in memory. This
+            # must tolerate *any* shape of garbage, not just truncation: a file
+            # whose top level or a "sites"/"monitor" value is the wrong type (e.g.
+            # a JSON list) would otherwise raise AttributeError on .get()/.items()
+            # and crash startup, defeating the best-effort contract (Tenet 1).
             self.sites = {}
             self.recent_restarts = []
             self.monitor = MonitorStats()

--- a/gluetun_monitor/site_stats.py
+++ b/gluetun_monitor/site_stats.py
@@ -1,0 +1,188 @@
+"""Persistent per-site statistics + a flaky-site advisory (ADR-0008).
+
+Records, across monitor restarts, how each test site behaves over time so the
+operator gets attribution ("which sites cause the restarts, how often") and a
+historical "this site keeps being flaky" view — and so the monitor can advise
+"<site> caused A of the last B restarts over the last <window>; review it."
+
+This is **observability**, not control flow: it never changes whether the
+monitor restarts. Persistence is best-effort — a missing/corrupt/unwritable
+stats file degrades to in-memory and never blocks the monitor (Tenet 7). That's
+why persisting it doesn't violate the stateless recovery stance (Tenets 8/9):
+recovery stays in-memory and reset-on-restart; only the *stats* persist.
+
+Note: every failing poll belongs to exactly one failure episode, so the average
+episode length (in polls) is simply total_failures / failure_episodes.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from collections import Counter
+from collections.abc import Callable
+from dataclasses import asdict, dataclass
+from pathlib import Path
+
+Clock = Callable[[], float]
+
+
+@dataclass
+class SiteStat:
+    """Lifetime counters for one test site."""
+
+    first_seen: float
+    total_polls: int = 0
+    total_failures: int = 0
+    failure_episodes: int = 0  # count of distinct consecutive-failure runs
+    restarts_triggered: int = 0
+    current_fail_streak: int = 0
+    last_failure: float | None = None
+    last_success: float | None = None
+
+    @property
+    def failure_rate(self) -> float:
+        return self.total_failures / self.total_polls if self.total_polls else 0.0
+
+    @property
+    def avg_episode_polls(self) -> float:
+        return self.total_failures / self.failure_episodes if self.failure_episodes else 0.0
+
+
+@dataclass
+class Advisory:
+    """A flaky-site finding worth surfacing to the operator."""
+
+    site: str
+    site_restarts: int
+    total_restarts: int
+    window_seconds: int
+
+
+class SiteStatsStore:
+    """In-memory site stats with best-effort JSON persistence + advisory logic."""
+
+    def __init__(
+        self,
+        path: str | None = None,
+        *,
+        clock: Clock = time.time,
+        recent_restarts_max: int = 500,
+    ) -> None:
+        self._path = Path(path) if path else None
+        self._clock = clock
+        self._recent_max = recent_restarts_max
+        self.sites: dict[str, SiteStat] = {}
+        self.recent_restarts: list[dict[str, object]] = []  # {"ts": float, "site": str}
+        self._load()
+
+    # ----- recording -----
+
+    def record_poll(self, site: str, ok: bool) -> None:
+        """Record one test of ``site`` (a primary loop poll; not the re-verify)."""
+        now = self._clock()
+        st = self.sites.get(site)
+        if st is None:
+            st = self.sites[site] = SiteStat(first_seen=now)
+        st.total_polls += 1
+        if ok:
+            st.current_fail_streak = 0
+            st.last_success = now
+        else:
+            st.total_failures += 1
+            if st.current_fail_streak == 0:
+                st.failure_episodes += 1  # a new failure episode begins
+            st.current_fail_streak += 1
+            st.last_failure = now
+
+    def record_restart(self, site: str) -> None:
+        """Record that ``site`` triggered a gluetun restart (attribution)."""
+        now = self._clock()
+        st = self.sites.get(site)
+        if st is None:
+            st = self.sites[site] = SiteStat(first_seen=now)
+        st.restarts_triggered += 1
+        self.recent_restarts.append({"ts": now, "site": site})
+        if len(self.recent_restarts) > self._recent_max:
+            del self.recent_restarts[: -self._recent_max]
+
+    # ----- advisory -----
+
+    def advisory(
+        self, window_seconds: int, min_restarts: int, dominance: float
+    ) -> Advisory | None:
+        """Return an Advisory if one site dominates recent restarts, else None.
+
+        Fires when there have been >= ``min_restarts`` restarts within
+        ``window_seconds`` and a single site accounts for >= ``dominance`` of them.
+        """
+        cutoff = self._clock() - window_seconds
+        recent = [
+            r for r in self.recent_restarts
+            if isinstance(r.get("ts"), int | float) and float(r["ts"]) >= cutoff  # type: ignore[arg-type]
+        ]
+        if len(recent) < min_restarts:
+            return None
+        counts = Counter(str(r["site"]) for r in recent)
+        site, top = counts.most_common(1)[0]
+        if top / len(recent) >= dominance:
+            return Advisory(site, top, len(recent), window_seconds)
+        return None
+
+    # ----- persistence (best-effort) -----
+
+    def _load(self) -> None:
+        if self._path is None or not self._path.exists():
+            return
+        try:
+            data = json.loads(self._path.read_text(encoding="utf-8"))
+            for url, raw in data.get("sites", {}).items():
+                self.sites[url] = SiteStat(
+                    first_seen=raw.get("first_seen", 0.0),
+                    total_polls=raw.get("total_polls", 0),
+                    total_failures=raw.get("total_failures", 0),
+                    failure_episodes=raw.get("failure_episodes", 0),
+                    restarts_triggered=raw.get("restarts_triggered", 0),
+                    current_fail_streak=raw.get("current_fail_streak", 0),
+                    last_failure=raw.get("last_failure"),
+                    last_success=raw.get("last_success"),
+                )
+            recent = data.get("recent_restarts", [])
+            self.recent_restarts = [
+                r for r in recent if isinstance(r, dict) and "ts" in r and "site" in r
+            ]
+        except (OSError, ValueError, TypeError):
+            # Corrupt/unreadable stats are non-fatal — start fresh in memory.
+            self.sites = {}
+            self.recent_restarts = []
+
+    def save(self) -> bool:
+        """Write stats to disk atomically. Returns False (and is ignored) on any
+        I/O error — stats must never block the monitor."""
+        if self._path is None:
+            return False
+        payload = {
+            "version": 1,
+            "updated": self._clock(),
+            "sites": {url: asdict(st) for url, st in self.sites.items()},
+            "recent_restarts": self.recent_restarts,
+        }
+        try:
+            self._path.parent.mkdir(parents=True, exist_ok=True)
+            tmp = self._path.with_suffix(self._path.suffix + ".tmp")
+            tmp.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+            tmp.replace(self._path)  # atomic
+            return True
+        except OSError:
+            return False
+
+
+def format_window(seconds: int) -> str:
+    """Human-readable window like '24h' / '90m' / '7d' for advisory messages."""
+    if seconds % 86400 == 0:
+        return f"{seconds // 86400}d"
+    if seconds % 3600 == 0:
+        return f"{seconds // 3600}h"
+    if seconds % 60 == 0:
+        return f"{seconds // 60}m"
+    return f"{seconds}s"

--- a/gluetun_monitor/site_stats.py
+++ b/gluetun_monitor/site_stats.py
@@ -85,9 +85,13 @@ class SiteStat:
         return self.total_failures / self.failure_episodes if self.failure_episodes else 0.0
 
     @property
-    def restart_effectiveness(self) -> float:
-        """Fraction of this site's restarts after which it recovered on re-verify."""
-        return self.restarts_cleared / self.restarts_triggered if self.restarts_triggered else 0.0
+    def restart_effectiveness(self) -> float | None:
+        """Fraction of this site's restarts after which it recovered on re-verify,
+        or None when the site has triggered no restarts (so callers render 'n/a'
+        rather than a misleading 0% that reads as 'restarts never worked')."""
+        if not self.restarts_triggered:
+            return None
+        return self.restarts_cleared / self.restarts_triggered
 
     def latency_summary(self) -> dict[str, int]:
         """min/avg/max + p50/p90/p99 (ms) over the recent successful-poll samples.
@@ -334,7 +338,8 @@ class SiteStatsStore:
             raw = asdict(st)
             raw["failure_rate"] = round(st.failure_rate, 4)
             raw["avg_episode_polls"] = round(st.avg_episode_polls, 2)
-            raw["restart_effectiveness"] = round(st.restart_effectiveness, 4)
+            eff = st.restart_effectiveness
+            raw["restart_effectiveness"] = round(eff, 4) if eff is not None else None
             raw["latency_ms"] = st.latency_summary()
             sites_out[url] = raw
         now = self._clock()

--- a/gluetun_monitor/site_stats.py
+++ b/gluetun_monitor/site_stats.py
@@ -82,17 +82,20 @@ class SiteStat:
 
     @property
     def failure_rate(self) -> float:
+        """Fraction of all polls that failed (0.0 if never polled)."""
         return self.total_failures / self.total_polls if self.total_polls else 0.0
 
     @property
     def avg_episode_polls(self) -> float:
+        """Average length, in failed polls, of a failure episode (0.0 if none)."""
         return self.total_failures / self.failure_episodes if self.failure_episodes else 0.0
 
     @property
     def restart_effectiveness(self) -> float | None:
         """Fraction of this site's restarts after which it recovered on re-verify,
         or None when the site has triggered no restarts (so callers render 'n/a'
-        rather than a misleading 0% that reads as 'restarts never worked')."""
+        rather than a misleading 0% that reads as 'restarts never worked').
+        """
         if not self.restarts_triggered:
             return None
         return self.restarts_cleared / self.restarts_triggered
@@ -212,7 +215,8 @@ class SiteStatsStore:
 
     def record_loop(self) -> None:
         """Mark one check cycle: accumulate running time + bump the loop count.
-        Downtime between runs isn't counted (the tick resets on restart)."""
+        Downtime between runs isn't counted (the tick resets on restart).
+        """
         now = self._clock()
         self.monitor.total_runtime_seconds += max(0.0, now - self._last_tick)
         self._last_tick = now
@@ -220,12 +224,14 @@ class SiteStatsStore:
 
     def record_gluetun_restart(self) -> None:
         """One gluetun restart initiated (monitor-wide count; counted when the
-        action is taken, not gated on it clearing the failure)."""
+        action is taken, not gated on it clearing the failure).
+        """
         self.monitor.total_gluetun_restarts += 1
 
     def record_dependent_remediation(self) -> None:
         """One dependent remediation initiated — restart/recreate (monitor-wide
-        count; counted when the action is taken, not gated on it succeeding)."""
+        count; counted when the action is taken, not gated on it succeeding).
+        """
         self.monitor.total_dependent_remediations += 1
 
     def record_advisory(self) -> None:
@@ -235,14 +241,16 @@ class SiteStatsStore:
     def record_restart_outcome(self, site: str, cleared: bool) -> None:
         """Record whether ``site`` recovered after the restart it triggered (the
         post-restart re-verify). Drives restart-effectiveness — a site whose
-        restarts rarely clear it is the site's fault, not the VPN's."""
+        restarts rarely clear it is the site's fault, not the VPN's.
+        """
         if cleared:
             self._stat(site).restarts_cleared += 1
 
     def prune_stale(self, retention_seconds: float) -> list[str]:
         """Drop sites not polled within ``retention_seconds`` (e.g. removed from
         sites.conf 90+ days ago). Returns the pruned site names. A non-positive
-        retention disables pruning (keep forever)."""
+        retention disables pruning (keep forever).
+        """
         if retention_seconds <= 0:
             return []
         cutoff = self._clock() - retention_seconds

--- a/gluetun_monitor/sites.py
+++ b/gluetun_monitor/sites.py
@@ -46,15 +46,29 @@ def parse_sites_csv(value: str) -> list[str]:
     return [s for s in (trim(x) for x in value.split(",")) if s]
 
 
-def load_sites(config_file: str | Path, sites_env: str | None) -> list[str]:
-    """Effective test set: the union of ``sites.conf`` and the ``SITES`` env CSV.
+def unsafe_site_reason(site: str) -> str | None:
+    """Why ``site`` is unsafe/useless to probe, or None if it's acceptable.
 
-    Either source is optional; both may be supplied. Duplicates are removed,
-    first-occurrence order preserved (file entries first, then env-only ones). A
-    missing config file contributes nothing (not an error here — the caller
-    decides whether the *combined* set being empty is fatal). The file is re-read
-    on each call, so editing it is picked up live; the env value is fixed at
-    process start.
+    A leading-dash entry would be parsed by ``wget``/``ping`` as an *option*
+    rather than a URL — e.g. ``--directory-prefix=/etc`` could write files inside
+    a container (the exec layer also guards this with a ``--`` separator; this
+    keeps such a bogus "flag URL" out of the test set entirely — Tenet 1). An
+    entry with no host component tests nothing.
+    """
+    if site.startswith("-"):
+        return "looks like a command-line flag (leading '-')"
+    if not hostname_of(site):
+        return "no host component"
+    return None
+
+
+def load_sites_report(
+    config_file: str | Path, sites_env: str | None
+) -> tuple[list[str], list[tuple[str, str]]]:
+    """Like :func:`load_sites`, but also returns rejected ``(entry, reason)`` pairs.
+
+    Used at startup so the operator gets a loud warning about dropped entries; the
+    per-loop path uses :func:`load_sites` and drops them silently (already warned).
     """
     try:
         file_sites = parse_sites_conf(config_file)
@@ -63,12 +77,31 @@ def load_sites(config_file: str | Path, sites_env: str | None) -> list[str]:
     env_sites = parse_sites_csv(sites_env) if sites_env else []
 
     seen: set[str] = set()
-    merged: list[str] = []
+    safe: list[str] = []
+    rejected: list[tuple[str, str]] = []
     for site in (*file_sites, *env_sites):
-        if site not in seen:
-            seen.add(site)
-            merged.append(site)
-    return merged
+        if site in seen:
+            continue
+        seen.add(site)
+        reason = unsafe_site_reason(site)
+        if reason is not None:
+            rejected.append((site, reason))
+        else:
+            safe.append(site)
+    return safe, rejected
+
+
+def load_sites(config_file: str | Path, sites_env: str | None) -> list[str]:
+    """Effective test set: the union of ``sites.conf`` and the ``SITES`` env CSV.
+
+    Either source is optional; both may be supplied. Duplicates are removed,
+    first-occurrence order preserved (file entries first, then env-only ones).
+    Unsafe entries (see :func:`unsafe_site_reason`) are dropped. A missing config
+    file contributes nothing (not an error here — the caller decides whether the
+    *combined* set being empty is fatal). The file is re-read on each call, so
+    editing it is picked up live; the env value is fixed at process start.
+    """
+    return load_sites_report(config_file, sites_env)[0]
 
 
 def hostname_of(url: str) -> str:

--- a/gluetun_monitor/sites.py
+++ b/gluetun_monitor/sites.py
@@ -41,6 +41,36 @@ def parse_sites_conf(path: str | Path) -> list[str]:
     return sites
 
 
+def parse_sites_csv(value: str) -> list[str]:
+    """Parse a comma-separated ``SITES`` env value into trimmed URLs."""
+    return [s for s in (trim(x) for x in value.split(",")) if s]
+
+
+def load_sites(config_file: str | Path, sites_env: str | None) -> list[str]:
+    """Effective test set: the union of ``sites.conf`` and the ``SITES`` env CSV.
+
+    Either source is optional; both may be supplied. Duplicates are removed,
+    first-occurrence order preserved (file entries first, then env-only ones). A
+    missing config file contributes nothing (not an error here — the caller
+    decides whether the *combined* set being empty is fatal). The file is re-read
+    on each call, so editing it is picked up live; the env value is fixed at
+    process start.
+    """
+    try:
+        file_sites = parse_sites_conf(config_file)
+    except FileNotFoundError:
+        file_sites = []
+    env_sites = parse_sites_csv(sites_env) if sites_env else []
+
+    seen: set[str] = set()
+    merged: list[str] = []
+    for site in (*file_sites, *env_sites):
+        if site not in seen:
+            seen.add(site)
+            merged.append(site)
+    return merged
+
+
 def hostname_of(url: str) -> str:
     """Return the host portion of a URL (no port, brackets stripped for IPv6)."""
     # urlsplit needs a scheme to populate .hostname; assume http if bare.

--- a/gluetun_monitor/sites.py
+++ b/gluetun_monitor/sites.py
@@ -1,0 +1,69 @@
+"""sites.conf parsing and URL classification.
+
+Parsing mirrors v1.x exactly: skip blank lines and ``#`` comments, trim
+whitespace. Classification (resolvable hostname vs IP-literal) feeds the
+ADR-0006 per-dependent viability pool — only hostname URLs exercise a
+dependent's DNS.
+"""
+
+from __future__ import annotations
+
+import ipaddress
+from pathlib import Path
+from urllib.parse import urlsplit
+
+
+def trim(s: str) -> str:
+    """Strip leading/trailing whitespace.
+
+    Pure replacement for the v1.x bash ``trim`` (which avoided ``xargs`` so that
+    quotes in input — e.g. ``Provence-Alpes-Cote-d'Azur`` — don't crash; issue
+    #17). Quotes are preserved.
+    """
+    return s.strip()
+
+
+def parse_sites_conf(path: str | Path) -> list[str]:
+    """Read a sites.conf and return the list of test URLs.
+
+    Skips blank/whitespace-only lines and ``#`` comments; trims each entry.
+    Raises FileNotFoundError if the file is missing (caller decides severity).
+    """
+    sites: list[str] = []
+    text = Path(path).read_text(encoding="utf-8")
+    for raw_line in text.splitlines():
+        if raw_line.lstrip().startswith("#"):
+            continue
+        site = trim(raw_line)
+        if not site:
+            continue
+        sites.append(site)
+    return sites
+
+
+def hostname_of(url: str) -> str:
+    """Return the host portion of a URL (no port, brackets stripped for IPv6)."""
+    # urlsplit needs a scheme to populate .hostname; assume http if bare.
+    parsed = urlsplit(url if "://" in url else f"http://{url}")
+    return parsed.hostname or ""
+
+
+def is_ip_literal(host: str) -> bool:
+    """True if ``host`` is a bare IPv4/IPv6 address rather than a DNS name."""
+    if not host:
+        return False
+    try:
+        ipaddress.ip_address(host)
+    except ValueError:
+        return False
+    return True
+
+
+def resolvable_pool(sites: list[str]) -> list[str]:
+    """URLs whose host is a DNS name — these exercise a dependent's resolver."""
+    return [s for s in sites if not is_ip_literal(hostname_of(s))]
+
+
+def ip_pool(sites: list[str]) -> list[str]:
+    """URLs whose host is an IP literal — connectivity-only fallback."""
+    return [s for s in sites if is_ip_literal(hostname_of(s))]

--- a/gluetun_monitor/state.py
+++ b/gluetun_monitor/state.py
@@ -43,6 +43,7 @@ class Counter:
         self._counts[key] = 0
 
     def get(self, key: str) -> int:
+        """Current consecutive-failure count for ``key`` (0 if never seen)."""
         return self._counts.get(key, 0)
 
     def reset_all(self) -> None:

--- a/gluetun_monitor/state.py
+++ b/gluetun_monitor/state.py
@@ -46,6 +46,11 @@ class Counter:
         """Current consecutive-failure count for ``key`` (0 if never seen)."""
         return self._counts.get(key, 0)
 
+    def discard(self, key: str) -> None:
+        """Forget ``key`` entirely (e.g. a site removed from the config), so a
+        later re-add starts clean rather than resuming a stale count."""
+        self._counts.pop(key, None)
+
     def reset_all(self) -> None:
         """Zero every counter (post-recovery, per v1.x ``handle_failure``)."""
         for key in self._counts:

--- a/gluetun_monitor/state.py
+++ b/gluetun_monitor/state.py
@@ -48,7 +48,8 @@ class Counter:
 
     def discard(self, key: str) -> None:
         """Forget ``key`` entirely (e.g. a site removed from the config), so a
-        later re-add starts clean rather than resuming a stale count."""
+        later re-add starts clean rather than resuming a stale count.
+        """
         self._counts.pop(key, None)
 
     def reset_all(self) -> None:

--- a/gluetun_monitor/state.py
+++ b/gluetun_monitor/state.py
@@ -1,7 +1,7 @@
 """In-memory state: consecutive-failure counters and state-machine enums.
 
 Counters are consecutive and reset on any pass; nothing is persisted and there
-is no backoff/circuit-breaker (ADR-0006, Tenet 8 / ROC): recovery is cheap and
+is no backoff/circuit-breaker (ADR-0006, Tenet 9 / ROC): recovery is cheap and
 non-destructive, so we re-evaluate every loop rather than carry fragile state.
 A monitor restart zeroes everything.
 """

--- a/gluetun_monitor/state.py
+++ b/gluetun_monitor/state.py
@@ -1,0 +1,51 @@
+"""In-memory state: consecutive-failure counters and state-machine enums.
+
+Counters are consecutive and reset on any pass; nothing is persisted and there
+is no backoff/circuit-breaker (ADR-0006, Tenet 8 / ROC): recovery is cheap and
+non-destructive, so we re-evaluate every loop rather than carry fragile state.
+A monitor restart zeroes everything.
+"""
+
+from __future__ import annotations
+
+from enum import Enum, auto
+
+
+class InterfaceStatus(Enum):
+    """Result of the ADR-0004 interface check (``ls /sys/class/net``)."""
+
+    LIVE = auto()  # has a non-loopback interface (eth0/tun0) — eligible worker
+    STRANDED = auto()  # only ``lo`` — netns binding lost; hard failure
+    UNKNOWN = auto()  # could not determine (e.g. distroless, exec failed)
+
+
+class RemediationAction(Enum):
+    """The ADR-0004 restart-vs-recreate decision for a failing dependent."""
+
+    RESTART = auto()  # NetworkMode target == current gluetun id -> docker restart
+    RECREATE = auto()  # target != current id -> must recreate (NetworkMode immutable)
+    TRY_RESTART = auto()  # name-form / unreadable target -> try restart, escalate
+
+
+class Counter:
+    """Per-key consecutive-failure counter. ``fail`` bumps, ``reset`` zeroes."""
+
+    def __init__(self) -> None:
+        self._counts: dict[str, int] = {}
+
+    def fail(self, key: str) -> int:
+        """Increment ``key``'s consecutive-failure count and return the new value."""
+        self._counts[key] = self._counts.get(key, 0) + 1
+        return self._counts[key]
+
+    def reset(self, key: str) -> None:
+        """Zero ``key``'s counter (a passing loop)."""
+        self._counts[key] = 0
+
+    def get(self, key: str) -> int:
+        return self._counts.get(key, 0)
+
+    def reset_all(self) -> None:
+        """Zero every counter (post-recovery, per v1.x ``handle_failure``)."""
+        for key in self._counts:
+            self._counts[key] = 0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,13 +35,15 @@ dev = [
 packages = ["gluetun_monitor"]
 
 [tool.ruff]
-line-length = 100
+# 120, not 80 — modern wide displays, not a 1980s terminal. Wide enough to not
+# fight you; a guardrail for diffs/side-by-side review, not a straitjacket.
+line-length = 120
 target-version = "py313"
 src = ["gluetun_monitor", "tests"]
 
 [tool.ruff.lint]
 select = [
-    "E", "F", "W",   # pycodestyle + pyflakes
+    "E", "F", "W",   # pycodestyle + pyflakes (PEP 8)
     "I",             # isort
     "B",             # bugbear
     "UP",            # pyupgrade
@@ -49,14 +51,24 @@ select = [
     "SIM",           # simplify
     "RET",           # return
     "PTH",           # prefer pathlib
+    "D",             # pydocstyle (PEP 257 docstring conventions)
     "RUF",
 ]
 ignore = [
     "SIM105",  # contextlib.suppress over try/except/pass — try/except reads fine here
+    # pydocstyle: we enforce docstring *presence* + formatting, but exempt the three
+    # most commonly-waived stylistic rules (our docstrings are already clear):
+    "D107",    # __init__ docstring — the class docstring already covers it
+    "D205",    # blank line between summary and description — we wrap summaries
+    "D401",    # imperative mood — "True if…"/"Whether…" reads fine for predicates
 ]
 
+[tool.ruff.lint.pydocstyle]
+convention = "pep257"
+
 [tool.ruff.lint.per-file-ignores]
-"tests/*" = ["B011"]
+# Tests: don't require docstrings on every test fn (module docstrings still apply).
+"tests/*" = ["B011", "D"]
 
 [tool.ruff.lint.isort]
 known-first-party = ["gluetun_monitor"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,93 @@
+[build-system]
+requires = ["setuptools>=68", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "gluetun-monitor"
+version = "2.0.0"
+description = "Dependent-aware connectivity monitor and self-healer for gluetun VPN stacks"
+readme = "README.md"
+license = { file = "LICENSE" }
+requires-python = ">=3.13"
+authors = [{ name = "Charles Marshall" }]
+keywords = ["gluetun", "vpn", "docker", "monitoring", "healthcheck"]
+dependencies = [
+    "docker>=7.0,<8",
+]
+
+[project.urls]
+Homepage = "https://github.com/csmarshall/gluetun-monitor"
+Issues = "https://github.com/csmarshall/gluetun-monitor/issues"
+
+[project.scripts]
+gluetun-monitor = "gluetun_monitor.cli:main"
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=8",
+    "pytest-cov>=5",
+    "ruff>=0.6",
+    "mypy>=1.11",
+]
+
+[tool.setuptools]
+packages = ["gluetun_monitor"]
+
+[tool.ruff]
+line-length = 100
+target-version = "py313"
+src = ["gluetun_monitor", "tests"]
+
+[tool.ruff.lint]
+select = [
+    "E", "F", "W",   # pycodestyle + pyflakes
+    "I",             # isort
+    "B",             # bugbear
+    "UP",            # pyupgrade
+    "C4",            # comprehensions
+    "SIM",           # simplify
+    "RET",           # return
+    "PTH",           # prefer pathlib
+    "RUF",
+]
+ignore = [
+    "SIM105",  # contextlib.suppress over try/except/pass — try/except reads fine here
+]
+
+[tool.ruff.lint.per-file-ignores]
+"tests/*" = ["B011"]
+
+[tool.ruff.lint.isort]
+known-first-party = ["gluetun_monitor"]
+
+[tool.mypy]
+python_version = "3.13"
+strict = true
+warn_unreachable = true
+warn_redundant_casts = true
+# docker-py ships partial/loose stubs; don't fail the build on its internals.
+[[tool.mypy.overrides]]
+module = "docker.*"
+ignore_missing_imports = true
+follow_imports = "skip"
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+addopts = "-ra -q"
+markers = [
+    "integration: tests that require a live Docker daemon (deselect with -m 'not integration')",
+    "differential: compares the legacy bash implementation against the Python port",
+]
+
+[tool.coverage.run]
+branch = true
+source = ["gluetun_monitor"]
+omit = ["gluetun_monitor/__main__.py"]
+
+[tool.coverage.report]
+show_missing = true
+exclude_lines = [
+    "pragma: no cover",
+    "if TYPE_CHECKING:",
+    "raise NotImplementedError",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,4 +90,7 @@ exclude_lines = [
     "pragma: no cover",
     "if TYPE_CHECKING:",
     "raise NotImplementedError",
+    # Protocol method stubs are never executed (definition-only).
+    "^\\s*\\.\\.\\.$",
+    'if __name__ == .__main__.:',
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ Issues = "https://github.com/csmarshall/gluetun-monitor/issues"
 
 [project.scripts]
 gluetun-monitor = "gluetun_monitor.cli:main"
+gluetun-monitor-stats = "gluetun_monitor.report:main"
 
 [project.optional-dependencies]
 dev = [

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,40 @@
+"""Shared fixtures: a fake client, a captured-output logger, and a base Config."""
+
+from __future__ import annotations
+
+import io
+
+import pytest
+
+from gluetun_monitor.config import Config
+from gluetun_monitor.logging_setup import Logger
+
+from .fakes import FakeDockerClient
+
+
+@pytest.fixture
+def fake_client() -> FakeDockerClient:
+    return FakeDockerClient()
+
+
+@pytest.fixture
+def log_stream() -> io.StringIO:
+    return io.StringIO()
+
+
+@pytest.fixture
+def logger(log_stream: io.StringIO) -> Logger:
+    # DEBUG level so tests can assert on debug lines; no file (stream only).
+    return Logger(log_file=None, level="DEBUG", stream=log_stream)
+
+
+@pytest.fixture
+def config() -> Config:
+    # Defaults match the v1.x contract; tests override fields as needed.
+    return Config()
+
+
+@pytest.fixture
+def no_sleep():
+    """A sleep callable that does nothing — keeps recovery tests instant."""
+    return lambda _seconds: None

--- a/tests/fakes.py
+++ b/tests/fakes.py
@@ -1,0 +1,136 @@
+"""In-memory fake DockerClient + inspect-dict builder for unit tests.
+
+The fake records every mutating call (restart/remove/create/start) so tests can
+assert *what the monitor decided to do* without a live daemon — this is the seam
+ADR-0007 exists to provide.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any
+
+from gluetun_monitor.docker_client import ContainerInfo, ExecResult
+
+ExecHandler = Callable[[str, list[str]], ExecResult]
+
+
+def make_inspect(
+    name: str,
+    *,
+    id: str,
+    network_mode: str = "",
+    running: bool = True,
+    health: str | None = "healthy",
+    mounts: list[dict[str, Any]] | None = None,
+    config: dict[str, Any] | None = None,
+    host_config: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Build a docker-inspect-shaped dict."""
+    state: dict[str, Any] = {"Running": running}
+    if health is not None:
+        state["Health"] = {"Status": health}
+    full_host_config = {"NetworkMode": network_mode}
+    full_host_config.update(host_config or {})
+    return {
+        "Id": id,
+        "Name": f"/{name}",
+        "State": state,
+        "Config": config or {"Image": "example/app:latest"},
+        "HostConfig": full_host_config,
+        "Mounts": mounts or [],
+    }
+
+
+class FakeDockerClient:
+    """Scriptable in-memory DockerClient."""
+
+    def __init__(self) -> None:
+        self._store: dict[str, dict[str, Any]] = {}  # id -> raw inspect
+        self.ping_ok = True
+        self.on_exec: ExecHandler = lambda name, cmd: ExecResult(0, "")
+        # Recorded mutations:
+        self.restarted: list[str] = []
+        self.removed: list[tuple[str, bool]] = []  # (name_or_id, volumes)
+        self.created: list[tuple[dict[str, Any], str]] = []  # (body, name)
+        self.started: list[str] = []
+        self._id_seq = 1000
+
+    # ----- test setup helpers -----
+
+    def add(self, raw: dict[str, Any]) -> ContainerInfo:
+        self._store[raw["Id"]] = raw
+        return ContainerInfo.from_inspect(raw)
+
+    def add_container(self, name: str, **kwargs: Any) -> ContainerInfo:
+        if "id" not in kwargs:
+            kwargs["id"] = f"id_{name}_{self._next_id()}"
+        return self.add(make_inspect(name, **kwargs))
+
+    def _next_id(self) -> int:
+        self._id_seq += 1
+        return self._id_seq
+
+    def _resolve(self, name_or_id: str) -> dict[str, Any] | None:
+        if name_or_id in self._store:
+            return self._store[name_or_id]
+        for raw in self._store.values():
+            if raw["Name"].lstrip("/") == name_or_id:
+                return raw
+            if raw["Id"].startswith(name_or_id) and len(name_or_id) >= 12:
+                return raw
+        return None
+
+    # ----- DockerClient protocol -----
+
+    def ping(self) -> bool:
+        return self.ping_ok
+
+    def list_running_ids(self) -> list[str]:
+        return [
+            raw["Id"]
+            for raw in self._store.values()
+            if raw.get("State", {}).get("Running", False)
+        ]
+
+    def inspect(self, name_or_id: str) -> ContainerInfo | None:
+        raw = self._resolve(name_or_id)
+        return ContainerInfo.from_inspect(raw) if raw is not None else None
+
+    def exec_run(self, name_or_id: str, cmd: list[str]) -> ExecResult:
+        return self.on_exec(name_or_id, cmd)
+
+    def logs(self, name_or_id: str) -> str:
+        raw = self._resolve(name_or_id)
+        return raw.get("_logs", "") if raw else ""
+
+    def restart(self, name_or_id: str) -> None:
+        raw = self._resolve(name_or_id)
+        if raw is None:
+            raise RuntimeError(f"no such container: {name_or_id}")
+        raw["State"]["Running"] = True
+        self.restarted.append(name_or_id)
+
+    def remove(self, name_or_id: str, *, volumes: bool) -> None:
+        raw = self._resolve(name_or_id)
+        if raw is None:
+            raise RuntimeError(f"no such container: {name_or_id}")
+        del self._store[raw["Id"]]
+        self.removed.append((name_or_id, volumes))
+
+    def create_from_config(self, config: dict[str, Any], name: str) -> str:
+        new_id = f"id_{name}_recreated_{self._next_id()}"
+        nm = config.get("HostConfig", {}).get("NetworkMode", "")
+        raw = make_inspect(name, id=new_id, network_mode=nm, running=False, health="healthy")
+        raw["Config"] = {k: v for k, v in config.items() if k != "HostConfig"}
+        raw["HostConfig"] = config.get("HostConfig", {})
+        self._store[new_id] = raw
+        self.created.append((config, name))
+        return new_id
+
+    def start(self, name_or_id: str) -> None:
+        raw = self._resolve(name_or_id)
+        if raw is None:
+            raise RuntimeError(f"no such container: {name_or_id}")
+        raw["State"]["Running"] = True
+        self.started.append(name_or_id)

--- a/tests/test_advisory_integration.py
+++ b/tests/test_advisory_integration.py
@@ -48,8 +48,7 @@ def test_repeated_restarts_from_one_site_raise_advisory(tmp_path: Path) -> None:
         fail_threshold=1,            # breach on first failure each loop
         dns_wait_timeout=2,
         advisory_min_restarts=3,     # advise after 3 restarts
-        advisory_dominance=0.5,
-        stats_save_every=1000,       # don't write during the test
+        advisory_dominance=0.5,       # don't write during the test
     )
     mon = Monitor(
         fake, cfg, Logger(log_file=None, stream=stream),
@@ -80,8 +79,7 @@ def test_advisory_deduped_not_per_loop(tmp_path: Path) -> None:
     )
     stream = io.StringIO()
     cfg = Config(config_file=str(conf), gluetun_container="gluetun", fail_threshold=1,
-                 dns_wait_timeout=2, advisory_min_restarts=3, advisory_dominance=0.5,
-                 stats_save_every=1000)
+                 dns_wait_timeout=2, advisory_min_restarts=3, advisory_dominance=0.5)
     mon = Monitor(fake, cfg, Logger(log_file=None, stream=stream),
                   rng=random.Random(0), sleep=lambda _s: None, stats=SiteStatsStore(None))
     for _ in range(6):

--- a/tests/test_advisory_integration.py
+++ b/tests/test_advisory_integration.py
@@ -1,0 +1,89 @@
+"""End-to-end: a chronically-flaky site triggers the flaky-site advisory.
+
+Why: ties the gluetun root test → restart attribution → advisory together, the
+way it runs live. A site that keeps causing restarts should, after enough of
+them, produce the "FLAKY SITE … review it" warning (the human-in-the-loop
+escalation chosen over auto-quarantine).
+"""
+
+from __future__ import annotations
+
+import io
+import random
+from pathlib import Path
+
+from gluetun_monitor.config import Config
+from gluetun_monitor.docker_client import ExecResult
+from gluetun_monitor.logging_setup import Logger
+from gluetun_monitor.monitor import Monitor
+from gluetun_monitor.site_stats import SiteStatsStore
+
+from .fakes import FakeDockerClient
+
+GLUETUN_ID = "a" * 64
+
+
+def test_repeated_restarts_from_one_site_raise_advisory(tmp_path: Path) -> None:
+    conf = tmp_path / "sites.conf"
+    conf.write_text("https://flaky.example\n")
+
+    fake = FakeDockerClient()
+    fake.add_container("gluetun", id=GLUETUN_ID, health="healthy")
+
+    def handler(name: str, cmd: list[str]) -> ExecResult:
+        # gluetun's DNS-stability probe passes (fast wait); the test site always
+        # fails to respond -> breaches every loop -> triggers a restart each loop.
+        if cmd and cmd[0] == "nslookup":
+            return ExecResult(0, "")
+        if "https://1.1.1.1" in cmd:
+            return ExecResult(0, "")
+        return ExecResult(4, "")  # flaky.example never responds
+
+    fake.on_exec = handler
+
+    stream = io.StringIO()
+    cfg = Config(
+        config_file=str(conf),
+        gluetun_container="gluetun",
+        fail_threshold=1,            # breach on first failure each loop
+        dns_wait_timeout=2,
+        advisory_min_restarts=3,     # advise after 3 restarts
+        advisory_dominance=0.5,
+        stats_save_every=1000,       # don't write during the test
+    )
+    mon = Monitor(
+        fake, cfg, Logger(log_file=None, stream=stream),
+        rng=random.Random(0), sleep=lambda _s: None,
+        stats=SiteStatsStore(None),  # in-memory, no filesystem
+    )
+
+    mon.run_once()  # restart 1
+    mon.run_once()  # restart 2
+    assert "FLAKY SITE" not in stream.getvalue()
+    mon.run_once()  # restart 3 -> advisory fires
+    out = stream.getvalue()
+    assert "FLAKY SITE: https://flaky.example" in out
+    assert "review" in out
+    # The site's restart attribution is recorded.
+    assert mon.stats.sites["https://flaky.example"].restarts_triggered == 3
+
+
+def test_advisory_deduped_not_per_loop(tmp_path: Path) -> None:
+    """Once warned about a site, don't repeat every loop (no spam)."""
+    conf = tmp_path / "sites.conf"
+    conf.write_text("https://flaky.example\n")
+    fake = FakeDockerClient()
+    fake.add_container("gluetun", id=GLUETUN_ID, health="healthy")
+    fake.on_exec = lambda n, c: (
+        ExecResult(0, "") if (c and c[0] == "nslookup") or "https://1.1.1.1" in c
+        else ExecResult(4, "")
+    )
+    stream = io.StringIO()
+    cfg = Config(config_file=str(conf), gluetun_container="gluetun", fail_threshold=1,
+                 dns_wait_timeout=2, advisory_min_restarts=3, advisory_dominance=0.5,
+                 stats_save_every=1000)
+    mon = Monitor(fake, cfg, Logger(log_file=None, stream=stream),
+                  rng=random.Random(0), sleep=lambda _s: None, stats=SiteStatsStore(None))
+    for _ in range(6):
+        mon.run_once()
+    assert stream.getvalue().count("FLAKY SITE: https://flaky.example") == 1

--- a/tests/test_arg_injection.py
+++ b/tests/test_arg_injection.py
@@ -1,0 +1,98 @@
+"""A leading-dash site can't be turned into a wget/ping/getent option.
+
+Why (Tenet 1 — first do no harm): site URLs come from sites.conf / SITES, which
+an operator may template or share. An entry like ``--directory-prefix=/etc`` is
+parsed by GNU wget as a flag, not a URL — it could write files inside a probed
+container and corrupts the connectivity signal. Two layers close this: the exec
+arg-lists put ``--`` before the URL/host, and sites parsing drops leading-dash /
+hostless entries with a warning rather than probing them.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from gluetun_monitor.connectivity import probe_site
+from gluetun_monitor.dns_check import validate_dns
+from gluetun_monitor.docker_client import ExecResult
+from gluetun_monitor.sites import load_sites, load_sites_report, unsafe_site_reason
+
+from .fakes import FakeDockerClient
+
+
+def _capture() -> tuple[FakeDockerClient, list[list[str]]]:
+    fake = FakeDockerClient()
+    cmds: list[list[str]] = []
+
+    def handler(name: str, cmd: list[str]) -> ExecResult:
+        cmds.append(cmd)
+        return ExecResult(0, "  HTTP/1.1 200 OK\n")
+
+    fake.on_exec = handler
+    return fake, cmds
+
+
+def _end_of_options(cmd: list[str], value: str) -> bool:
+    """The value appears, and a ``--`` separator precedes it."""
+    return value in cmd and "--" in cmd[: cmd.index(value)]
+
+
+def test_probe_site_puts_url_after_end_of_options() -> None:
+    fake, cmds = _capture()
+    probe_site(fake, "dep", "--directory-prefix=/etc", timeout=10)
+    assert _end_of_options(cmds[0], "--directory-prefix=/etc")
+
+
+def test_validate_dns_guards_wget_getent_ping() -> None:
+    """All three cascade tools get the host after ``--`` (none present -> full
+    cascade, so we see every command)."""
+    fake = FakeDockerClient()
+    cmds: list[list[str]] = []
+
+    def handler(name: str, cmd: list[str]) -> ExecResult:
+        cmds.append(cmd)
+        if cmd and cmd[0] == "wget":
+            return ExecResult(-1, "")  # absent -> fall through to getent
+        if cmd[:2] == ["getent", "hosts"]:
+            return ExecResult(127, "not found")  # absent -> fall through to ping
+        return ExecResult(1, "")  # ping ran, no resolution
+
+    fake.on_exec = handler
+    validate_dns(fake, "dep", "http://-evil.example", "-evil.example", timeout=5)
+    wget = next(c for c in cmds if c and c[0] == "wget")
+    getent = next(c for c in cmds if c[:2] == ["getent", "hosts"])
+    ping = next(c for c in cmds if c and c[0] == "ping")
+    assert _end_of_options(wget, "http://-evil.example")
+    assert _end_of_options(getent, "-evil.example")
+    assert _end_of_options(ping, "-evil.example")
+
+
+def test_unsafe_site_reason() -> None:
+    assert unsafe_site_reason("--output-document=/x") is not None
+    assert unsafe_site_reason("-x") is not None
+    assert unsafe_site_reason("http://") is not None  # no host
+    assert unsafe_site_reason("https://www.google.com") is None
+    assert unsafe_site_reason("1.1.1.1") is None  # bare IP is fine
+
+
+def test_load_sites_drops_unsafe_entries(tmp_path: Path) -> None:
+    conf = tmp_path / "sites.conf"
+    conf.write_text("https://ok.example\n--evil-flag\nhttp://\n", encoding="utf-8")
+    safe = load_sites(conf, None)
+    assert safe == ["https://ok.example"]
+
+
+def test_load_sites_report_explains_rejections(tmp_path: Path) -> None:
+    conf = tmp_path / "sites.conf"
+    conf.write_text("https://ok.example\n--evil-flag\n", encoding="utf-8")
+    safe, rejected = load_sites_report(conf, None)
+    assert safe == ["https://ok.example"]
+    assert rejected and rejected[0][0] == "--evil-flag"
+    assert "flag" in rejected[0][1]
+
+
+def test_unsafe_entries_from_sites_env_are_dropped(tmp_path: Path) -> None:
+    safe, rejected = load_sites_report(tmp_path / "missing.conf",
+                                       "https://a.example,-bad,--also-bad")
+    assert safe == ["https://a.example"]
+    assert {e for e, _ in rejected} == {"-bad", "--also-bad"}

--- a/tests/test_branches.py
+++ b/tests/test_branches.py
@@ -1,4 +1,10 @@
-"""Defensive exception / malformed-input branches across modules."""
+"""Defensive exception / malformed-input branches across modules.
+
+Why: a watchdog must survive a flaky daemon and odd container state — a thrown
+exec, a failed create, a vanished container, a malformed mount/NetworkMode.
+These tests ensure each such case degrades to a safe outcome (skip / False /
+unknown / default) rather than crashing the loop (Tenets 1, 7).
+"""
 
 from __future__ import annotations
 
@@ -22,10 +28,9 @@ def _logger() -> Logger:
     return Logger(log_file=None, level="DEBUG", stream=io.StringIO())
 
 
-# ----- endpoint: logs() raising -----
-
-
 def test_get_endpoint_info_handles_logs_exception() -> None:
+    """If fetching gluetun's logs throws, endpoint info degrades to "unknown" —
+    logging is best-effort and must never gate the loop."""
     fake = FakeDockerClient()
 
     def boom(name: str) -> str:
@@ -36,20 +41,18 @@ def test_get_endpoint_info_handles_logs_exception() -> None:
     assert info.public_ip == "unknown"  # default, no crash
 
 
-# ----- dependents: empty gluetun id reaches _ids_match guard -----
-
-
 def test_remediation_recreate_when_gluetun_id_empty() -> None:
+    """An empty current gluetun id can't match any target → recreate (exercises
+    the _ids_match empty-string guard; an empty id never falsely matches)."""
     fake = FakeDockerClient()
     info = fake.add_container("dep", network_mode=f"container:{GLUETUN_ID}")
-    # An empty current id can't match -> recreate (exercises the _ids_match guard).
     assert remediation_action(info, "") is RemediationAction.RECREATE
 
 
-# ----- recreate: malformed mounts are skipped -----
-
-
 def test_build_create_body_skips_malformed_mounts() -> None:
+    """Mount entries we can't faithfully reproduce (no name/source/destination,
+    unknown type) are dropped, not carried as broken specs — only the valid one
+    survives, so a recreate never fails on a malformed mount."""
     raw = make_inspect(
         "dep",
         id="d1",
@@ -66,10 +69,9 @@ def test_build_create_body_skips_malformed_mounts() -> None:
     assert hc["Mounts"] == [{"Type": "volume", "Source": "ok", "Target": "/d", "ReadOnly": False}]
 
 
-# ----- recreate: create failure -> False (and the old container is already gone) -----
-
-
 def test_recreate_dependent_create_failure_returns_false() -> None:
+    """If the create step fails mid-recreate, recreate_dependent returns False so
+    the caller reports FAILED (rather than assuming success)."""
     fake = FakeDockerClient()
     fake.add(make_inspect("dep", id="d1", network_mode=f"container:{GLUETUN_ID}"))
 
@@ -80,10 +82,9 @@ def test_recreate_dependent_create_failure_returns_false() -> None:
     assert recreate_dependent(fake, "dep", "f" * 64, _logger()) is False
 
 
-# ----- recovery: restart_gluetun when restart raises -----
-
-
 def test_restart_gluetun_handles_restart_exception() -> None:
+    """A restart call that raises is caught and reported as failure, not an
+    unhandled crash."""
     fake = FakeDockerClient()
     fake.add_container("gluetun", id=GLUETUN_ID)
 
@@ -94,10 +95,9 @@ def test_restart_gluetun_handles_restart_exception() -> None:
     assert restart_gluetun(fake, Config(), _logger(), sleep=lambda _s: None) is False
 
 
-# ----- recovery: wait_for_dns swallows exec exceptions and times out -----
-
-
 def test_wait_for_dns_handles_exec_exception() -> None:
+    """If the DNS probe exec throws, wait_for_dns keeps polling and times out
+    gracefully (False) instead of propagating the error."""
     fake = FakeDockerClient()
     fake.add_container("gluetun", id=GLUETUN_ID)
 
@@ -108,19 +108,17 @@ def test_wait_for_dns_handles_exec_exception() -> None:
     assert wait_for_dns(fake, "gluetun", 4, _logger(), sleep=lambda _s: None) is False
 
 
-# ----- recovery: remediate when the container vanished -----
-
-
 def test_remediate_missing_container_returns_false() -> None:
+    """Remediating a container that no longer exists returns False (nothing to
+    act on) rather than raising."""
     fake = FakeDockerClient()
     ok = remediate_dependent(fake, "ghost", GLUETUN_ID, Config(), _logger(), sleep=lambda _s: None)
     assert ok is False
 
 
-# ----- recovery: try-restart succeeds (no escalation) -----
-
-
 def test_remediate_try_restart_success_without_escalation() -> None:
+    """Name-form target whose restart *succeeds* heals via restart alone — we
+    only escalate to recreate when the restart fails."""
     fake = FakeDockerClient()
     fake.add_container("dep", network_mode="container:gluetun")  # name form -> TRY_RESTART
 

--- a/tests/test_branches.py
+++ b/tests/test_branches.py
@@ -1,0 +1,136 @@
+"""Defensive exception / malformed-input branches across modules."""
+
+from __future__ import annotations
+
+import io
+
+from gluetun_monitor.config import Config
+from gluetun_monitor.dependents import remediation_action
+from gluetun_monitor.docker_client import ExecResult
+from gluetun_monitor.endpoint import get_endpoint_info
+from gluetun_monitor.logging_setup import Logger
+from gluetun_monitor.recovery import remediate_dependent, restart_gluetun, wait_for_dns
+from gluetun_monitor.recreate import build_create_body, recreate_dependent
+from gluetun_monitor.state import RemediationAction
+
+from .fakes import FakeDockerClient, make_inspect
+
+GLUETUN_ID = "a" * 64
+
+
+def _logger() -> Logger:
+    return Logger(log_file=None, level="DEBUG", stream=io.StringIO())
+
+
+# ----- endpoint: logs() raising -----
+
+
+def test_get_endpoint_info_handles_logs_exception() -> None:
+    fake = FakeDockerClient()
+
+    def boom(name: str) -> str:
+        raise RuntimeError("logs unavailable")
+
+    fake.logs = boom  # type: ignore[method-assign]
+    info = get_endpoint_info(fake, "gluetun")
+    assert info.public_ip == "unknown"  # default, no crash
+
+
+# ----- dependents: empty gluetun id reaches _ids_match guard -----
+
+
+def test_remediation_recreate_when_gluetun_id_empty() -> None:
+    fake = FakeDockerClient()
+    info = fake.add_container("dep", network_mode=f"container:{GLUETUN_ID}")
+    # An empty current id can't match -> recreate (exercises the _ids_match guard).
+    assert remediation_action(info, "") is RemediationAction.RECREATE
+
+
+# ----- recreate: malformed mounts are skipped -----
+
+
+def test_build_create_body_skips_malformed_mounts() -> None:
+    raw = make_inspect(
+        "dep",
+        id="d1",
+        network_mode=f"container:{GLUETUN_ID}",
+        mounts=[
+            {"Type": "volume", "Destination": "/a"},          # volume w/o Name -> skip
+            {"Type": "bind", "Destination": "/b"},            # bind w/o Source -> skip
+            {"Type": "weird", "Destination": "/c"},           # unknown type -> skip
+            {"Type": "volume", "Name": "v", "Destination": ""},  # no destination -> skip
+            {"Type": "volume", "Name": "ok", "Destination": "/d"},  # kept
+        ],
+    )
+    hc = build_create_body(raw, "f" * 64)["HostConfig"]
+    assert hc["Mounts"] == [{"Type": "volume", "Source": "ok", "Target": "/d", "ReadOnly": False}]
+
+
+# ----- recreate: create failure -> False (and the old container is already gone) -----
+
+
+def test_recreate_dependent_create_failure_returns_false() -> None:
+    fake = FakeDockerClient()
+    fake.add(make_inspect("dep", id="d1", network_mode=f"container:{GLUETUN_ID}"))
+
+    def boom(config: dict[str, object], name: str) -> str:
+        raise RuntimeError("create rejected")
+
+    fake.create_from_config = boom  # type: ignore[method-assign]
+    assert recreate_dependent(fake, "dep", "f" * 64, _logger()) is False
+
+
+# ----- recovery: restart_gluetun when restart raises -----
+
+
+def test_restart_gluetun_handles_restart_exception() -> None:
+    fake = FakeDockerClient()
+    fake.add_container("gluetun", id=GLUETUN_ID)
+
+    def boom(name: str) -> None:
+        raise RuntimeError("daemon refused")
+
+    fake.restart = boom  # type: ignore[method-assign]
+    assert restart_gluetun(fake, Config(), _logger(), sleep=lambda _s: None) is False
+
+
+# ----- recovery: wait_for_dns swallows exec exceptions and times out -----
+
+
+def test_wait_for_dns_handles_exec_exception() -> None:
+    fake = FakeDockerClient()
+    fake.add_container("gluetun", id=GLUETUN_ID)
+
+    def boom(name: str, cmd: list[str]) -> ExecResult:
+        raise RuntimeError("exec failed")
+
+    fake.on_exec = boom
+    assert wait_for_dns(fake, "gluetun", 4, _logger(), sleep=lambda _s: None) is False
+
+
+# ----- recovery: remediate when the container vanished -----
+
+
+def test_remediate_missing_container_returns_false() -> None:
+    fake = FakeDockerClient()
+    ok = remediate_dependent(fake, "ghost", GLUETUN_ID, Config(), _logger(), sleep=lambda _s: None)
+    assert ok is False
+
+
+# ----- recovery: try-restart succeeds (no escalation) -----
+
+
+def test_remediate_try_restart_success_without_escalation() -> None:
+    fake = FakeDockerClient()
+    fake.add_container("dep", network_mode="container:gluetun")  # name form -> TRY_RESTART
+
+    def handler(name: str, cmd: list[str]) -> ExecResult:
+        if cmd[:2] == ["ls", "/sys/class/net"]:
+            return ExecResult(0, "eth0\nlo\n")
+        return ExecResult(0, "")
+
+    fake.on_exec = handler
+    ok = remediate_dependent(fake, "dep", GLUETUN_ID, Config(), _logger(), sleep=lambda _s: None)
+    assert ok is True
+    assert fake.restarted == ["dep"]
+    assert fake.created == []  # restart worked, no escalation to recreate

--- a/tests/test_characterization.py
+++ b/tests/test_characterization.py
@@ -1,0 +1,108 @@
+"""Characterization / differential suite (ADR-0007 no-regressions gate).
+
+These tests pin the v1.x bash contract by executing the *actual* legacy
+functions from ``gluetun-monitor.sh`` and asserting the Python port produces
+identical results. The bash script stays in-tree as the differential oracle.
+Marked ``differential``; skipped automatically if bash or the script is absent.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from gluetun_monitor.config import Config
+from gluetun_monitor.connectivity import WGET_PASS_CODES, decode_wget_exit_code
+from gluetun_monitor.sites import trim
+
+_BASH = shutil.which("bash")
+_SCRIPT = Path(__file__).resolve().parent.parent / "gluetun-monitor.sh"
+
+pytestmark = [
+    pytest.mark.differential,
+    pytest.mark.skipif(
+        _BASH is None or not _SCRIPT.exists(),
+        reason="bash and the legacy gluetun-monitor.sh are required for differential tests",
+    ),
+]
+
+
+def _source_and_call(call: str, env_extra: dict[str, str] | None = None) -> str:
+    """Source the legacy script (main disabled) and run one function call."""
+    src = _SCRIPT.read_text(encoding="utf-8")
+    # Disable the loop entry point the same way the bats suite does.
+    src = src.replace('main "$@"', ': # main disabled for differential tests')
+    program = f"{src}\n{call}\n"
+    env = {**os.environ, **(env_extra or {})}
+    result = subprocess.run(
+        [_BASH, "-c", program],
+        capture_output=True,
+        text=True,
+        env=env,
+        timeout=30,
+    )
+    assert result.returncode == 0, f"bash failed: {result.stderr}"
+    return result.stdout
+
+
+# ----- differential: trim (bash trim vs Python trim) -----
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "   hello world   ",
+        "\t  hello\t",
+        "",
+        "     ",
+        ' say "hi" ',
+        " Provence-Alpes-Cote-d'Azur ",  # issue #17
+        "no-surrounding-space",
+    ],
+)
+def test_trim_matches_bash(value: str) -> None:
+    # Pass via env to avoid any shell-quoting differences in the harness itself.
+    bash_out = _source_and_call('trim "$TRIM_IN"', {"TRIM_IN": value})
+    assert trim(value) == bash_out  # bash trim uses printf '%s' (no trailing newline)
+
+
+# ----- differential: wget exit-code decoding -----
+
+
+@pytest.mark.parametrize("code", [0, 1, 2, 3, 4, 5, 6, 7, 8, 99])
+def test_decode_wget_exit_code_matches_bash(code: int) -> None:
+    bash_out = _source_and_call(f"decode_wget_exit_code {code}").rstrip("\n")
+    assert decode_wget_exit_code(code) == bash_out
+
+
+def test_wget_pass_codes_match_bash_logic() -> None:
+    # v1.x test_site_async treats exit 0 (success) and 6/8 (site responded) as PASS.
+    assert frozenset({0, 6, 8}) == WGET_PASS_CODES
+
+
+# ----- contract: env-var defaults match the legacy script's defaults -----
+
+
+def _bash_default(var: str) -> str:
+    """Extract the ``${VAR:-default}`` fallback from the legacy script."""
+    text = _SCRIPT.read_text(encoding="utf-8")
+    m = re.search(rf'^{var}="\$\{{{var}:-([^}}]*)\}}"', text, re.MULTILINE)
+    assert m, f"could not find default for {var} in legacy script"
+    return m.group(1)
+
+
+def test_env_defaults_match_legacy_script() -> None:
+    c = Config()
+    assert _bash_default("CONFIG_FILE") == c.config_file
+    assert _bash_default("LOG_FILE") == c.log_file
+    assert int(_bash_default("CHECK_INTERVAL")) == c.check_interval
+    assert int(_bash_default("TIMEOUT")) == c.timeout
+    assert int(_bash_default("FAIL_THRESHOLD")) == c.fail_threshold
+    assert _bash_default("GLUETUN_CONTAINER") == c.gluetun_container
+    assert int(_bash_default("HEALTHY_WAIT_TIMEOUT")) == c.healthy_wait_timeout
+    assert _bash_default("DEPENDENT_CONTAINERS") == c.dependent_containers

--- a/tests/test_characterization.py
+++ b/tests/test_characterization.py
@@ -66,6 +66,8 @@ def _source_and_call(call: str, env_extra: dict[str, str] | None = None) -> str:
     ],
 )
 def test_trim_matches_bash(value: str) -> None:
+    """Differential: the Python trim must produce byte-identical output to the
+    legacy bash trim for every input — including the #17 apostrophe case."""
     # Pass via env to avoid any shell-quoting differences in the harness itself.
     bash_out = _source_and_call('trim "$TRIM_IN"', {"TRIM_IN": value})
     assert trim(value) == bash_out  # bash trim uses printf '%s' (no trailing newline)
@@ -76,12 +78,15 @@ def test_trim_matches_bash(value: str) -> None:
 
 @pytest.mark.parametrize("code", [0, 1, 2, 3, 4, 5, 6, 7, 8, 99])
 def test_decode_wget_exit_code_matches_bash(code: int) -> None:
+    """Differential: the Python exit-code reasons match the legacy bash function
+    exactly — the no-regressions gate for the connectivity classification."""
     bash_out = _source_and_call(f"decode_wget_exit_code {code}").rstrip("\n")
     assert decode_wget_exit_code(code) == bash_out
 
 
 def test_wget_pass_codes_match_bash_logic() -> None:
-    # v1.x test_site_async treats exit 0 (success) and 6/8 (site responded) as PASS.
+    """The pass set matches v1.x test_site_async: 0 (success) and 6/8 (site
+    responded) count as the tunnel working."""
     assert frozenset({0, 6, 8}) == WGET_PASS_CODES
 
 
@@ -97,6 +102,9 @@ def _bash_default(var: str) -> str:
 
 
 def test_env_defaults_match_legacy_script() -> None:
+    """Contract: every shared env default in the Python Config equals the
+    ${VAR:-default} the legacy bash script used — so a port didn't silently
+    change a default an existing deployment relies on."""
     c = Config()
     assert _bash_default("CONFIG_FILE") == c.config_file
     assert _bash_default("LOG_FILE") == c.log_file

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,52 @@
+"""CLI prerequisite checks (v1.x ``check_prerequisites`` parity)."""
+
+from __future__ import annotations
+
+import io
+from pathlib import Path
+
+from gluetun_monitor.cli import check_prerequisites
+from gluetun_monitor.config import Config
+from gluetun_monitor.logging_setup import Logger
+
+from .fakes import FakeDockerClient
+
+GLUETUN_ID = "a" * 64
+
+
+def _logger() -> Logger:
+    return Logger(log_file=None, level="DEBUG", stream=io.StringIO())
+
+
+def _sites(tmp_path: Path) -> str:
+    conf = tmp_path / "sites.conf"
+    conf.write_text("https://www.google.com\n")
+    return str(conf)
+
+
+def test_prereqs_pass(tmp_path: Path) -> None:
+    fake = FakeDockerClient()
+    fake.add_container("gluetun", id=GLUETUN_ID)
+    cfg = Config(config_file=_sites(tmp_path))
+    assert check_prerequisites(fake, cfg, _logger()) is True
+
+
+def test_prereqs_fail_missing_config(tmp_path: Path) -> None:
+    fake = FakeDockerClient()
+    fake.add_container("gluetun", id=GLUETUN_ID)
+    cfg = Config(config_file=str(tmp_path / "absent.conf"))
+    assert check_prerequisites(fake, cfg, _logger()) is False
+
+
+def test_prereqs_fail_docker_unreachable(tmp_path: Path) -> None:
+    fake = FakeDockerClient()
+    fake.add_container("gluetun", id=GLUETUN_ID)
+    fake.ping_ok = False
+    cfg = Config(config_file=_sites(tmp_path))
+    assert check_prerequisites(fake, cfg, _logger()) is False
+
+
+def test_prereqs_fail_gluetun_absent(tmp_path: Path) -> None:
+    fake = FakeDockerClient()  # no gluetun container
+    cfg = Config(config_file=_sites(tmp_path))
+    assert check_prerequisites(fake, cfg, _logger()) is False

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,4 +1,10 @@
-"""Config defaults + env parsing. The v1.x defaults are part of the contract."""
+"""Config defaults + env parsing.
+
+Why: the env-var names and their defaults are a compatibility contract with v1.x
+(documented in the README and pinned by the differential suite). These tests
+guard against a default silently drifting and against env overrides not taking
+effect — either of which would change behavior for existing deployments.
+"""
 
 from __future__ import annotations
 
@@ -8,6 +14,7 @@ from gluetun_monitor.config import Config
 
 
 def test_defaults_match_v1_contract() -> None:
+    """The v1.x env defaults must not drift — existing users rely on them."""
     c = Config()
     assert c.config_file == "/config/sites.conf"
     assert c.log_file == "/logs/gluetun-monitor.log"
@@ -21,6 +28,7 @@ def test_defaults_match_v1_contract() -> None:
 
 
 def test_v2_defaults() -> None:
+    """The new v2 knobs default to safe, on-by-default behavior (Tenet 7)."""
     c = Config()
     assert c.dependent_container_failures == 2  # mirrors fail_threshold
     assert c.max_parallel_checks == 6
@@ -29,6 +37,8 @@ def test_v2_defaults() -> None:
 
 
 def test_from_env_defaults_with_clean_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """With no env set, from_env() must equal the dataclass defaults — i.e. the
+    two default sources can't diverge."""
     for var in (
         "CONFIG_FILE", "LOG_FILE", "CHECK_INTERVAL", "TIMEOUT", "FAIL_THRESHOLD",
         "GLUETUN_CONTAINER", "HEALTHY_WAIT_TIMEOUT", "DEPENDENT_CONTAINERS",
@@ -40,6 +50,7 @@ def test_from_env_defaults_with_clean_env(monkeypatch: pytest.MonkeyPatch) -> No
 
 
 def test_from_env_overrides(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Env values actually override the defaults (the basic config path works)."""
     monkeypatch.setenv("CHECK_INTERVAL", "15")
     monkeypatch.setenv("FAIL_THRESHOLD", "5")
     monkeypatch.setenv("GLUETUN_CONTAINER", "vpn")
@@ -54,6 +65,8 @@ def test_from_env_overrides(monkeypatch: pytest.MonkeyPatch) -> None:
 def test_dependent_container_failures_defaults_to_fail_threshold(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    """Unset, the dependent threshold mirrors FAIL_THRESHOLD — one mental model
+    for the whole stack (ADR-0006)."""
     monkeypatch.setenv("FAIL_THRESHOLD", "4")
     monkeypatch.delenv("DEPENDENT_CONTAINER_FAILURES", raising=False)
     assert Config.from_env().dependent_container_failures == 4
@@ -62,6 +75,7 @@ def test_dependent_container_failures_defaults_to_fail_threshold(
 def test_dependent_container_failures_independent_override(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    """...but it can still be tuned independently of FAIL_THRESHOLD when set."""
     monkeypatch.setenv("FAIL_THRESHOLD", "4")
     monkeypatch.setenv("DEPENDENT_CONTAINER_FAILURES", "2")
     assert Config.from_env().dependent_container_failures == 2
@@ -70,15 +84,19 @@ def test_dependent_container_failures_independent_override(
 @pytest.mark.parametrize(
     ("value", "expected"),
     [("1", True), ("0", False), ("true", True), ("false", False),
-     ("yes", True), ("no", False), ("on", True), ("off", False)],
+     ("yes", True), ("on", True), ("off", False), ("no", False)],
 )
 def test_auto_recreate_bool_parsing(
     monkeypatch: pytest.MonkeyPatch, value: str, expected: bool
 ) -> None:
+    """All documented boolean spellings parse correctly (so AUTO_RECREATE=yes
+    isn't silently treated as off)."""
     monkeypatch.setenv("AUTO_RECREATE", value)
     assert Config.from_env().auto_recreate is expected
 
 
 def test_int_fallback_on_garbage(monkeypatch: pytest.MonkeyPatch) -> None:
+    """An unparseable int still yields the default value on the object (the CLI
+    separately treats the recorded error as fatal — see test_config_warnings)."""
     monkeypatch.setenv("CHECK_INTERVAL", "not-a-number")
     assert Config.from_env().check_interval == 30

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,84 @@
+"""Config defaults + env parsing. The v1.x defaults are part of the contract."""
+
+from __future__ import annotations
+
+import pytest
+
+from gluetun_monitor.config import Config
+
+
+def test_defaults_match_v1_contract() -> None:
+    c = Config()
+    assert c.config_file == "/config/sites.conf"
+    assert c.log_file == "/logs/gluetun-monitor.log"
+    assert c.check_interval == 30
+    assert c.timeout == 10
+    assert c.fail_threshold == 2
+    assert c.gluetun_container == "gluetun"
+    assert c.healthy_wait_timeout == 120
+    assert c.dependent_containers == "auto"
+    assert c.docker_host is None
+
+
+def test_v2_defaults() -> None:
+    c = Config()
+    assert c.dependent_container_failures == 2  # mirrors fail_threshold
+    assert c.max_parallel_checks == 6
+    assert c.auto_recreate is True
+    assert c.log_level == "INFO"
+
+
+def test_from_env_defaults_with_clean_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    for var in (
+        "CONFIG_FILE", "LOG_FILE", "CHECK_INTERVAL", "TIMEOUT", "FAIL_THRESHOLD",
+        "GLUETUN_CONTAINER", "HEALTHY_WAIT_TIMEOUT", "DEPENDENT_CONTAINERS",
+        "DOCKER_HOST", "DEPENDENT_CONTAINER_FAILURES", "MAX_PARALLEL_CHECKS",
+        "AUTO_RECREATE", "LOG_LEVEL", "DNS_WAIT_TIMEOUT",
+    ):
+        monkeypatch.delenv(var, raising=False)
+    assert Config.from_env() == Config()
+
+
+def test_from_env_overrides(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("CHECK_INTERVAL", "15")
+    monkeypatch.setenv("FAIL_THRESHOLD", "5")
+    monkeypatch.setenv("GLUETUN_CONTAINER", "vpn")
+    monkeypatch.setenv("DOCKER_HOST", "tcp://proxy:2375")
+    c = Config.from_env()
+    assert c.check_interval == 15
+    assert c.fail_threshold == 5
+    assert c.gluetun_container == "vpn"
+    assert c.docker_host == "tcp://proxy:2375"
+
+
+def test_dependent_container_failures_defaults_to_fail_threshold(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("FAIL_THRESHOLD", "4")
+    monkeypatch.delenv("DEPENDENT_CONTAINER_FAILURES", raising=False)
+    assert Config.from_env().dependent_container_failures == 4
+
+
+def test_dependent_container_failures_independent_override(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("FAIL_THRESHOLD", "4")
+    monkeypatch.setenv("DEPENDENT_CONTAINER_FAILURES", "2")
+    assert Config.from_env().dependent_container_failures == 2
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [("1", True), ("0", False), ("true", True), ("false", False),
+     ("yes", True), ("no", False), ("on", True), ("off", False)],
+)
+def test_auto_recreate_bool_parsing(
+    monkeypatch: pytest.MonkeyPatch, value: str, expected: bool
+) -> None:
+    monkeypatch.setenv("AUTO_RECREATE", value)
+    assert Config.from_env().auto_recreate is expected
+
+
+def test_int_fallback_on_garbage(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("CHECK_INTERVAL", "not-a-number")
+    assert Config.from_env().check_interval == 30

--- a/tests/test_config_warnings.py
+++ b/tests/test_config_warnings.py
@@ -29,6 +29,13 @@ def test_invalid_bool_records_error(monkeypatch: pytest.MonkeyPatch) -> None:
     assert any("AUTO_RECREATE" in e for e in c.errors)
 
 
+def test_invalid_float_records_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A non-numeric ADVISORY_DOMINANCE is a fatal config error (not silently default)."""
+    monkeypatch.setenv("ADVISORY_DOMINANCE", "half")
+    c = Config.from_env()
+    assert any("ADVISORY_DOMINANCE" in e for e in c.errors)
+
+
 def test_invalid_log_level_records_error(monkeypatch: pytest.MonkeyPatch) -> None:
     """An unknown LOG_LEVEL errors rather than silently defaulting to INFO."""
     monkeypatch.setenv("LOG_LEVEL", "verbose")

--- a/tests/test_config_warnings.py
+++ b/tests/test_config_warnings.py
@@ -43,6 +43,62 @@ def test_invalid_log_level_records_error(monkeypatch: pytest.MonkeyPatch) -> Non
     assert any("LOG_LEVEL" in e for e in c.errors)
 
 
+@pytest.mark.parametrize(
+    "var",
+    ["CHECK_INTERVAL", "TIMEOUT", "WGET_TRIES", "FAIL_THRESHOLD",
+     "DEPENDENT_CONTAINER_FAILURES", "MAX_PARALLEL_CHECKS", "HEALTHY_WAIT_TIMEOUT",
+     "ADVISORY_WINDOW", "ADVISORY_MIN_RESTARTS"],
+)
+def test_zero_is_rejected_for_must_be_positive_dials(
+    monkeypatch: pytest.MonkeyPatch, var: str
+) -> None:
+    """0 (and negatives) on these would cause real bugs — infinite wget timeout,
+    busy-loops, restart-on-every-loop — so they're fatal, not silently accepted."""
+    monkeypatch.setenv(var, "0")
+    assert any(var in e for e in Config.from_env().errors)
+
+
+@pytest.mark.parametrize("var", ["TIMEOUT", "WGET_TRIES", "MAX_PARALLEL_CHECKS"])
+def test_negative_is_rejected(monkeypatch: pytest.MonkeyPatch, var: str) -> None:
+    monkeypatch.setenv(var, "-3")
+    assert any(var in e for e in Config.from_env().errors)
+
+
+def test_advisory_dominance_out_of_range_rejected(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Dominance is a fraction; >1 (never fires) or <0 (always) are fatal."""
+    monkeypatch.setenv("ADVISORY_DOMINANCE", "9")
+    assert any("ADVISORY_DOMINANCE" in e for e in Config.from_env().errors)
+    monkeypatch.setenv("ADVISORY_DOMINANCE", "-0.5")
+    assert any("ADVISORY_DOMINANCE" in e for e in Config.from_env().errors)
+
+
+def test_in_range_values_are_accepted(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("TIMEOUT", "30")
+    monkeypatch.setenv("WGET_TRIES", "3")
+    monkeypatch.setenv("ADVISORY_DOMINANCE", "0.75")
+    c = Config.from_env()
+    assert c.errors == ()
+    assert c.timeout == 30 and c.wget_tries == 3 and c.advisory_dominance == 0.75
+
+
+def test_intentional_special_values_are_allowed(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Documented sentinels are NOT rejected: STATS_RETENTION_DAYS<=0 = keep
+    forever, LOG_MAX_BYTES=0 = no rotation, DEPENDENT_VIABILITY_SAMPLES=-1 = all."""
+    monkeypatch.setenv("STATS_RETENTION_DAYS", "0")
+    monkeypatch.setenv("LOG_MAX_BYTES", "0")
+    monkeypatch.setenv("DEPENDENT_VIABILITY_SAMPLES", "-1")
+    c = Config.from_env()
+    assert c.errors == ()
+    assert c.stats_retention_days == 0
+    assert c.log_max_bytes == 0
+    assert c.dependent_viability_samples == -1
+
+
+def test_viability_samples_below_minus_one_rejected(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("DEPENDENT_VIABILITY_SAMPLES", "-5")
+    assert any("DEPENDENT_VIABILITY_SAMPLES" in e for e in Config.from_env().errors)
+
+
 def test_clean_env_has_no_errors(monkeypatch: pytest.MonkeyPatch) -> None:
     """The crucial contrast: with everything unset, there are NO errors — unset
     is just the default, never a misconfiguration."""

--- a/tests/test_config_warnings.py
+++ b/tests/test_config_warnings.py
@@ -1,4 +1,10 @@
-"""Malformed env values are collected as fatal errors, not silently swallowed."""
+"""Malformed env values are collected as fatal errors, not silently swallowed.
+
+Why: "bad config is fatal, don't guess" (Tenet 1) — a watchdog acting on the
+system must not run with parameters it couldn't parse. from_env records each
+malformed value in .errors; the CLI refuses to start if any are present. These
+tests pin that *unset* (sane default) and *set-but-bad* (error) are distinct.
+"""
 
 from __future__ import annotations
 
@@ -8,24 +14,31 @@ from gluetun_monitor.config import Config
 
 
 def test_invalid_int_records_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A non-integer CHECK_INTERVAL is recorded as a fatal error (not silently
+    defaulted, as v1 did)."""
     monkeypatch.setenv("CHECK_INTERVAL", "abc")
     c = Config.from_env()
     assert any("CHECK_INTERVAL" in e for e in c.errors)
 
 
 def test_invalid_bool_records_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    """An unrecognized AUTO_RECREATE value errors rather than being coerced to
+    False — a silent coercion could disable recreate without the user knowing."""
     monkeypatch.setenv("AUTO_RECREATE", "maybe")
     c = Config.from_env()
     assert any("AUTO_RECREATE" in e for e in c.errors)
 
 
 def test_invalid_log_level_records_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    """An unknown LOG_LEVEL errors rather than silently defaulting to INFO."""
     monkeypatch.setenv("LOG_LEVEL", "verbose")
     c = Config.from_env()
     assert any("LOG_LEVEL" in e for e in c.errors)
 
 
 def test_clean_env_has_no_errors(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The crucial contrast: with everything unset, there are NO errors — unset
+    is just the default, never a misconfiguration."""
     for var in ("CHECK_INTERVAL", "TIMEOUT", "FAIL_THRESHOLD", "HEALTHY_WAIT_TIMEOUT",
                 "DEPENDENT_CONTAINER_FAILURES", "MAX_PARALLEL_CHECKS", "AUTO_RECREATE",
                 "DNS_WAIT_TIMEOUT", "LOG_LEVEL"):

--- a/tests/test_config_warnings.py
+++ b/tests/test_config_warnings.py
@@ -99,6 +99,19 @@ def test_viability_samples_below_minus_one_rejected(monkeypatch: pytest.MonkeyPa
     assert any("DEPENDENT_VIABILITY_SAMPLES" in e for e in Config.from_env().errors)
 
 
+def test_viability_samples_zero_rejected(monkeypatch: pytest.MonkeyPatch) -> None:
+    """0 would probe nothing and the monitor would silently coerce it to 1, so
+    it's fatal — only -1 (all) or a positive count are valid."""
+    monkeypatch.setenv("DEPENDENT_VIABILITY_SAMPLES", "0")
+    assert any("DEPENDENT_VIABILITY_SAMPLES" in e for e in Config.from_env().errors)
+
+
+def test_viability_samples_one_and_minus_one_accepted(monkeypatch: pytest.MonkeyPatch) -> None:
+    for val in ("1", "-1", "5"):
+        monkeypatch.setenv("DEPENDENT_VIABILITY_SAMPLES", val)
+        assert Config.from_env().errors == ()
+
+
 def test_clean_env_has_no_errors(monkeypatch: pytest.MonkeyPatch) -> None:
     """The crucial contrast: with everything unset, there are NO errors — unset
     is just the default, never a misconfiguration."""

--- a/tests/test_config_warnings.py
+++ b/tests/test_config_warnings.py
@@ -1,0 +1,33 @@
+"""Malformed env values are collected as fatal errors, not silently swallowed."""
+
+from __future__ import annotations
+
+import pytest
+
+from gluetun_monitor.config import Config
+
+
+def test_invalid_int_records_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("CHECK_INTERVAL", "abc")
+    c = Config.from_env()
+    assert any("CHECK_INTERVAL" in e for e in c.errors)
+
+
+def test_invalid_bool_records_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("AUTO_RECREATE", "maybe")
+    c = Config.from_env()
+    assert any("AUTO_RECREATE" in e for e in c.errors)
+
+
+def test_invalid_log_level_records_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("LOG_LEVEL", "verbose")
+    c = Config.from_env()
+    assert any("LOG_LEVEL" in e for e in c.errors)
+
+
+def test_clean_env_has_no_errors(monkeypatch: pytest.MonkeyPatch) -> None:
+    for var in ("CHECK_INTERVAL", "TIMEOUT", "FAIL_THRESHOLD", "HEALTHY_WAIT_TIMEOUT",
+                "DEPENDENT_CONTAINER_FAILURES", "MAX_PARALLEL_CHECKS", "AUTO_RECREATE",
+                "DNS_WAIT_TIMEOUT", "LOG_LEVEL"):
+        monkeypatch.delenv(var, raising=False)
+    assert Config.from_env().errors == ()

--- a/tests/test_connectivity.py
+++ b/tests/test_connectivity.py
@@ -1,4 +1,11 @@
-"""Connectivity probe: the wget exit-code map and pass/fail classification."""
+"""Connectivity probe: the wget exit-code map and pass/fail classification.
+
+Why: this is the authoritative "is the tunnel up" signal (ADR-0001/Tenet 2), and
+its subtlety is that a site *responding* with an error (auth/4xx/5xx) still means
+egress works. Getting the 0/6/8-pass mapping wrong would either miss real outages
+or restart gluetun over a harmless 403 — so it's pinned hard (and cross-checked
+against the legacy bash in the differential suite).
+"""
 
 from __future__ import annotations
 
@@ -30,10 +37,14 @@ from .fakes import FakeDockerClient
     ],
 )
 def test_decode_wget_exit_code(code: int, message: str) -> None:
+    """Every wget exit code maps to the same human reason v1.x used (preserved
+    verbatim — the differential suite checks this against the bash function)."""
     assert decode_wget_exit_code(code) == message
 
 
 def test_pass_codes_are_0_6_8() -> None:
+    """0 (ok), 6 (auth), 8 (4xx/5xx) count as pass — the site responded, so the
+    tunnel is up (Tenet 2). Changing this set changes restart behavior."""
     assert frozenset({0, 6, 8}) == WGET_PASS_CODES
 
 
@@ -44,6 +55,7 @@ def _client_returning(code: int, output: str = "") -> FakeDockerClient:
 
 
 def test_site_pass_on_exit_0() -> None:
+    """A clean success parses the HTTP code and reports pass."""
     fake = _client_returning(0, "  HTTP/1.1 200 OK\n")
     result = probe_site(fake, "gluetun", "https://example.com", 10)
     assert result.ok is True
@@ -53,6 +65,8 @@ def test_site_pass_on_exit_0() -> None:
 
 @pytest.mark.parametrize("code", [6, 8])
 def test_site_pass_on_responded_error_codes(code: int) -> None:
+    """A 403/5xx (codes 6/8) is still a pass: the site answered, so egress works
+    — the core "a broken tunnel is not a sad website" distinction (Tenet 2)."""
     fake = _client_returning(code, "  HTTP/1.1 403 Forbidden\n")
     result = probe_site(fake, "gluetun", "https://example.com", 10)
     assert result.ok is True
@@ -61,6 +75,8 @@ def test_site_pass_on_responded_error_codes(code: int) -> None:
 
 @pytest.mark.parametrize("code", [1, 4, 5, 7])
 def test_site_fail_on_connectivity_codes(code: int) -> None:
+    """DNS/connection/SSL/protocol failures are real failures (the tunnel path is
+    broken), reported with the decoded reason."""
     fake = _client_returning(code, "")
     result = probe_site(fake, "gluetun", "https://example.com", 10)
     assert result.ok is False
@@ -68,6 +84,7 @@ def test_site_fail_on_connectivity_codes(code: int) -> None:
 
 
 def test_site_parses_last_http_code() -> None:
+    """On a redirect chain we report the final status, not the 3xx hop."""
     output = "HTTP/1.1 301 Moved\nLocation: ...\nHTTP/1.1 200 OK\n"
     fake = _client_returning(0, output)
     result = probe_site(fake, "gluetun", "https://example.com", 10)
@@ -75,6 +92,8 @@ def test_site_parses_last_http_code() -> None:
 
 
 def test_site_exec_exception_is_a_failure() -> None:
+    """If the exec itself blows up (daemon gone mid-probe), that's a failure, not
+    an unhandled crash — the loop must survive (Tenet 7)."""
     fake = FakeDockerClient()
 
     def boom(name: str, cmd: list[str]) -> ExecResult:

--- a/tests/test_connectivity.py
+++ b/tests/test_connectivity.py
@@ -1,0 +1,86 @@
+"""Connectivity probe: the wget exit-code map and pass/fail classification."""
+
+from __future__ import annotations
+
+import pytest
+
+from gluetun_monitor.connectivity import (
+    WGET_PASS_CODES,
+    decode_wget_exit_code,
+    probe_site,
+)
+from gluetun_monitor.docker_client import ExecResult
+
+from .fakes import FakeDockerClient
+
+
+@pytest.mark.parametrize(
+    ("code", "message"),
+    [
+        (0, "Success"),
+        (1, "Generic error"),
+        (2, "Parse error"),
+        (3, "File I/O error"),
+        (4, "Network failure (DNS or connection)"),
+        (5, "SSL verification failure"),
+        (6, "Authentication required"),
+        (7, "Protocol error"),
+        (8, "Server error (HTTP 4xx/5xx)"),
+        (99, "Unknown error (code 99)"),
+    ],
+)
+def test_decode_wget_exit_code(code: int, message: str) -> None:
+    assert decode_wget_exit_code(code) == message
+
+
+def test_pass_codes_are_0_6_8() -> None:
+    assert frozenset({0, 6, 8}) == WGET_PASS_CODES
+
+
+def _client_returning(code: int, output: str = "") -> FakeDockerClient:
+    fake = FakeDockerClient()
+    fake.on_exec = lambda name, cmd: ExecResult(code, output)
+    return fake
+
+
+def test_site_pass_on_exit_0() -> None:
+    fake = _client_returning(0, "  HTTP/1.1 200 OK\n")
+    result = probe_site(fake, "gluetun", "https://example.com", 10)
+    assert result.ok is True
+    assert result.http_code == "200"
+    assert result.reason == "HTTP 200"
+
+
+@pytest.mark.parametrize("code", [6, 8])
+def test_site_pass_on_responded_error_codes(code: int) -> None:
+    fake = _client_returning(code, "  HTTP/1.1 403 Forbidden\n")
+    result = probe_site(fake, "gluetun", "https://example.com", 10)
+    assert result.ok is True
+    assert "VPN working" in result.reason
+
+
+@pytest.mark.parametrize("code", [1, 4, 5, 7])
+def test_site_fail_on_connectivity_codes(code: int) -> None:
+    fake = _client_returning(code, "")
+    result = probe_site(fake, "gluetun", "https://example.com", 10)
+    assert result.ok is False
+    assert result.reason == decode_wget_exit_code(code)
+
+
+def test_site_parses_last_http_code() -> None:
+    output = "HTTP/1.1 301 Moved\nLocation: ...\nHTTP/1.1 200 OK\n"
+    fake = _client_returning(0, output)
+    result = probe_site(fake, "gluetun", "https://example.com", 10)
+    assert result.http_code == "200"
+
+
+def test_site_exec_exception_is_a_failure() -> None:
+    fake = FakeDockerClient()
+
+    def boom(name: str, cmd: list[str]) -> ExecResult:
+        raise RuntimeError("daemon gone")
+
+    fake.on_exec = boom
+    result = probe_site(fake, "gluetun", "https://example.com", 10)
+    assert result.ok is False
+    assert "exec failed" in result.reason

--- a/tests/test_connectivity.py
+++ b/tests/test_connectivity.py
@@ -64,23 +64,62 @@ def test_site_pass_on_exit_0() -> None:
 
 
 @pytest.mark.parametrize("code", [6, 8])
-def test_site_pass_on_responded_error_codes(code: int) -> None:
-    """A 403/5xx (codes 6/8) is still a pass: the site answered, so egress works
-    — the core "a broken tunnel is not a sad website" distinction (Tenet 2)."""
+def test_site_pass_on_responded_error_codes_gnu(code: int) -> None:
+    """GNU wget: a 403 with exit 6/8 is a pass — the site answered, so egress
+    works (Tenet 3, "a broken tunnel is not a sad website")."""
     fake = _client_returning(code, "  HTTP/1.1 403 Forbidden\n")
     result = probe_site(fake, "gluetun", "https://example.com", 10)
     assert result.ok is True
-    assert "VPN working" in result.reason
+    assert result.http_code == "403"
+
+
+def test_site_pass_on_busybox_404_exit_1() -> None:
+    """REGRESSION (dogfood): busybox wget returns exit 1 for an HTTP 404, but the
+    site DID respond (DNS+connect+egress worked), so it must be a PASS. The old
+    exit-code-only map wrongly failed this on every busybox-wget dependent."""
+    output = "  HTTP/1.1 404 Not Found\nwget: server returned error: HTTP/1.1 404 Not Found\n"
+    fake = _client_returning(1, output)
+    result = probe_site(fake, "prowlarr", "https://dognzb.cr", 10)
+    assert result.ok is True
+    assert result.http_code == "404"
 
 
 @pytest.mark.parametrize("code", [1, 4, 5, 7])
-def test_site_fail_on_connectivity_codes(code: int) -> None:
-    """DNS/connection/SSL/protocol failures are real failures (the tunnel path is
-    broken), reported with the decoded reason."""
+def test_site_fail_on_real_failure_no_http(code: int) -> None:
+    """With NO HTTP response (genuine DNS/connect/SSL failure), it's a failure —
+    falls back to the decoded exit code when there's no diagnostic line."""
     fake = _client_returning(code, "")
     result = probe_site(fake, "gluetun", "https://example.com", 10)
     assert result.ok is False
     assert result.reason == decode_wget_exit_code(code)
+
+
+def test_site_failure_reports_real_reason_not_generic() -> None:
+    """REGRESSION (dogfood): a real failure surfaces wget's actual diagnostic, not
+    a useless 'Generic error'. Here a DNS failure with exit 1."""
+    output = "Connecting to bad.example (bad.example)\nwget: bad address 'bad.example'\n"
+    fake = _client_returning(1, output)
+    result = probe_site(fake, "qbittorrent", "https://bad.example", 10)
+    assert result.ok is False
+    assert "bad address" in result.reason
+    assert result.reason != "Generic error"
+    assert result.dns_failed is True  # positively identified as a DNS failure
+
+
+def test_dns_failed_flag_distinguishes_dns_from_connect() -> None:
+    """dns_failed is the dependent-viability signal: True for a resolution failure,
+    False for a connect/timeout failure (DNS resolved, the remote just didn't
+    answer) — the latter is not a per-container fault in a shared netns."""
+    dns = _client_returning(1, "wget: bad address 'x.example'\n")
+    assert probe_site(dns, "dep", "https://x.example", 10).dns_failed is True
+
+    refused = _client_returning(1, "wget: can't connect to remote host: Connection refused\n")
+    r = probe_site(refused, "dep", "https://x.example", 10)
+    assert r.ok is False          # gluetun root test would count this as a site fail
+    assert r.dns_failed is False  # but dependent viability would NOT (DNS resolved)
+
+    responded = _client_returning(1, "  HTTP/1.1 404 Not Found\n")
+    assert probe_site(responded, "dep", "https://x.example", 10).dns_failed is False
 
 
 def test_site_parses_last_http_code() -> None:

--- a/tests/test_dependents.py
+++ b/tests/test_dependents.py
@@ -1,4 +1,11 @@
-"""Discovery, interface classification, and the remediation decision tree."""
+"""Discovery, interface classification, and the remediation decision tree.
+
+Why: these three feed the #20 fix. Discovery decides *who* is watched; the
+interface check is the ground-truth strand signal (ADR-0004); and
+remediation_action is the load-bearing restart-vs-recreate decision — picking the
+wrong branch either fails to heal (restart into a dead netns) or recreates
+needlessly. The id-vs-name cases below are exactly the ambiguities ADR-0004 calls out.
+"""
 
 from __future__ import annotations
 
@@ -24,24 +31,30 @@ def _stack() -> FakeDockerClient:
 
 
 def test_discover_by_full_id() -> None:
+    """A dependent whose NetworkMode is the resolved full id (the compose
+    `service:` form) is discovered."""
     fake = _stack()
     fake.add_container("qbittorrent", network_mode=f"container:{GLUETUN_ID}")
     assert discover_dependents(fake, "gluetun") == ["qbittorrent"]
 
 
 def test_discover_by_name_form() -> None:
+    """The `container:<name>` form is discovered too (some setups write the name)."""
     fake = _stack()
     fake.add_container("sonarr", network_mode="container:gluetun")
     assert discover_dependents(fake, "gluetun") == ["sonarr"]
 
 
 def test_discover_by_short_id_prefix() -> None:
+    """The 12-char short-id prefix form is matched."""
     fake = _stack()
     fake.add_container("radarr", network_mode=f"container:{GLUETUN_ID[:12]}")
     assert discover_dependents(fake, "gluetun") == ["radarr"]
 
 
 def test_discover_excludes_gluetun_and_unrelated() -> None:
+    """gluetun itself and bridge-networked containers are never treated as
+    dependents (no false positives)."""
     fake = _stack()
     fake.add_container("app1", network_mode=f"container:{GLUETUN_ID}")
     fake.add_container("unrelated", network_mode="bridge")
@@ -50,6 +63,7 @@ def test_discover_excludes_gluetun_and_unrelated() -> None:
 
 
 def test_discover_skips_stopped_containers() -> None:
+    """Discovery considers only running containers (it lists by `docker ps`)."""
     fake = _stack()
     fake.add_container("running-dep", network_mode=f"container:{GLUETUN_ID}")
     fake.add_container("stopped-dep", network_mode=f"container:{GLUETUN_ID}", running=False)
@@ -57,6 +71,7 @@ def test_discover_skips_stopped_containers() -> None:
 
 
 def test_get_dependents_manual_list() -> None:
+    """A manual DEPENDENT_CONTAINERS value is parsed (trimmed, blanks dropped)."""
     fake = FakeDockerClient()
     cfg = Config(dependent_containers=" app1 , app2,app3 ")
     logger = _NullLogger()
@@ -68,36 +83,44 @@ def _exec_returns(output: str, code: int = 0):
 
 
 def test_interface_check_live() -> None:
+    """A non-loopback interface (eth0/tun0 present) → LIVE (eligible worker)."""
     fake = FakeDockerClient()
     fake.on_exec = _exec_returns("eth0\nlo\ntun0\n")
     assert interface_check(fake, "dep") is InterfaceStatus.LIVE
 
 
 def test_interface_check_stranded() -> None:
+    """Only `lo` → STRANDED — the exact #20 loopback-only state."""
     fake = FakeDockerClient()
     fake.on_exec = _exec_returns("lo\n")
     assert interface_check(fake, "dep") is InterfaceStatus.STRANDED
 
 
 def test_interface_check_unknown_on_exec_failure() -> None:
+    """A failed exec (no shell / distroless) → UNKNOWN, routing to the inspect
+    fallback rather than a wrong LIVE/STRANDED guess."""
     fake = FakeDockerClient()
     fake.on_exec = _exec_returns("", code=1)
     assert interface_check(fake, "dep") is InterfaceStatus.UNKNOWN
 
 
 def test_interface_check_unknown_on_empty_output() -> None:
+    """Empty output is inconclusive → UNKNOWN, not a false STRANDED."""
     fake = FakeDockerClient()
     fake.on_exec = _exec_returns("   \n")
     assert interface_check(fake, "dep") is InterfaceStatus.UNKNOWN
 
 
 def test_remediation_restart_when_id_matches() -> None:
+    """NetworkMode target == current gluetun id → restart (it can rejoin)."""
     fake = _stack()
     info = fake.add_container("dep", network_mode=f"container:{GLUETUN_ID}")
     assert remediation_action(info, GLUETUN_ID) is RemediationAction.RESTART
 
 
 def test_remediation_recreate_when_id_differs() -> None:
+    """Target is a *different* id (gluetun was recreated) → recreate; a restart
+    would fail into a dead netns (the #20 B1 case)."""
     fake = _stack()
     old_id = "b" * 64
     info = fake.add_container("dep", network_mode=f"container:{old_id}")
@@ -105,18 +128,24 @@ def test_remediation_recreate_when_id_differs() -> None:
 
 
 def test_remediation_restart_short_id_match() -> None:
+    """A short-id target that prefixes the current full id still counts as a match
+    → restart."""
     fake = _stack()
     info = fake.add_container("dep", network_mode=f"container:{GLUETUN_ID[:12]}")
     assert remediation_action(info, GLUETUN_ID) is RemediationAction.RESTART
 
 
 def test_remediation_try_restart_name_form() -> None:
+    """A name-form target (`container:gluetun`) is ambiguous (can't compare ids)
+    → try-restart-then-escalate, per ADR-0004's untested-name branch."""
     fake = _stack()
     info = fake.add_container("dep", network_mode="container:gluetun")
     assert remediation_action(info, GLUETUN_ID) is RemediationAction.TRY_RESTART
 
 
 def test_remediation_try_restart_unexpected_form() -> None:
+    """An unexpected NetworkMode (not container:*) defaults to the safe
+    try-restart path rather than a recreate."""
     fake = _stack()
     info = fake.add_container("dep", network_mode="bridge")
     assert remediation_action(info, GLUETUN_ID) is RemediationAction.TRY_RESTART

--- a/tests/test_dependents.py
+++ b/tests/test_dependents.py
@@ -1,0 +1,131 @@
+"""Discovery, interface classification, and the remediation decision tree."""
+
+from __future__ import annotations
+
+from gluetun_monitor.config import Config
+from gluetun_monitor.dependents import (
+    discover_dependents,
+    get_dependents,
+    interface_check,
+    remediation_action,
+)
+from gluetun_monitor.docker_client import ExecResult
+from gluetun_monitor.state import InterfaceStatus, RemediationAction
+
+from .fakes import FakeDockerClient
+
+GLUETUN_ID = "a" * 64
+
+
+def _stack() -> FakeDockerClient:
+    fake = FakeDockerClient()
+    fake.add_container("gluetun", id=GLUETUN_ID)
+    return fake
+
+
+def test_discover_by_full_id() -> None:
+    fake = _stack()
+    fake.add_container("qbittorrent", network_mode=f"container:{GLUETUN_ID}")
+    assert discover_dependents(fake, "gluetun") == ["qbittorrent"]
+
+
+def test_discover_by_name_form() -> None:
+    fake = _stack()
+    fake.add_container("sonarr", network_mode="container:gluetun")
+    assert discover_dependents(fake, "gluetun") == ["sonarr"]
+
+
+def test_discover_by_short_id_prefix() -> None:
+    fake = _stack()
+    fake.add_container("radarr", network_mode=f"container:{GLUETUN_ID[:12]}")
+    assert discover_dependents(fake, "gluetun") == ["radarr"]
+
+
+def test_discover_excludes_gluetun_and_unrelated() -> None:
+    fake = _stack()
+    fake.add_container("app1", network_mode=f"container:{GLUETUN_ID}")
+    fake.add_container("unrelated", network_mode="bridge")
+    found = discover_dependents(fake, "gluetun")
+    assert found == ["app1"]
+
+
+def test_discover_skips_stopped_containers() -> None:
+    fake = _stack()
+    fake.add_container("running-dep", network_mode=f"container:{GLUETUN_ID}")
+    fake.add_container("stopped-dep", network_mode=f"container:{GLUETUN_ID}", running=False)
+    assert discover_dependents(fake, "gluetun") == ["running-dep"]
+
+
+def test_get_dependents_manual_list() -> None:
+    fake = FakeDockerClient()
+    cfg = Config(dependent_containers=" app1 , app2,app3 ")
+    logger = _NullLogger()
+    assert get_dependents(fake, cfg, logger) == ["app1", "app2", "app3"]
+
+
+def _exec_returns(output: str, code: int = 0):
+    return lambda name, cmd: ExecResult(code, output)
+
+
+def test_interface_check_live() -> None:
+    fake = FakeDockerClient()
+    fake.on_exec = _exec_returns("eth0\nlo\ntun0\n")
+    assert interface_check(fake, "dep") is InterfaceStatus.LIVE
+
+
+def test_interface_check_stranded() -> None:
+    fake = FakeDockerClient()
+    fake.on_exec = _exec_returns("lo\n")
+    assert interface_check(fake, "dep") is InterfaceStatus.STRANDED
+
+
+def test_interface_check_unknown_on_exec_failure() -> None:
+    fake = FakeDockerClient()
+    fake.on_exec = _exec_returns("", code=1)
+    assert interface_check(fake, "dep") is InterfaceStatus.UNKNOWN
+
+
+def test_interface_check_unknown_on_empty_output() -> None:
+    fake = FakeDockerClient()
+    fake.on_exec = _exec_returns("   \n")
+    assert interface_check(fake, "dep") is InterfaceStatus.UNKNOWN
+
+
+def test_remediation_restart_when_id_matches() -> None:
+    fake = _stack()
+    info = fake.add_container("dep", network_mode=f"container:{GLUETUN_ID}")
+    assert remediation_action(info, GLUETUN_ID) is RemediationAction.RESTART
+
+
+def test_remediation_recreate_when_id_differs() -> None:
+    fake = _stack()
+    old_id = "b" * 64
+    info = fake.add_container("dep", network_mode=f"container:{old_id}")
+    assert remediation_action(info, GLUETUN_ID) is RemediationAction.RECREATE
+
+
+def test_remediation_restart_short_id_match() -> None:
+    fake = _stack()
+    info = fake.add_container("dep", network_mode=f"container:{GLUETUN_ID[:12]}")
+    assert remediation_action(info, GLUETUN_ID) is RemediationAction.RESTART
+
+
+def test_remediation_try_restart_name_form() -> None:
+    fake = _stack()
+    info = fake.add_container("dep", network_mode="container:gluetun")
+    assert remediation_action(info, GLUETUN_ID) is RemediationAction.TRY_RESTART
+
+
+def test_remediation_try_restart_unexpected_form() -> None:
+    fake = _stack()
+    info = fake.add_container("dep", network_mode="bridge")
+    assert remediation_action(info, GLUETUN_ID) is RemediationAction.TRY_RESTART
+
+
+class _NullLogger:
+    def info(self, m: str) -> None: ...
+    def warn(self, m: str) -> None: ...
+    def error(self, m: str) -> None: ...
+    def debug(self, m: str) -> None: ...
+    def check(self, m: str) -> None: ...
+    def endpoint(self, m: str) -> None: ...

--- a/tests/test_dependents_edges.py
+++ b/tests/test_dependents_edges.py
@@ -1,0 +1,35 @@
+"""Edge/exception branches in discovery and the remediation decision."""
+
+from __future__ import annotations
+
+from gluetun_monitor.dependents import (
+    discover_dependents,
+    interface_check,
+    remediation_action,
+)
+from gluetun_monitor.state import InterfaceStatus, RemediationAction
+
+from .fakes import FakeDockerClient
+
+GLUETUN_ID = "a" * 64
+
+
+def test_discover_returns_empty_when_gluetun_absent() -> None:
+    fake = FakeDockerClient()  # no gluetun
+    assert discover_dependents(fake, "gluetun") == []
+
+
+def test_interface_check_unknown_when_exec_raises() -> None:
+    fake = FakeDockerClient()
+
+    def boom(name: str, cmd: list[str]):
+        raise RuntimeError("no such exec target")
+
+    fake.on_exec = boom
+    assert interface_check(fake, "dep") is InterfaceStatus.UNKNOWN
+
+
+def test_remediation_empty_target_is_try_restart() -> None:
+    fake = FakeDockerClient()
+    info = fake.add_container("dep", network_mode="container:")
+    assert remediation_action(info, GLUETUN_ID) is RemediationAction.TRY_RESTART

--- a/tests/test_dependents_edges.py
+++ b/tests/test_dependents_edges.py
@@ -1,4 +1,9 @@
-"""Edge/exception branches in discovery and the remediation decision."""
+"""Edge/exception branches in discovery and the remediation decision.
+
+Why: these guard the defensive paths — a missing gluetun, an exec that throws,
+and a malformed NetworkMode — so an odd container or a transient Docker error
+degrades to a safe default instead of crashing the loop or mis-deciding.
+"""
 
 from __future__ import annotations
 
@@ -15,11 +20,15 @@ GLUETUN_ID = "a" * 64
 
 
 def test_discover_returns_empty_when_gluetun_absent() -> None:
+    """If gluetun can't be inspected, discovery returns [] rather than raising —
+    prereqs handle the missing-gluetun error; discovery just no-ops."""
     fake = FakeDockerClient()  # no gluetun
     assert discover_dependents(fake, "gluetun") == []
 
 
 def test_interface_check_unknown_when_exec_raises() -> None:
+    """An exec that throws (not just non-zero) is treated as UNKNOWN, not a crash
+    — a transient Docker error must not take down the loop (Tenet 7)."""
     fake = FakeDockerClient()
 
     def boom(name: str, cmd: list[str]):
@@ -30,6 +39,8 @@ def test_interface_check_unknown_when_exec_raises() -> None:
 
 
 def test_remediation_empty_target_is_try_restart() -> None:
+    """A malformed `container:` (empty target) can't be compared to an id, so it
+    falls to the safe try-restart branch rather than a recreate."""
     fake = FakeDockerClient()
     info = fake.add_container("dep", network_mode="container:")
     assert remediation_action(info, GLUETUN_ID) is RemediationAction.TRY_RESTART

--- a/tests/test_distroless_fallback.py
+++ b/tests/test_distroless_fallback.py
@@ -1,0 +1,84 @@
+"""A1: inspect-based strand detection for non-exec'able dependents (ADR-0004).
+
+A distroless/scratch dependent has no shell, so ``ls /sys/class/net`` fails and
+the interface check is UNKNOWN. The monitor then falls back to comparing the
+dependent's NetworkMode target to gluetun's current id, and acts only on the
+unambiguous moved-id verdict — closing the #20 blind spot for shell-less images.
+"""
+
+from __future__ import annotations
+
+import io
+import random
+from pathlib import Path
+
+from gluetun_monitor.config import Config
+from gluetun_monitor.docker_client import ExecResult
+from gluetun_monitor.logging_setup import Logger
+from gluetun_monitor.monitor import Monitor
+from gluetun_monitor.state import InterfaceStatus
+
+from .fakes import FakeDockerClient
+
+GLUETUN_ID = "a" * 64
+OLD_ID = "b" * 64
+
+
+def _mon(fake: FakeDockerClient, **cfg: object) -> Monitor:
+    cfg.setdefault("config_file", "/dev/null")
+    cfg.setdefault("gluetun_container", "gluetun")
+    config = Config(**cfg)
+    logger = Logger(log_file=None, level="DEBUG", stream=io.StringIO())
+    return Monitor(fake, config, logger, rng=random.Random(0), sleep=lambda _s: None)
+
+
+def _no_shell(name: str, cmd: list[str]) -> ExecResult:
+    """Every exec fails — simulates a distroless image with no shell/wget/ls."""
+    return ExecResult(1, "")
+
+
+def test_distroless_moved_id_is_flagged_stranded() -> None:
+    fake = FakeDockerClient()
+    fake.add_container("distroless", network_mode=f"container:{OLD_ID}")  # gluetun moved
+    fake.on_exec = _no_shell
+    probe = _mon(fake)._probe_dependent("distroless", GLUETUN_ID, ["https://x"], [])
+    # Interface check was UNKNOWN, but the inspect fallback re-classifies it.
+    assert probe.status is InterfaceStatus.STRANDED
+    assert "inspect" in probe.reason
+
+
+def test_distroless_same_id_is_left_alone() -> None:
+    fake = FakeDockerClient()
+    fake.add_container("distroless", network_mode=f"container:{GLUETUN_ID}")  # current id
+    fake.on_exec = _no_shell
+    probe = _mon(fake)._probe_dependent("distroless", GLUETUN_ID, ["https://x"], [])
+    assert probe.status is InterfaceStatus.UNKNOWN  # not churned (Tenet 2)
+    assert probe.running is True
+
+
+def test_distroless_nameform_target_is_left_alone() -> None:
+    fake = FakeDockerClient()
+    fake.add_container("distroless", network_mode="container:gluetun")  # name form
+    fake.on_exec = _no_shell
+    probe = _mon(fake)._probe_dependent("distroless", GLUETUN_ID, ["https://x"], [])
+    assert probe.status is InterfaceStatus.UNKNOWN  # can't prove a strand -> leave it
+
+
+def test_distroless_moved_id_is_recreated_end_to_end(tmp_path: Path) -> None:
+    conf = tmp_path / "sites.conf"
+    conf.write_text("https://www.google.com\n")
+    fake = FakeDockerClient()
+    fake.add_container("gluetun", id=GLUETUN_ID)
+    fake.add_container("distroless", network_mode=f"container:{OLD_ID}")
+
+    def handler(name: str, cmd: list[str]) -> ExecResult:
+        # gluetun's own site probe passes; the distroless dep has no shell.
+        if name == "gluetun" and cmd and cmd[0] == "wget":
+            return ExecResult(0, "")
+        return ExecResult(1, "")
+
+    fake.on_exec = handler
+    mon = _mon(fake, config_file=str(conf), dependent_containers="distroless")
+    mon.run_once()
+    assert len(fake.created) == 1  # recreated onto the current gluetun id
+    assert fake.removed == [("distroless", False)]

--- a/tests/test_dns_check.py
+++ b/tests/test_dns_check.py
@@ -1,0 +1,101 @@
+"""The getaddrinfo DNS cascade (wget -> getent -> ping) and its three outcomes.
+
+Why: this is the per-dependent DNS validator. It must (a) prefer the faithful
+tool that's present, (b) cascade past tools the container lacks, (c) return
+UNVALIDATED (not a false pass/fail) when no tool exists, and (d) read each tool's
+output correctly — especially that a resolved-but-unreachable ping (blocked ICMP)
+is still a DNS success.
+"""
+
+from __future__ import annotations
+
+from gluetun_monitor.dns_check import DnsStatus, validate_dns
+from gluetun_monitor.docker_client import ExecResult
+
+from .fakes import FakeDockerClient
+
+
+def _client(handler) -> FakeDockerClient:
+    fake = FakeDockerClient()
+    fake.add_container("dep", network_mode="container:x")
+    fake.on_exec = handler
+    return fake
+
+
+# ----- tool 1: wget present (the common case) -----
+
+
+def test_wget_resolves_ok() -> None:
+    """wget gets an HTTP response → DNS resolved → OK via wget (no cascade)."""
+    fake = _client(lambda n, c: ExecResult(0, "  HTTP/1.1 200 OK\n"))
+    r = validate_dns(fake, "dep", "https://x", "x", 5)
+    assert r.status is DnsStatus.OK and r.tool == "wget"
+
+
+def test_wget_404_is_ok() -> None:
+    """busybox wget 404 (exit 1, responded) → DNS resolved → OK."""
+    fake = _client(lambda n, c: ExecResult(1, "  HTTP/1.1 404 Not Found\n"))
+    assert validate_dns(fake, "dep", "https://x", "x", 5).status is DnsStatus.OK
+
+
+def test_wget_dns_failure_is_broken() -> None:
+    """wget 'bad address' → DNS broken → BROKEN via wget."""
+    fake = _client(lambda n, c: ExecResult(1, "wget: bad address 'x'\n"))
+    r = validate_dns(fake, "dep", "https://x", "x", 5)
+    assert r.status is DnsStatus.BROKEN and r.tool == "wget"
+
+
+# ----- cascade past an absent wget -----
+
+
+def _cascade(responses: dict[str, ExecResult]):
+    """Handler that returns a canned result per leading command word, or a
+    'not found' (exit 127) for anything not in the map (simulating an absent tool)."""
+    def handler(name: str, cmd: list[str]) -> ExecResult:
+        return responses.get(cmd[0], ExecResult(127, f"exec: {cmd[0]}: executable file not found"))
+    return handler
+
+
+def test_falls_through_wget_absent_to_getent_ok() -> None:
+    """No wget → cascade to getent, which resolves → OK via getent."""
+    fake = _client(_cascade({"getent": ExecResult(0, "1.2.3.4  x\n")}))
+    r = validate_dns(fake, "dep", "https://x", "x", 5)
+    assert r.status is DnsStatus.OK and r.tool == "getent"
+
+
+def test_getent_name_not_found_is_broken() -> None:
+    """getent exit 2 = name not found → BROKEN."""
+    fake = _client(_cascade({"getent": ExecResult(2, "")}))
+    r = validate_dns(fake, "dep", "https://x", "x", 5)
+    assert r.status is DnsStatus.BROKEN and r.tool == "getent"
+
+
+def test_falls_through_to_ping_resolved_despite_blocked_icmp() -> None:
+    """No wget/getent → ping; ICMP blocked (permission denied) but the name still
+    resolved → OK (we care about resolution, not reachability)."""
+    fake = _client(_cascade({
+        "ping": ExecResult(1, "PING x (1.2.3.4): 56 data bytes\nping: permission denied\n"),
+    }))
+    r = validate_dns(fake, "dep", "https://x", "x", 5)
+    assert r.status is DnsStatus.OK and r.tool == "ping"
+
+
+def test_ping_resolution_failure_is_broken() -> None:
+    fake = _client(_cascade({"ping": ExecResult(1, "ping: bad address 'x'\n")}))
+    assert validate_dns(fake, "dep", "https://x", "x", 5).status is DnsStatus.BROKEN
+
+
+def test_no_tools_is_unvalidated() -> None:
+    """Distroless-style: nothing present → UNVALIDATED (don't guess)."""
+    fake = _client(_cascade({}))  # every command -> not found
+    r = validate_dns(fake, "dep", "https://x", "x", 5)
+    assert r.status is DnsStatus.UNVALIDATED and r.tool == ""
+
+
+def test_exec_exception_treated_as_absent_then_unvalidated() -> None:
+    """If every exec raises, no tool could run → UNVALIDATED, not a crash."""
+    def boom(name: str, cmd: list[str]) -> ExecResult:
+        raise RuntimeError("daemon hiccup")
+
+    fake = _client(boom)
+    assert validate_dns(fake, "dep", "https://x", "x", 5).status is DnsStatus.UNVALIDATED

--- a/tests/test_dns_check.py
+++ b/tests/test_dns_check.py
@@ -45,6 +45,28 @@ def test_wget_dns_failure_is_broken() -> None:
     assert r.status is DnsStatus.BROKEN and r.tool == "wget"
 
 
+def test_wget_resolved_but_no_http_is_ok() -> None:
+    """wget resolved DNS but couldn't complete (connection refused) → still OK
+    (DNS is the only per-container fault), and the reason says so honestly rather
+    than claiming a full connection."""
+    fake = _client(lambda n, c: ExecResult(1, "Connecting to x (1.2.3.4)\n"
+                                              "wget: can't connect: Connection refused\n"))
+    r = validate_dns(fake, "dep", "https://x", "x", 5)
+    assert r.status is DnsStatus.OK and r.tool == "wget"
+    assert "no HTTP response" in r.reason
+
+
+def test_wget_broken_short_circuits_the_cascade() -> None:
+    """A definitive DNS failure from wget must NOT fall through to getent/ping —
+    we already know resolution failed. (getent here would say OK if consulted.)"""
+    fake = _client(_cascade({
+        "wget": ExecResult(1, "wget: bad address 'x'\n"),
+        "getent": ExecResult(0, "1.2.3.4 x\n"),  # would say OK if (wrongly) consulted
+    }))
+    r = validate_dns(fake, "dep", "https://x", "x", 5)
+    assert r.status is DnsStatus.BROKEN and r.tool == "wget"
+
+
 # ----- cascade past an absent wget -----
 
 

--- a/tests/test_dns_check.py
+++ b/tests/test_dns_check.py
@@ -53,7 +53,7 @@ def test_wget_resolved_but_no_http_is_ok() -> None:
                                               "wget: can't connect: Connection refused\n"))
     r = validate_dns(fake, "dep", "https://x", "x", 5)
     assert r.status is DnsStatus.OK and r.tool == "wget"
-    assert "no HTTP response" in r.reason
+    assert r.reason.startswith("no HTTP:")
 
 
 def test_wget_broken_short_circuits_the_cascade() -> None:

--- a/tests/test_docker_client.py
+++ b/tests/test_docker_client.py
@@ -1,0 +1,138 @@
+"""DockerPyClient adapter logic — the translation we own, not docker-py itself.
+
+Constructed via __new__ with a stub low-level API so these stay hermetic (no
+daemon, no real docker-py client). What's asserted here is *our* adaptation:
+NotFound -> None, exec output decode + exit-code fallback, ping swallows errors.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import docker.errors
+
+from gluetun_monitor.docker_client import DockerPyClient
+
+
+class _StubAPI:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, tuple[Any, ...]]] = []
+        self.ping_raises = False
+        self.inspect_raises_notfound = False
+        self.exec_exit_code: int | None = 0
+        self.exec_output: bytes | None = b"out"
+
+    def ping(self) -> bool:
+        if self.ping_raises:
+            raise RuntimeError("down")
+        return True
+
+    def containers(self, all: bool = False) -> list[dict[str, Any]]:
+        return [{"Id": "id1"}, {"Id": "id2"}]
+
+    def inspect_container(self, name: str) -> dict[str, Any]:
+        if self.inspect_raises_notfound:
+            raise docker.errors.NotFound("nope")
+        return {"Id": name, "Name": f"/{name}", "State": {"Running": True},
+                "HostConfig": {"NetworkMode": "bridge"}}
+
+    def exec_create(self, name: str, cmd: list[str]) -> dict[str, str]:
+        self.calls.append(("exec_create", (name, tuple(cmd))))
+        return {"Id": "exec1"}
+
+    def exec_start(self, exec_id: str) -> bytes | None:
+        return self.exec_output
+
+    def exec_inspect(self, exec_id: str) -> dict[str, Any]:
+        return {"ExitCode": self.exec_exit_code}
+
+    def logs(self, name: str, stdout: bool = True, stderr: bool = True) -> bytes:
+        return b"log line"
+
+    def restart(self, name: str) -> None:
+        self.calls.append(("restart", (name,)))
+
+    def remove_container(self, name: str, v: bool = False, force: bool = False) -> None:
+        self.calls.append(("remove_container", (name, v, force)))
+
+    def create_container_from_config(self, config: dict[str, Any], name: str) -> dict[str, str]:
+        self.calls.append(("create", (name,)))
+        return {"Id": "newid"}
+
+    def start(self, name: str) -> None:
+        self.calls.append(("start", (name,)))
+
+
+def _client() -> tuple[DockerPyClient, _StubAPI]:
+    client = DockerPyClient.__new__(DockerPyClient)  # skip __init__ (no daemon)
+    api = _StubAPI()
+    client._api = api  # type: ignore[attr-defined]
+    return client, api
+
+
+def test_ping_true() -> None:
+    client, _ = _client()
+    assert client.ping() is True
+
+
+def test_ping_swallows_errors() -> None:
+    client, api = _client()
+    api.ping_raises = True
+    assert client.ping() is False
+
+
+def test_list_running_ids() -> None:
+    client, _ = _client()
+    assert client.list_running_ids() == ["id1", "id2"]
+
+
+def test_inspect_returns_container_info() -> None:
+    client, _ = _client()
+    info = client.inspect("gluetun")
+    assert info is not None
+    assert info.name == "gluetun"
+    assert info.running is True
+
+
+def test_inspect_notfound_returns_none() -> None:
+    client, api = _client()
+    api.inspect_raises_notfound = True
+    assert client.inspect("ghost") is None
+
+
+def test_exec_run_decodes_output_and_exit_code() -> None:
+    client, api = _client()
+    api.exec_output = b"hello\xff"  # includes an undecodable byte
+    api.exec_exit_code = 7
+    result = client.exec_run("c", ["wget", "x"])
+    assert result.exit_code == 7
+    assert "hello" in result.output  # decoded with errors="replace", no crash
+
+
+def test_exec_run_none_exit_code_falls_back_to_failure() -> None:
+    client, api = _client()
+    api.exec_exit_code = None  # still-running / unknown
+    assert client.exec_run("c", ["x"]).exit_code == 1
+
+
+def test_exec_run_empty_output() -> None:
+    client, api = _client()
+    api.exec_output = None
+    assert client.exec_run("c", ["x"]).output == ""
+
+
+def test_logs_decodes() -> None:
+    client, _ = _client()
+    assert client.logs("c") == "log line"
+
+
+def test_restart_remove_create_start_delegate() -> None:
+    client, api = _client()
+    client.restart("c")
+    client.remove("c", volumes=False)
+    new_id = client.create_from_config({"HostConfig": {}}, "c")
+    client.start(new_id)
+    assert ("restart", ("c",)) in api.calls
+    assert ("remove_container", ("c", False, True)) in api.calls  # force=True, v=volumes
+    assert new_id == "newid"
+    assert ("start", ("newid",)) in api.calls

--- a/tests/test_docker_client.py
+++ b/tests/test_docker_client.py
@@ -71,22 +71,27 @@ def _client() -> tuple[DockerPyClient, _StubAPI]:
 
 
 def test_ping_true() -> None:
+    """ping() reports reachable when the API answers."""
     client, _ = _client()
     assert client.ping() is True
 
 
 def test_ping_swallows_errors() -> None:
+    """A transport error from ping is swallowed → False (unreachable), not raised
+    — prereqs turn that into a clean exit, not a stack trace."""
     client, api = _client()
     api.ping_raises = True
     assert client.ping() is False
 
 
 def test_list_running_ids() -> None:
+    """The container list is flattened to just the ids the monitor uses."""
     client, _ = _client()
     assert client.list_running_ids() == ["id1", "id2"]
 
 
 def test_inspect_returns_container_info() -> None:
+    """inspect maps the raw payload into the normalized ContainerInfo."""
     client, _ = _client()
     info = client.inspect("gluetun")
     assert info is not None
@@ -95,12 +100,16 @@ def test_inspect_returns_container_info() -> None:
 
 
 def test_inspect_notfound_returns_none() -> None:
+    """A NotFound is translated to None (not an exception) — callers test for
+    None to mean "doesn't exist"."""
     client, api = _client()
     api.inspect_raises_notfound = True
     assert client.inspect("ghost") is None
 
 
 def test_exec_run_decodes_output_and_exit_code() -> None:
+    """exec output is decoded with errors='replace' (an undecodable byte won't
+    crash a probe) and the real exit code is returned."""
     client, api = _client()
     api.exec_output = b"hello\xff"  # includes an undecodable byte
     api.exec_exit_code = 7
@@ -110,23 +119,29 @@ def test_exec_run_decodes_output_and_exit_code() -> None:
 
 
 def test_exec_run_none_exit_code_falls_back_to_failure() -> None:
+    """A None/unknown exit code is treated as failure (1), not success — an
+    indeterminate probe must not read as healthy (Tenet 7)."""
     client, api = _client()
     api.exec_exit_code = None  # still-running / unknown
     assert client.exec_run("c", ["x"]).exit_code == 1
 
 
 def test_exec_run_empty_output() -> None:
+    """No output decodes to "" rather than None — callers can string-parse safely."""
     client, api = _client()
     api.exec_output = None
     assert client.exec_run("c", ["x"]).output == ""
 
 
 def test_logs_decodes() -> None:
+    """logs() returns decoded text (the endpoint parser consumes a str)."""
     client, _ = _client()
     assert client.logs("c") == "log line"
 
 
 def test_restart_remove_create_start_delegate() -> None:
+    """The mutating ops map to the right docker-py calls — notably remove passes
+    force=True with v=volumes, so the recreate path's "rm without -v" is honored."""
     client, api = _client()
     client.restart("c")
     client.remove("c", volumes=False)

--- a/tests/test_dry_run.py
+++ b/tests/test_dry_run.py
@@ -1,0 +1,129 @@
+"""DRY_RUN observe-only mode: detect + log intended actions, never mutate.
+
+Why: a watchdog that restarts/recreates containers needs a way to be soak-tested
+against a real stack — alongside an already-active monitor — without two actors
+fighting. DRY_RUN runs all read-only detection (inspect / ls / wget) so its
+*decisions* are visible, but replaces every mutating action with a
+"[DRY-RUN] would ..." log line. These tests pin that nothing is restarted,
+removed, recreated, or started while observing is on.
+"""
+
+from __future__ import annotations
+
+import io
+import random
+from pathlib import Path
+
+from gluetun_monitor.config import Config
+from gluetun_monitor.docker_client import ExecResult
+from gluetun_monitor.logging_setup import Logger
+from gluetun_monitor.monitor import Monitor
+
+from .fakes import FakeDockerClient
+
+GLUETUN_ID = "a" * 64
+OLD_ID = "b" * 64
+
+
+def _sites(tmp_path: Path) -> str:
+    conf = tmp_path / "sites.conf"
+    conf.write_text("https://www.google.com\n")
+    return str(conf)
+
+
+def _mon(fake: FakeDockerClient, sites: str, **cfg) -> tuple[Monitor, io.StringIO]:
+    stream = io.StringIO()
+    config = Config(config_file=sites, gluetun_container="gluetun", dry_run=True, **cfg)
+    logger = Logger(log_file=None, level="DEBUG", stream=stream)
+    return Monitor(fake, config, logger, rng=random.Random(0), sleep=lambda _s: None), stream
+
+
+def _assert_no_mutations(fake: FakeDockerClient) -> None:
+    assert fake.restarted == []
+    assert fake.removed == []
+    assert fake.created == []
+    assert fake.started == []
+
+
+def test_dry_run_stranded_dependent_is_not_restarted(tmp_path: Path) -> None:
+    """A stranded dependent that would normally be restarted is only logged."""
+    fake = FakeDockerClient()
+    fake.add_container("gluetun", id=GLUETUN_ID)
+    fake.add_container("dep", network_mode=f"container:{GLUETUN_ID}")
+
+    def handler(name: str, cmd: list[str]) -> ExecResult:
+        if cmd[:2] == ["ls", "/sys/class/net"]:
+            return ExecResult(0, "lo\n")  # stranded
+        return ExecResult(0, "")
+
+    fake.on_exec = handler
+    mon, stream = _mon(fake, _sites(tmp_path))
+    mon.run_once()
+    _assert_no_mutations(fake)
+    out = stream.getvalue()
+    assert "[DRY-RUN] would remediate dep" in out
+    assert "action=RESTART" in out
+
+
+def test_dry_run_moved_id_would_recreate_but_does_not(tmp_path: Path) -> None:
+    """A moved-id strand reports action=RECREATE but nothing is removed/created."""
+    fake = FakeDockerClient()
+    fake.add_container("gluetun", id=GLUETUN_ID)
+    fake.add_container("dep", network_mode=f"container:{OLD_ID}")
+
+    def handler(name: str, cmd: list[str]) -> ExecResult:
+        if cmd[:2] == ["ls", "/sys/class/net"]:
+            return ExecResult(0, "lo\n")  # stranded
+        return ExecResult(0, "")
+
+    fake.on_exec = handler
+    mon, stream = _mon(fake, _sites(tmp_path), dependent_containers="dep")
+    mon.run_once()
+    _assert_no_mutations(fake)
+    assert "action=RECREATE" in stream.getvalue()
+
+
+def test_dry_run_gluetun_failure_is_not_restarted(tmp_path: Path) -> None:
+    """When gluetun's sites breach threshold, dry-run logs the would-restart and
+    still probes dependents, but never restarts gluetun."""
+    fake = FakeDockerClient()
+    fake.add_container("gluetun", id=GLUETUN_ID)
+    fake.add_container("dep", network_mode=f"container:{GLUETUN_ID}")
+
+    def handler(name: str, cmd: list[str]) -> ExecResult:
+        if cmd[:2] == ["ls", "/sys/class/net"]:
+            return ExecResult(0, "eth0\nlo\n")
+        return ExecResult(4, "")  # every site probe fails
+
+    fake.on_exec = handler
+    mon, stream = _mon(fake, _sites(tmp_path), fail_threshold=1)
+    mon.run_once()
+    _assert_no_mutations(fake)
+    assert "[DRY-RUN] would restart gluetun" in stream.getvalue()
+
+
+def test_dry_run_still_counts_failures(tmp_path: Path) -> None:
+    """Detection/counting is real in dry-run — the failure counter still climbs,
+    so the observed decision matches what a live run would do."""
+    fake = FakeDockerClient()
+    fake.add_container("gluetun", id=GLUETUN_ID)
+    fake.add_container("dep", network_mode=f"container:{GLUETUN_ID}")
+
+    def handler(name: str, cmd: list[str]) -> ExecResult:
+        if cmd[:2] == ["ls", "/sys/class/net"]:
+            return ExecResult(0, "eth0\nlo\n")
+        if name == "gluetun":
+            return ExecResult(0, "")  # gluetun root test passes
+        return ExecResult(4, "")  # dependent viability fails
+
+    fake.on_exec = handler
+    mon, _ = _mon(fake, _sites(tmp_path), dependent_container_failures=2)
+    mon.run_once()
+    assert mon.dependent_failures.get("dep") == 1
+    mon.run_once()
+    assert mon.dependent_failures.get("dep") == 2  # counts for real; just no action
+    _assert_no_mutations(fake)
+
+
+def test_dry_run_off_by_default() -> None:
+    assert Config().dry_run is False

--- a/tests/test_dry_run.py
+++ b/tests/test_dry_run.py
@@ -114,7 +114,7 @@ def test_dry_run_still_counts_failures(tmp_path: Path) -> None:
             return ExecResult(0, "eth0\nlo\n")
         if name == "gluetun":
             return ExecResult(0, "")  # gluetun root test passes
-        return ExecResult(4, "")  # dependent viability fails
+        return ExecResult(1, "wget: bad address 'site'")  # dependent DNS failure
 
     fake.on_exec = handler
     mon, _ = _mon(fake, _sites(tmp_path), dependent_container_failures=2)

--- a/tests/test_endpoint.py
+++ b/tests/test_endpoint.py
@@ -1,4 +1,10 @@
-"""Gluetun endpoint-log parsing, including the issue #17 apostrophe regression."""
+"""Gluetun endpoint-log parsing, including the issue #17 apostrophe regression.
+
+Why: the reported public IP/country/city/server are read from gluetun's own logs
+(Tenet 2 — reflect the tunnel, not the host). The parse must be quote-safe: a
+region like Provence-Alpes-Cote-d'Azur crashed the v1 monitor (#17), and a parse
+that throws here would take down the whole loop.
+"""
 
 from __future__ import annotations
 
@@ -14,6 +20,7 @@ _WG = "2026-05-10T12:30:00+02:00 INFO [wireguard] Connecting to 185.156.46.20:51
 
 
 def test_parse_basic_endpoint() -> None:
+    """The happy path: IP, country, city, and WG server are all extracted."""
     info = parse_endpoint(f"{_WG}\n{_IP_GETTER}\n")
     assert info.public_ip == "31.40.215.70"
     assert info.country == "Switzerland"
@@ -22,6 +29,8 @@ def test_parse_basic_endpoint() -> None:
 
 
 def test_parse_apostrophe_location_issue_17() -> None:
+    """The #17 regression: an apostrophe in the location must parse cleanly and
+    never crash (this exact string broke the v1 xargs-based parse)."""
     line = (
         "2026-05-10T12:31:08+02:00 INFO [ip getter] Public IP address is 159.26.112.51 "
         "(France, Provence-Alpes-Cote-d'Azur, Marseille - "
@@ -34,6 +43,7 @@ def test_parse_apostrophe_location_issue_17() -> None:
 
 
 def test_parse_takes_last_ip_getter_line() -> None:
+    """Logs accumulate; we report the *most recent* endpoint, not a stale one."""
     older = "INFO [ip getter] Public IP address is 1.1.1.1 (A, B, C - source: x)"
     newer = "INFO [ip getter] Public IP address is 2.2.2.2 (D, E, F - source: y)"
     info = parse_endpoint(f"{older}\n{newer}")
@@ -42,11 +52,14 @@ def test_parse_takes_last_ip_getter_line() -> None:
 
 
 def test_parse_missing_data_is_unknown() -> None:
+    """No matching log lines → all-"unknown", not an exception (logging must be
+    best-effort; it never gates the loop)."""
     info = parse_endpoint("nothing useful here\n")
     assert info == EndpointInfo()  # all "unknown"
 
 
 def test_format_message() -> None:
+    """The ENDPOINT log line includes every field in the v1.x layout."""
     info = EndpointInfo("1.2.3.4", "US", "NYC", "9.9.9.9")
     msg = info.format("NEW", "After restart")
     assert "IP: 1.2.3.4" in msg
@@ -57,6 +70,7 @@ def test_format_message() -> None:
 
 
 def test_get_endpoint_info_from_client() -> None:
+    """End to end: fetch a container's logs via the client and parse them."""
     fake = FakeDockerClient()
     raw = make_inspect("gluetun", id="gid")
     raw["_logs"] = _IP_GETTER

--- a/tests/test_endpoint.py
+++ b/tests/test_endpoint.py
@@ -1,0 +1,65 @@
+"""Gluetun endpoint-log parsing, including the issue #17 apostrophe regression."""
+
+from __future__ import annotations
+
+from gluetun_monitor.endpoint import EndpointInfo, get_endpoint_info, parse_endpoint
+
+from .fakes import FakeDockerClient, make_inspect
+
+_IP_GETTER = (
+    "2026-05-10T12:31:08+02:00 INFO [ip getter] Public IP address is 31.40.215.70 "
+    "(Switzerland, Zurich, Zürich - source: ipinfo)"
+)
+_WG = "2026-05-10T12:30:00+02:00 INFO [wireguard] Connecting to 185.156.46.20:51820"
+
+
+def test_parse_basic_endpoint() -> None:
+    info = parse_endpoint(f"{_WG}\n{_IP_GETTER}\n")
+    assert info.public_ip == "31.40.215.70"
+    assert info.country == "Switzerland"
+    assert info.city == "Zurich"
+    assert info.wg_server == "185.156.46.20"
+
+
+def test_parse_apostrophe_location_issue_17() -> None:
+    line = (
+        "2026-05-10T12:31:08+02:00 INFO [ip getter] Public IP address is 159.26.112.51 "
+        "(France, Provence-Alpes-Cote-d'Azur, Marseille - "
+        "source: ifconfig.co+ip2location+cloudflare)"
+    )
+    info = parse_endpoint(line)
+    assert info.public_ip == "159.26.112.51"
+    assert info.country == "France"
+    assert info.city == "Provence-Alpes-Cote-d'Azur"
+
+
+def test_parse_takes_last_ip_getter_line() -> None:
+    older = "INFO [ip getter] Public IP address is 1.1.1.1 (A, B, C - source: x)"
+    newer = "INFO [ip getter] Public IP address is 2.2.2.2 (D, E, F - source: y)"
+    info = parse_endpoint(f"{older}\n{newer}")
+    assert info.public_ip == "2.2.2.2"
+    assert info.country == "D"
+
+
+def test_parse_missing_data_is_unknown() -> None:
+    info = parse_endpoint("nothing useful here\n")
+    assert info == EndpointInfo()  # all "unknown"
+
+
+def test_format_message() -> None:
+    info = EndpointInfo("1.2.3.4", "US", "NYC", "9.9.9.9")
+    msg = info.format("NEW", "After restart")
+    assert "IP: 1.2.3.4" in msg
+    assert "Country: US" in msg
+    assert "City: NYC" in msg
+    assert "VPN Server: 9.9.9.9" in msg
+    assert "Reason: After restart" in msg
+
+
+def test_get_endpoint_info_from_client() -> None:
+    fake = FakeDockerClient()
+    raw = make_inspect("gluetun", id="gid")
+    raw["_logs"] = _IP_GETTER
+    fake.add(raw)
+    info = get_endpoint_info(fake, "gluetun")
+    assert info.public_ip == "31.40.215.70"

--- a/tests/test_entrypoint.py
+++ b/tests/test_entrypoint.py
@@ -1,0 +1,140 @@
+"""cli.main() wiring, signal handling, and the Monitor.run() loop."""
+
+from __future__ import annotations
+
+import io
+import random
+import signal
+from pathlib import Path
+
+import pytest
+
+from gluetun_monitor import cli
+from gluetun_monitor.config import Config
+from gluetun_monitor.logging_setup import Logger
+from gluetun_monitor.monitor import Monitor
+
+from .fakes import FakeDockerClient
+
+GLUETUN_ID = "a" * 64
+
+
+class _StopLoop(Exception):
+    """Sentinel used to break the otherwise-infinite run() loop in tests."""
+
+
+def _logger(stream: io.StringIO) -> Logger:
+    return Logger(log_file=None, level="DEBUG", stream=stream)
+
+
+# ----- Monitor.run() loop -----
+
+
+def test_run_calls_run_once_then_sleeps(tmp_path: Path) -> None:
+    fake = FakeDockerClient()
+    fake.add_container("gluetun", id=GLUETUN_ID)
+    mon = Monitor(fake, Config(), _logger(io.StringIO()), rng=random.Random(0),
+                  sleep=lambda _s: None)
+    calls: list[int] = []
+    mon.run_once = lambda: calls.append(1)  # type: ignore[method-assign]
+
+    def sleeper(_s: float) -> None:
+        raise _StopLoop
+
+    mon._sleep = sleeper  # type: ignore[assignment]
+    with pytest.raises(_StopLoop):
+        mon.run()
+    assert calls == [1]
+
+
+def test_run_survives_a_failing_iteration() -> None:
+    fake = FakeDockerClient()
+    fake.add_container("gluetun", id=GLUETUN_ID)
+    stream = io.StringIO()
+    mon = Monitor(fake, Config(), _logger(stream), rng=random.Random(0), sleep=lambda _s: None)
+
+    seq = iter([RuntimeError("boom"), None])
+
+    def run_once() -> None:
+        item = next(seq)
+        if item is not None:
+            raise item
+
+    mon.run_once = run_once  # type: ignore[method-assign]
+
+    sleeps = [0]
+
+    def sleeper(_s: float) -> None:
+        sleeps[0] += 1
+        if sleeps[0] >= 2:  # let the loop run twice, then stop
+            raise _StopLoop
+
+    mon._sleep = sleeper  # type: ignore[assignment]
+    with pytest.raises(_StopLoop):
+        mon.run()
+    assert "Unhandled error in monitor loop" in stream.getvalue()
+
+
+def test_announce_logs_connection_and_endpoint() -> None:
+    fake = FakeDockerClient()
+    fake.add_container("gluetun", id=GLUETUN_ID)
+    stream = io.StringIO()
+    cfg = Config(docker_host="tcp://proxy:2375")
+    Monitor(fake, cfg, _logger(stream)).announce()
+    out = stream.getvalue()
+    assert "socket proxy (tcp://proxy:2375)" in out
+    assert "[ENDPOINT]" in out
+
+
+# ----- cli.main() -----
+
+
+def _prep_env(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    conf = tmp_path / "sites.conf"
+    conf.write_text("https://www.google.com\n")
+    monkeypatch.setenv("CONFIG_FILE", str(conf))
+    monkeypatch.setenv("LOG_FILE", str(tmp_path / "monitor.log"))
+    monkeypatch.setenv("GLUETUN_CONTAINER", "gluetun")
+
+
+def test_main_success(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    _prep_env(monkeypatch, tmp_path)
+    fake = FakeDockerClient()
+    fake.add_container("gluetun", id=GLUETUN_ID)
+    monkeypatch.setattr(cli, "DockerPyClient", lambda **_kw: fake)
+    ran: list[int] = []
+    monkeypatch.setattr(cli.Monitor, "announce", lambda self: None)
+    monkeypatch.setattr(cli.Monitor, "run", lambda self: ran.append(1))
+    assert cli.main() == 0
+    assert ran == [1]
+
+
+def test_main_client_init_failure_returns_1(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    _prep_env(monkeypatch, tmp_path)
+
+    def boom(**_kw: object) -> object:
+        raise RuntimeError("no docker")
+
+    monkeypatch.setattr(cli, "DockerPyClient", boom)
+    assert cli.main() == 1
+
+
+def test_main_prereq_failure_returns_1(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    _prep_env(monkeypatch, tmp_path)
+    fake = FakeDockerClient()  # no gluetun container -> prereq fails
+    monkeypatch.setattr(cli, "DockerPyClient", lambda **_kw: fake)
+    assert cli.main() == 1
+
+
+def test_signal_handler_exits_cleanly() -> None:
+    logger = _logger(io.StringIO())
+    cli._install_signal_handlers(logger)
+    handler = signal.getsignal(signal.SIGTERM)
+    assert callable(handler)
+    with pytest.raises(SystemExit) as exc:
+        handler(signal.SIGTERM, None)
+    assert exc.value.code == 0

--- a/tests/test_exclude.py
+++ b/tests/test_exclude.py
@@ -1,0 +1,100 @@
+"""EXCLUDE_CONTAINERS denylist — containers the monitor must never manage.
+
+Why this exists: auto-discovery is all-or-nothing, so without a denylist a user
+who wants "discover everything except this one" would have to abandon auto and
+hand-maintain a full list. EXCLUDE is the escape hatch, and its overlap handling
+encodes the "first, do no harm" stance — when include and exclude contradict, we
+take the non-destructive action (exclude) and warn, rather than guess or restart.
+"""
+
+from __future__ import annotations
+
+import io
+import random
+
+from gluetun_monitor import cli
+from gluetun_monitor.config import Config
+from gluetun_monitor.logging_setup import Logger
+from gluetun_monitor.monitor import Monitor
+
+from .fakes import FakeDockerClient
+
+GLUETUN_ID = "a" * 64
+
+
+def _mon(fake: FakeDockerClient, **cfg: object) -> tuple[Monitor, io.StringIO]:
+    stream = io.StringIO()
+    cfg.setdefault("config_file", "/dev/null")
+    cfg.setdefault("gluetun_container", "gluetun")
+    config = Config(**cfg)
+    logger = Logger(log_file=None, level="DEBUG", stream=stream)
+    return Monitor(fake, config, logger, rng=random.Random(0), sleep=lambda _s: None), stream
+
+
+def _logger() -> Logger:
+    return Logger(log_file=None, level="DEBUG", stream=io.StringIO())
+
+
+def test_excluded_container_dropped_from_auto_discovery() -> None:
+    """An auto-discovered dependent named in EXCLUDE must not appear in the managed
+    set — proving exclude filters discovery, not just explicit lists."""
+    fake = FakeDockerClient()
+    fake.add_container("gluetun", id=GLUETUN_ID)
+    fake.add_container("dep1", network_mode=f"container:{GLUETUN_ID}")
+    fake.add_container("dep2", network_mode=f"container:{GLUETUN_ID}")
+    mon, _ = _mon(fake, exclude_containers="dep2")
+    assert mon._resolve_dependents() == ["dep1"]  # dep2 excluded
+
+
+def test_exclude_subtracts_from_explicit_list() -> None:
+    """Exclude also subtracts from an explicit DEPENDENT_CONTAINERS list, so the
+    denylist works regardless of how a dependent was selected."""
+    fake = FakeDockerClient()
+    fake.add_container("gluetun", id=GLUETUN_ID)
+    fake.add_container("dep1", network_mode=f"container:{GLUETUN_ID}")
+    fake.add_container("dep2", network_mode=f"container:{GLUETUN_ID}")
+    mon, _ = _mon(fake, dependent_containers="dep1,dep2", exclude_containers="dep2")
+    assert mon._resolve_dependents() == ["dep1"]
+
+
+def test_overlap_excludes_and_warns_first_do_no_harm() -> None:
+    """A container named in BOTH lists is a contradiction; we take the safe action
+    (exclude it) and WARN rather than fail or manage it — "first, do no harm"."""
+    fake = FakeDockerClient()
+    fake.add_container("gluetun", id=GLUETUN_ID)
+    fake.add_container("qbit", network_mode=f"container:{GLUETUN_ID}")
+    config = Config(
+        config_file="/dev/null", gluetun_container="gluetun",
+        sites_env="https://x", dependent_containers="qbit", exclude_containers="qbit",
+    )
+    stream = io.StringIO()
+    # Not fatal: prereqs pass (it just means gluetun-only).
+    assert cli.check_prerequisites(fake, config, Logger(log_file=None, stream=stream)) is True
+    out = stream.getvalue()
+    assert "both DEPENDENT_CONTAINERS and EXCLUDE_CONTAINERS" in out
+    assert "first, do no harm" in out
+
+
+def test_unmatched_exclude_name_warns_as_likely_typo() -> None:
+    """An exclude name matching no container is usually a typo — and a dangerous
+    one (the container you meant to protect would still be managed) — so we WARN.
+    Not fatal: it may legitimately not exist yet."""
+    fake = FakeDockerClient()
+    fake.add_container("gluetun", id=GLUETUN_ID)
+    config = Config(
+        config_file="/dev/null", gluetun_container="gluetun",
+        sites_env="https://x", exclude_containers="ghost",
+    )
+    stream = io.StringIO()
+    assert cli.check_prerequisites(fake, config, Logger(log_file=None, stream=stream)) is True
+    assert "EXCLUDE_CONTAINERS names container(s) not found: ghost" in stream.getvalue()
+
+
+def test_announce_logs_exclusions() -> None:
+    """Startup logging surfaces the denylist so an operator can confirm what is
+    deliberately unmanaged."""
+    fake = FakeDockerClient()
+    fake.add_container("gluetun", id=GLUETUN_ID)
+    mon, stream = _mon(fake, exclude_containers="dep2,dep3")
+    mon.announce()
+    assert "Excluded from management (EXCLUDE_CONTAINERS): dep2,dep3" in stream.getvalue()

--- a/tests/test_gateway_interface_log.py
+++ b/tests/test_gateway_interface_log.py
@@ -42,8 +42,8 @@ def test_gateway_interface_logged_before_site_tests(tmp_path: Path) -> None:
     )
     mon.run_once()
     out = stream.getvalue()
-    assert "[gateway:gluetun] interface check: live [eth0,lo,tun0]" in out
+    assert "[gateway:gluetun] link live: eth0,lo,tun0" in out
     # ...and it comes before the first site curl line.
-    gw_at = out.index("[gateway:gluetun] interface check:")
-    site_at = out.index("[gateway:gluetun] site https://www.google.com")
+    gw_at = out.index("[gateway:gluetun] link ")
+    site_at = out.index("[gateway:gluetun] reach ok: https://www.google.com")
     assert gw_at < site_at

--- a/tests/test_gateway_interface_log.py
+++ b/tests/test_gateway_interface_log.py
@@ -1,0 +1,49 @@
+"""The gateway logs its own interface/route check before the site curls.
+
+Why: symmetry with the dependent checks + early visibility of tun0 (tunnel up at
+L3) vs "sites unreachable". It's observability only — the site tests remain the
+authoritative tunnel check (ADR-0001), so this never gates behavior.
+"""
+
+from __future__ import annotations
+
+import io
+import random
+from pathlib import Path
+
+from gluetun_monitor.config import Config
+from gluetun_monitor.docker_client import ExecResult
+from gluetun_monitor.logging_setup import Logger
+from gluetun_monitor.monitor import Monitor
+from gluetun_monitor.site_stats import SiteStatsStore
+
+from .fakes import FakeDockerClient
+
+GLUETUN_ID = "a" * 64
+
+
+def test_gateway_interface_logged_before_site_tests(tmp_path: Path) -> None:
+    conf = tmp_path / "sites.conf"
+    conf.write_text("https://www.google.com\n")
+    fake = FakeDockerClient()
+    fake.add_container("gluetun", id=GLUETUN_ID)
+
+    def handler(name: str, cmd: list[str]) -> ExecResult:
+        if cmd[:2] == ["ls", "/sys/class/net"]:
+            return ExecResult(0, "eth0\nlo\ntun0\n")
+        return ExecResult(0, "  HTTP/1.1 200 OK\n")
+
+    fake.on_exec = handler
+    stream = io.StringIO()
+    mon = Monitor(
+        fake, Config(config_file=str(conf), gluetun_container="gluetun"),
+        Logger(log_file=None, level="DEBUG", stream=stream),
+        rng=random.Random(0), sleep=lambda _s: None, stats=SiteStatsStore(None),
+    )
+    mon.run_once()
+    out = stream.getvalue()
+    assert "[gateway:gluetun] interface check: live [eth0,lo,tun0]" in out
+    # ...and it comes before the first site curl line.
+    gw_at = out.index("[gateway:gluetun] interface check:")
+    site_at = out.index("[gateway:gluetun] site https://www.google.com")
+    assert gw_at < site_at

--- a/tests/test_histogram.py
+++ b/tests/test_histogram.py
@@ -1,0 +1,114 @@
+"""The DDSketch-style latency histogram: bounded memory, alpha-accurate percentiles.
+
+Why: it backs the all-time latency view. These tests pin the accuracy guarantee
+(every percentile within ALPHA relative error), the exact count/avg/min/max,
+monotonic percentiles, mergeability, JSON round-trip, and graceful handling of
+empty/garbage input (it feeds the best-effort stats sidecar).
+"""
+
+from __future__ import annotations
+
+import math
+import random
+
+from gluetun_monitor.histogram import ALPHA, LatencyHistogram
+
+
+def _true_quantile(values: list[int], q: float) -> int:
+    s = sorted(values)
+    return s[min(len(s) - 1, max(0, math.ceil(q * len(s)) - 1))]
+
+
+def test_percentiles_within_alpha_relative_error() -> None:
+    rng = random.Random(42)
+    data = [int(rng.lognormvariate(6.5, 0.6)) for _ in range(10_000)]  # skewed, ms-ish
+    h = LatencyHistogram()
+    for v in data:
+        h.add(v)
+    for q in (0.50, 0.90, 0.99):
+        est = h.quantile(q)
+        true = _true_quantile(data, q)
+        # The guarantee is relative error <= ALPHA; allow a hair for rounding.
+        assert abs(est - true) / true <= ALPHA + 0.01, (q, est, true)
+
+
+def test_exact_count_avg_min_max() -> None:
+    h = LatencyHistogram()
+    for v in (100, 200, 300, 400, 500):
+        h.add(v)
+    s = h.summary()
+    assert s["samples"] == 5
+    assert s["avg"] == 300  # exact, not bucketed
+    assert s["min"] == 100 and s["max"] == 500  # exact
+
+
+def test_percentiles_monotonic() -> None:
+    h = LatencyHistogram()
+    for v in range(1, 2001):
+        h.add(v)
+    s = h.summary()
+    assert s["p50"] <= s["p90"] <= s["p99"] <= s["max"]
+    assert s["min"] <= s["p50"]
+
+
+def test_empty_is_zeros() -> None:
+    h = LatencyHistogram()
+    assert h.quantile(0.9) == 0
+    assert h.summary() == {"samples": 0, "avg": 0, "min": 0, "max": 0,
+                           "p50": 0, "p90": 0, "p99": 0}
+
+
+def test_sub_millisecond_clamped() -> None:
+    h = LatencyHistogram()
+    h.add(0)
+    assert h.count == 1 and h.min_ms == 1  # 0 ms clamped to 1
+
+
+def test_bounded_bucket_count() -> None:
+    """A wide range of latencies still uses few buckets (log-scale)."""
+    h = LatencyHistogram()
+    rng = random.Random(1)
+    for _ in range(50_000):
+        h.add(rng.randint(50, 10_000))
+    assert len(h.buckets) < 120  # ~log_gamma(10000/50) buckets, not 50k samples
+
+
+def test_merge_is_additive() -> None:
+    a = LatencyHistogram()
+    b = LatencyHistogram()
+    for v in (100, 200, 300):
+        a.add(v)
+    for v in (400, 500, 600):
+        b.add(v)
+    combined = LatencyHistogram()
+    for v in (100, 200, 300, 400, 500, 600):
+        combined.add(v)
+    a.merge(b)
+    assert a.count == combined.count == 6
+    assert a.min_ms == 100 and a.max_ms == 600
+    assert a.summary() == combined.summary()
+
+
+def test_merge_empty_noop() -> None:
+    a = LatencyHistogram()
+    a.add(100)
+    a.merge(LatencyHistogram())
+    assert a.count == 1
+
+
+def test_json_round_trip() -> None:
+    h = LatencyHistogram()
+    rng = random.Random(7)
+    for _ in range(2000):
+        h.add(rng.randint(100, 3000))
+    h2 = LatencyHistogram.from_dict(h.to_dict())
+    assert h2.count == h.count and h2.min_ms == h.min_ms and h2.max_ms == h.max_ms
+    assert h2.summary() == h.summary()
+
+
+def test_from_dict_tolerates_garbage() -> None:
+    assert LatencyHistogram.from_dict("not a dict").count == 0
+    assert LatencyHistogram.from_dict([1, 2, 3]).count == 0
+    assert LatencyHistogram.from_dict({"buckets": "nope"}).count == 0
+    # partial / wrong-typed values degrade to empty, never raise
+    assert LatencyHistogram.from_dict({"count": "x", "buckets": {}}).count == 0

--- a/tests/test_interface_logging.py
+++ b/tests/test_interface_logging.py
@@ -73,7 +73,12 @@ def test_live_dependent_logs_its_interfaces(tmp_path: Path) -> None:
     mon, stream = _mon(fake, tmp_path)
     mon.run_once()
     out = stream.getvalue()
-    assert "Dependent dep: interface=live [eth0,lo,tun0]" in out
+    # Two ordered lines: the interface/route check first, then the viability test.
+    assert "[dep] interface check: live [eth0,lo,tun0]" in out
+    assert "[dep] viability:" in out
+    iface_at = out.index("[dep] interface check:")
+    viability_at = out.index("[dep] viability:")
+    assert iface_at < viability_at  # path validated BEFORE the DNS/connect test
 
 
 def test_stranded_dependent_logs_loopback_only(tmp_path: Path) -> None:
@@ -85,4 +90,4 @@ def test_stranded_dependent_logs_loopback_only(tmp_path: Path) -> None:
     )
     mon, stream = _mon(fake, tmp_path)
     mon.run_once()
-    assert "interface=stranded [lo]" in stream.getvalue()
+    assert "[dep] interface check: stranded [lo]" in stream.getvalue()

--- a/tests/test_interface_logging.py
+++ b/tests/test_interface_logging.py
@@ -74,10 +74,10 @@ def test_live_dependent_logs_its_interfaces(tmp_path: Path) -> None:
     mon.run_once()
     out = stream.getvalue()
     # Two ordered lines: the interface/route check first, then the viability test.
-    assert "[dep] interface check: live [eth0,lo,tun0]" in out
-    assert "[dep] viability:" in out
-    iface_at = out.index("[dep] interface check:")
-    viability_at = out.index("[dep] viability:")
+    assert "[dependent:dep] interface check: live [eth0,lo,tun0]" in out
+    assert "[dependent:dep] viability:" in out
+    iface_at = out.index("[dependent:dep] interface check:")
+    viability_at = out.index("[dependent:dep] viability:")
     assert iface_at < viability_at  # path validated BEFORE the DNS/connect test
 
 
@@ -90,4 +90,4 @@ def test_stranded_dependent_logs_loopback_only(tmp_path: Path) -> None:
     )
     mon, stream = _mon(fake, tmp_path)
     mon.run_once()
-    assert "[dep] interface check: stranded [lo]" in stream.getvalue()
+    assert "[dependent:dep] interface check: stranded [lo]" in stream.getvalue()

--- a/tests/test_interface_logging.py
+++ b/tests/test_interface_logging.py
@@ -1,0 +1,88 @@
+"""Interface (L3 route) check: capture the interface set + surface it in DEBUG.
+
+Why: "can a dependent route out" is the eth0/tun0-vs-lo-only question, and an
+operator wants to *see* it each loop — not just the DNS result. list_interfaces
+exposes the actual set; classify_interfaces turns it into the verdict; and the
+dependent-phase DEBUG line now shows both.
+"""
+
+from __future__ import annotations
+
+import io
+import random
+from pathlib import Path
+
+from gluetun_monitor.config import Config
+from gluetun_monitor.dependents import classify_interfaces, list_interfaces
+from gluetun_monitor.docker_client import ExecResult
+from gluetun_monitor.logging_setup import Logger
+from gluetun_monitor.monitor import Monitor
+from gluetun_monitor.site_stats import SiteStatsStore
+from gluetun_monitor.state import InterfaceStatus
+
+from .fakes import FakeDockerClient
+
+GLUETUN_ID = "a" * 64
+
+
+def test_list_interfaces_parses_the_set() -> None:
+    fake = FakeDockerClient()
+    fake.on_exec = lambda n, c: ExecResult(0, "eth0\nlo\ntun0\n")
+    assert list_interfaces(fake, "dep") == {"eth0", "lo", "tun0"}
+
+
+def test_list_interfaces_none_on_failure() -> None:
+    fake = FakeDockerClient()
+    fake.on_exec = lambda n, c: ExecResult(1, "")  # no shell / error
+    assert list_interfaces(fake, "dep") is None
+
+
+def test_classify_interfaces() -> None:
+    assert classify_interfaces({"eth0", "lo"}) is InterfaceStatus.LIVE
+    assert classify_interfaces({"lo"}) is InterfaceStatus.STRANDED
+    assert classify_interfaces(None) is InterfaceStatus.UNKNOWN
+    assert classify_interfaces(set()) is InterfaceStatus.UNKNOWN
+
+
+def _mon(fake: FakeDockerClient, tmp_path: Path) -> tuple[Monitor, io.StringIO]:
+    conf = tmp_path / "sites.conf"
+    conf.write_text("https://www.google.com\n")
+    stream = io.StringIO()
+    cfg = Config(config_file=str(conf), gluetun_container="gluetun")
+    logger = Logger(log_file=None, level="DEBUG", stream=stream)
+    return (
+        Monitor(fake, cfg, logger, rng=random.Random(0), sleep=lambda _s: None,
+                stats=SiteStatsStore(None)),
+        stream,
+    )
+
+
+def test_live_dependent_logs_its_interfaces(tmp_path: Path) -> None:
+    """A healthy dependent's DEBUG line shows the interface verdict AND the actual
+    interfaces (the route check), alongside the DNS result."""
+    fake = FakeDockerClient()
+    fake.add_container("gluetun", id=GLUETUN_ID)
+    fake.add_container("dep", network_mode=f"container:{GLUETUN_ID}")
+
+    def handler(name: str, cmd: list[str]) -> ExecResult:
+        if cmd[:2] == ["ls", "/sys/class/net"]:
+            return ExecResult(0, "eth0\nlo\ntun0\n")
+        return ExecResult(0, "  HTTP/1.1 200 OK\n")
+
+    fake.on_exec = handler
+    mon, stream = _mon(fake, tmp_path)
+    mon.run_once()
+    out = stream.getvalue()
+    assert "Dependent dep: interface=live [eth0,lo,tun0]" in out
+
+
+def test_stranded_dependent_logs_loopback_only(tmp_path: Path) -> None:
+    fake = FakeDockerClient()
+    fake.add_container("gluetun", id=GLUETUN_ID)
+    fake.add_container("dep", network_mode=f"container:{GLUETUN_ID}")
+    fake.on_exec = lambda n, c: (
+        ExecResult(0, "lo\n") if c[:2] == ["ls", "/sys/class/net"] else ExecResult(0, "")
+    )
+    mon, stream = _mon(fake, tmp_path)
+    mon.run_once()
+    assert "interface=stranded [lo]" in stream.getvalue()

--- a/tests/test_interface_logging.py
+++ b/tests/test_interface_logging.py
@@ -73,12 +73,12 @@ def test_live_dependent_logs_its_interfaces(tmp_path: Path) -> None:
     mon, stream = _mon(fake, tmp_path)
     mon.run_once()
     out = stream.getvalue()
-    # Two ordered lines: the interface/route check first, then the viability test.
-    assert "[dependent:dep] interface check: live [eth0,lo,tun0]" in out
-    assert "[dependent:dep] viability:" in out
-    iface_at = out.index("[dependent:dep] interface check:")
-    viability_at = out.index("[dependent:dep] viability:")
-    assert iface_at < viability_at  # path validated BEFORE the DNS/connect test
+    # Two ordered lines: the L3 link check first, then the reach (DNS/connect) test.
+    assert "[dependent:dep] link live: eth0,lo,tun0" in out
+    assert "[dependent:dep] reach " in out
+    iface_at = out.index("[dependent:dep] link ")
+    reach_at = out.index("[dependent:dep] reach ")
+    assert iface_at < reach_at  # path validated BEFORE the DNS/connect test
 
 
 def test_stranded_dependent_logs_loopback_only(tmp_path: Path) -> None:
@@ -90,4 +90,4 @@ def test_stranded_dependent_logs_loopback_only(tmp_path: Path) -> None:
     )
     mon, stream = _mon(fake, tmp_path)
     mon.run_once()
-    assert "[dependent:dep] interface check: stranded [lo]" in stream.getvalue()
+    assert "[dependent:dep] link stranded: lo" in stream.getvalue()

--- a/tests/test_live_reload.py
+++ b/tests/test_live_reload.py
@@ -53,4 +53,4 @@ def test_added_site_is_picked_up_without_restart(tmp_path: Path) -> None:
     mon.run_once()
 
     assert "https://c.example" in tested  # the new site is now tested
-    assert "Site count changed from 2 to 3" in stream.getvalue()
+    assert "Sites changed: added https://c.example (now 3)" in stream.getvalue()

--- a/tests/test_live_reload.py
+++ b/tests/test_live_reload.py
@@ -1,0 +1,56 @@
+"""sites.conf is re-read every cycle — add a site to the file, no restart needed.
+
+This is a v1 feature ("just add it to the sites file") that v2 preserves: the
+monitor parses the config file on each loop rather than caching it at startup.
+"""
+
+from __future__ import annotations
+
+import io
+import random
+from pathlib import Path
+
+from gluetun_monitor.config import Config
+from gluetun_monitor.docker_client import ExecResult
+from gluetun_monitor.logging_setup import Logger
+from gluetun_monitor.monitor import Monitor
+
+from .fakes import FakeDockerClient
+
+GLUETUN_ID = "a" * 64
+
+
+def test_added_site_is_picked_up_without_restart(tmp_path: Path) -> None:
+    fake = FakeDockerClient()
+    fake.add_container("gluetun", id=GLUETUN_ID)
+
+    tested: list[str] = []
+
+    def handler(name: str, cmd: list[str]) -> ExecResult:
+        if cmd and cmd[0] == "wget":
+            tested.append(cmd[-1])  # the URL probed inside gluetun
+        return ExecResult(0, "")
+
+    fake.on_exec = handler
+
+    conf = tmp_path / "sites.conf"
+    conf.write_text("https://a.example\nhttps://b.example\n")
+    stream = io.StringIO()
+    mon = Monitor(
+        fake,
+        Config(config_file=str(conf), gluetun_container="gluetun"),
+        Logger(log_file=None, level="DEBUG", stream=stream),
+        rng=random.Random(0),
+        sleep=lambda _s: None,
+    )
+
+    mon.run_once()
+    assert "Loaded 2 sites" in stream.getvalue()
+
+    # Add a site to the file at runtime — no restart.
+    conf.write_text("https://a.example\nhttps://b.example\nhttps://c.example\n")
+    tested.clear()
+    mon.run_once()
+
+    assert "https://c.example" in tested  # the new site is now tested
+    assert "Site count changed from 2 to 3" in stream.getvalue()

--- a/tests/test_log_heartbeat.py
+++ b/tests/test_log_heartbeat.py
@@ -1,0 +1,95 @@
+"""The per-loop INFO heartbeat — and the technique for testing log output by level.
+
+Why: the default level is INFO, and a healthy loop must still *say something*
+("sites: N/M ok", "dependents: N/M ok") without the per-item DEBUG spam. The way
+to test any log-level behavior: point a Logger at a StringIO at the chosen level,
+run a loop, and assert what is (and isn't) in the captured text.
+"""
+
+from __future__ import annotations
+
+import io
+import random
+
+from gluetun_monitor.config import Config
+from gluetun_monitor.docker_client import ExecResult
+from gluetun_monitor.logging_setup import Logger
+from gluetun_monitor.monitor import Monitor
+from gluetun_monitor.site_stats import SiteStatsStore
+
+from .fakes import FakeDockerClient
+
+GLUETUN_ID = "a" * 64
+SITES = ["https://google.com", "https://cloudflare.com", "https://nzb.su"]
+
+
+def _run_loop(level: str, *, exec_handler=None, **cfg: object) -> str:
+    """Run one monitoring loop at ``level`` and return the captured log text."""
+    fake = FakeDockerClient()
+    fake.add_container("gluetun", id=GLUETUN_ID)
+    fake.add_container("qbittorrent", network_mode=f"container:{GLUETUN_ID}")
+    fake.add_container("sonarr", network_mode=f"container:{GLUETUN_ID}")
+
+    def healthy(name: str, cmd: list[str]) -> ExecResult:
+        if cmd[:2] == ["ls", "/sys/class/net"]:
+            return ExecResult(0, "eth0\nlo\ntun0\n")
+        return ExecResult(0, "  HTTP/1.1 200 OK\n")
+
+    fake.on_exec = exec_handler or healthy
+    stream = io.StringIO()
+    logger = Logger(log_file=None, level=level, stream=stream)
+    cfg.setdefault("config_file", "/dev/null")
+    cfg.setdefault("gluetun_container", "gluetun")
+    cfg.setdefault("sites_env", ",".join(SITES))
+    mon = Monitor(fake, Config(**cfg), logger, rng=random.Random(0),
+                  sleep=lambda _s: None, stats=SiteStatsStore(None))
+    mon.run_once()
+    return stream.getvalue()
+
+
+def test_info_shows_heartbeat_not_per_item() -> None:
+    out = _run_loop("INFO")
+    # Heartbeat summaries ARE present at INFO...
+    assert "[gateway:gluetun] sites: 3/3 ok" in out
+    assert "dependents: 2/2 ok" in out
+    # ...but the per-item detail is NOT (that's DEBUG-only).
+    assert "reach ok: https://google.com" not in out
+    assert "link live:" not in out
+
+
+def test_debug_shows_heartbeat_and_per_item() -> None:
+    out = _run_loop("DEBUG")
+    assert "[gateway:gluetun] sites: 3/3 ok" in out        # heartbeat
+    assert "reach ok: https://google.com" in out           # per-site detail
+    assert "[dependent:qbittorrent] link live:" in out     # per-dependent detail
+
+
+def test_heartbeat_reports_failing_site() -> None:
+    """A site failing this loop (even below threshold) shows in the INFO summary."""
+    def one_bad(name: str, cmd: list[str]) -> ExecResult:
+        if cmd[:2] == ["ls", "/sys/class/net"]:
+            return ExecResult(0, "eth0\nlo\ntun0\n")
+        if "nzb.su" in cmd[-1]:
+            return ExecResult(4, "wget: bad address 'nzb.su'\n")  # no HTTP -> fail
+        return ExecResult(0, "  HTTP/1.1 200 OK\n")
+
+    out = _run_loop("INFO", exec_handler=one_bad)
+    assert "[gateway:gluetun] sites: 2/3 ok — failing: nzb.su" in out
+
+
+def test_heartbeat_reports_dependent_remediation() -> None:
+    """A stranded dependent shows as remediating in the INFO summary."""
+    def qb_stranded(name: str, cmd: list[str]) -> ExecResult:
+        if cmd[:2] == ["ls", "/sys/class/net"]:
+            return ExecResult(0, "lo\n") if name == "qbittorrent" else ExecResult(0, "eth0\nlo\n")
+        return ExecResult(0, "  HTTP/1.1 200 OK\n")
+
+    out = _run_loop("INFO", exec_handler=qb_stranded, dependent_containers="qbittorrent,sonarr")
+    assert "dependents: 1/2 ok — remediating: qbittorrent" in out
+
+
+def test_discovery_line_is_debug_only() -> None:
+    """The 'Discovered dependent containers' line moved to DEBUG (the heartbeat
+    covers it at INFO), so it must not appear at INFO."""
+    assert "Discovered dependent containers" not in _run_loop("INFO")
+    assert "Discovered dependent containers" in _run_loop("DEBUG")

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -95,3 +95,21 @@ def test_unwritable_file_degrades_gracefully() -> None:
     log = Logger(log_file="/proc/cannot/create/here.log", level="INFO", stream=stream)
     log.info("still works")
     assert "[INFO] still works" in stream.getvalue()
+
+
+def test_install_bash_format_on_root_formats_third_party() -> None:
+    """Library logs (via the root logger) render in the bash format, not Python's
+    default 'WARNING:name:msg' — so the container's output stays uniform."""
+    import logging as _logging
+
+    from gluetun_monitor.logging_setup import install_bash_format_on_root
+
+    install_bash_format_on_root("WARNING")
+    root = _logging.getLogger()
+    assert len(root.handlers) == 1
+    fmt = root.handlers[0].formatter
+    assert fmt is not None
+    rec = _logging.LogRecord("urllib3", _logging.WARNING, "x", 1, "pool full", None, None)
+    line = fmt.format(rec)
+    assert _LINE_RE.match(line), line   # [ts] [WARN] pool full
+    assert "[WARN]" in line

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -1,4 +1,11 @@
-"""Logger format parity + LOG_LEVEL gating + file output."""
+"""Logger format parity + LOG_LEVEL gating + file output.
+
+Why: the log format is a compatibility surface — users grep for `[CHECK]`,
+`[ENDPOINT]`, `[WARN]` and the `[ts] [LEVEL] msg` shape (preserved from v1.x).
+These tests pin that the stdlib-logging backend reproduces that exactly, that
+the custom CHECK/ENDPOINT levels survive the default INFO threshold, and that an
+unwritable log path degrades to stderr rather than crashing the monitor.
+"""
 
 from __future__ import annotations
 
@@ -21,6 +28,7 @@ def _lines(stream: io.StringIO) -> list[tuple[str, str]]:
 
 
 def test_format_matches_v1() -> None:
+    """An INFO line matches the exact v1.x `[ts] [LEVEL] msg` format."""
     stream = io.StringIO()
     log = Logger(log_file=None, level="DEBUG", stream=stream)
     log.info("hello")
@@ -28,12 +36,15 @@ def test_format_matches_v1() -> None:
 
 
 def test_warning_renders_as_warn() -> None:
+    """stdlib's WARNING renders as the v1.x token `WARN`, not `WARNING`."""
     stream = io.StringIO()
     Logger(log_file=None, level="DEBUG", stream=stream).warn("careful")
     assert _lines(stream) == [("WARN", "careful")]
 
 
 def test_check_and_endpoint_tokens() -> None:
+    """The v1.x CHECK/ENDPOINT markers exist as custom levels with those exact
+    token names (users grep for them)."""
     stream = io.StringIO()
     log = Logger(log_file=None, level="INFO", stream=stream)
     log.check("Start")
@@ -43,6 +54,7 @@ def test_check_and_endpoint_tokens() -> None:
 
 
 def test_debug_suppressed_at_info_level() -> None:
+    """DEBUG is gated by LOG_LEVEL — silent at the default INFO (new in v2)."""
     stream = io.StringIO()
     log = Logger(log_file=None, level="INFO", stream=stream)
     log.debug("noisy")
@@ -51,6 +63,7 @@ def test_debug_suppressed_at_info_level() -> None:
 
 
 def test_debug_shown_at_debug_level() -> None:
+    """...but DEBUG appears when LOG_LEVEL=DEBUG (the per-site/per-dependent detail)."""
     stream = io.StringIO()
     log = Logger(log_file=None, level="DEBUG", stream=stream)
     log.debug("seen")
@@ -58,8 +71,8 @@ def test_debug_shown_at_debug_level() -> None:
 
 
 def test_check_endpoint_survive_info_threshold() -> None:
-    # The whole point of putting CHECK/ENDPOINT above INFO: they must not be
-    # filtered out at the default level.
+    """CHECK/ENDPOINT are placed just above INFO precisely so they are NOT
+    filtered out at the default level — losing them would hide loop markers."""
     stream = io.StringIO()
     log = Logger(log_file=None, level="INFO", stream=stream)
     log.check("Start")
@@ -67,6 +80,7 @@ def test_check_endpoint_survive_info_threshold() -> None:
 
 
 def test_writes_to_file(tmp_path: Path) -> None:
+    """Logs are written to the file (creating the parent dir on demand)."""
     log_file = tmp_path / "sub" / "monitor.log"  # parent created on demand
     log = Logger(log_file=str(log_file), level="INFO", stream=io.StringIO())
     log.info("persisted")
@@ -75,7 +89,8 @@ def test_writes_to_file(tmp_path: Path) -> None:
 
 
 def test_unwritable_file_degrades_gracefully() -> None:
-    # A path under a non-existent, uncreatable location must not raise.
+    """An unwritable log path must not crash the monitor — it degrades to
+    stderr-only (the watchdog must never become the outage)."""
     stream = io.StringIO()
     log = Logger(log_file="/proc/cannot/create/here.log", level="INFO", stream=stream)
     log.info("still works")

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -97,6 +97,33 @@ def test_unwritable_file_degrades_gracefully() -> None:
     assert "[INFO] still works" in stream.getvalue()
 
 
+def test_log_file_rotates_at_max_bytes(tmp_path: Path) -> None:
+    """The file handler rotates so the watchdog can't fill its own disk: with a
+    tiny max_bytes, writing past it creates a .1 backup and the active file stays
+    bounded."""
+    log_file = tmp_path / "monitor.log"
+    log = Logger(log_file=str(log_file), level="INFO", stream=io.StringIO(),
+                 max_bytes=1024, backup_count=2)
+    for i in range(200):
+        log.info(f"line {i} " + "x" * 60)  # ~80 bytes each -> well past 1KB
+    assert (tmp_path / "monitor.log.1").exists()  # rotated
+    assert log_file.stat().st_size <= 4096  # active file is bounded, not unbounded
+    # backup_count respected: never more than .1 and .2
+    assert not (tmp_path / "monitor.log.3").exists()
+
+
+def test_log_rotation_disabled_with_zero_max_bytes(tmp_path: Path) -> None:
+    """max_bytes=0 disables rotation (plain FileHandler) — opt-out for users who
+    manage rotation externally (logrotate, etc.)."""
+    log_file = tmp_path / "monitor.log"
+    log = Logger(log_file=str(log_file), level="INFO", stream=io.StringIO(),
+                 max_bytes=0, backup_count=5)
+    for i in range(50):
+        log.info(f"line {i}")
+    assert log_file.exists()
+    assert not (tmp_path / "monitor.log.1").exists()  # no rotation
+
+
 def test_install_bash_format_on_root_formats_third_party() -> None:
     """Library logs (via the root logger) render in the bash format, not Python's
     default 'WARNING:name:msg' — so the container's output stays uniform."""

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -1,0 +1,82 @@
+"""Logger format parity + LOG_LEVEL gating + file output."""
+
+from __future__ import annotations
+
+import io
+import re
+from pathlib import Path
+
+from gluetun_monitor.logging_setup import Logger
+
+_LINE_RE = re.compile(r"^\[\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\] \[([A-Z]+)\] (.*)$")
+
+
+def _lines(stream: io.StringIO) -> list[tuple[str, str]]:
+    out = []
+    for raw in stream.getvalue().splitlines():
+        m = _LINE_RE.match(raw)
+        assert m, f"line does not match v1.x format: {raw!r}"
+        out.append((m.group(1), m.group(2)))
+    return out
+
+
+def test_format_matches_v1() -> None:
+    stream = io.StringIO()
+    log = Logger(log_file=None, level="DEBUG", stream=stream)
+    log.info("hello")
+    assert _lines(stream) == [("INFO", "hello")]
+
+
+def test_warning_renders_as_warn() -> None:
+    stream = io.StringIO()
+    Logger(log_file=None, level="DEBUG", stream=stream).warn("careful")
+    assert _lines(stream) == [("WARN", "careful")]
+
+
+def test_check_and_endpoint_tokens() -> None:
+    stream = io.StringIO()
+    log = Logger(log_file=None, level="INFO", stream=stream)
+    log.check("Start")
+    log.endpoint("Status: NEW")
+    levels = [lvl for lvl, _ in _lines(stream)]
+    assert levels == ["CHECK", "ENDPOINT"]
+
+
+def test_debug_suppressed_at_info_level() -> None:
+    stream = io.StringIO()
+    log = Logger(log_file=None, level="INFO", stream=stream)
+    log.debug("noisy")
+    log.info("kept")
+    assert _lines(stream) == [("INFO", "kept")]
+
+
+def test_debug_shown_at_debug_level() -> None:
+    stream = io.StringIO()
+    log = Logger(log_file=None, level="DEBUG", stream=stream)
+    log.debug("seen")
+    assert _lines(stream) == [("DEBUG", "seen")]
+
+
+def test_check_endpoint_survive_info_threshold() -> None:
+    # The whole point of putting CHECK/ENDPOINT above INFO: they must not be
+    # filtered out at the default level.
+    stream = io.StringIO()
+    log = Logger(log_file=None, level="INFO", stream=stream)
+    log.check("Start")
+    assert len(_lines(stream)) == 1
+
+
+def test_writes_to_file(tmp_path: Path) -> None:
+    log_file = tmp_path / "sub" / "monitor.log"  # parent created on demand
+    log = Logger(log_file=str(log_file), level="INFO", stream=io.StringIO())
+    log.info("persisted")
+    assert log_file.exists()
+    assert "[INFO] persisted" in log_file.read_text()
+
+
+def test_unwritable_file_degrades_gracefully() -> None:
+    # A path under a non-existent, uncreatable location must not raise.
+    stream = io.StringIO()
+    log = Logger(log_file="/proc/cannot/create/here.log", level="INFO", stream=stream)
+    log.info("still works")
+    assert "[INFO] still works" in stream.getvalue()

--- a/tests/test_misc_coverage.py
+++ b/tests/test_misc_coverage.py
@@ -1,0 +1,86 @@
+"""Small, direct tests for helper branches not exercised by higher-level tests:
+the _env_int upper-bound path, Logger.log, the empty-percentile guard, the
+unsafe-site startup warning, and the DRY_RUN banner.
+"""
+
+from __future__ import annotations
+
+import io
+from pathlib import Path
+
+from gluetun_monitor.cli import _announce_banner, check_prerequisites
+from gluetun_monitor.config import Config, _env_int
+from gluetun_monitor.logging_setup import Logger
+from gluetun_monitor.site_stats import _percentile
+
+from .fakes import FakeDockerClient
+
+GLUETUN_ID = "a" * 64
+
+
+def _logger() -> tuple[Logger, io.StringIO]:
+    stream = io.StringIO()
+    return Logger(log_file=None, level="DEBUG", stream=stream), stream
+
+
+# ----- _env_int upper bound (config.py:42-43) -----
+
+def test_env_int_rejects_above_maximum(monkeypatch) -> None:
+    monkeypatch.setenv("X", "11")
+    errors: list[str] = []
+    assert _env_int("X", 5, errors, minimum=0, maximum=10) == 5  # falls back to default
+    assert errors and "must be <= 10" in errors[0]
+
+
+def test_env_int_accepts_at_maximum(monkeypatch) -> None:
+    monkeypatch.setenv("X", "10")
+    errors: list[str] = []
+    assert _env_int("X", 5, errors, maximum=10) == 10
+    assert errors == []
+
+
+# ----- Logger.log generic dispatch (logging_setup.py:113) -----
+
+def test_logger_log_dispatches_named_level() -> None:
+    logger, stream = _logger()
+    logger.log("CHECK", "hello-check")
+    assert "hello-check" in stream.getvalue()
+
+
+# ----- empty percentile guard (site_stats.py:53) -----
+
+def test_percentile_of_empty_is_zero() -> None:
+    assert _percentile([], 50) == 0
+    assert _percentile([7], 99) == 7
+
+
+# ----- unsafe-site startup warning + still starts (cli.py:37) -----
+
+def test_prereqs_warn_on_unsafe_site_but_start(tmp_path: Path) -> None:
+    conf = tmp_path / "sites.conf"
+    conf.write_text("https://ok.example\n--evil-flag\n", encoding="utf-8")
+    fake = FakeDockerClient()
+    fake.add_container("gluetun", id=GLUETUN_ID)
+    logger, stream = _logger()
+    cfg = Config(config_file=str(conf), gluetun_container="gluetun")
+    assert check_prerequisites(fake, cfg, logger) is True  # one good site remains
+    assert "Ignoring unsafe site entry '--evil-flag'" in stream.getvalue()
+
+
+def test_prereqs_fail_when_only_site_is_unsafe(tmp_path: Path) -> None:
+    conf = tmp_path / "sites.conf"
+    conf.write_text("--evil-flag\n", encoding="utf-8")
+    fake = FakeDockerClient()
+    fake.add_container("gluetun", id=GLUETUN_ID)
+    logger, stream = _logger()
+    cfg = Config(config_file=str(conf), gluetun_container="gluetun")
+    assert check_prerequisites(fake, cfg, logger) is False  # nothing safe left to test
+    assert "No testable sites" in stream.getvalue()
+
+
+# ----- DRY_RUN banner (cli.py:119) -----
+
+def test_announce_banner_warns_on_dry_run() -> None:
+    logger, stream = _logger()
+    _announce_banner(Config(config_file="/dev/null", dry_run=True), logger)
+    assert "DRY_RUN enabled" in stream.getvalue()

--- a/tests/test_missing_dependent.py
+++ b/tests/test_missing_dependent.py
@@ -1,0 +1,47 @@
+"""An explicitly-listed DEPENDENT_CONTAINERS name that doesn't exist warns loudly."""
+
+from __future__ import annotations
+
+import io
+import random
+
+from gluetun_monitor.config import Config
+from gluetun_monitor.logging_setup import Logger
+from gluetun_monitor.monitor import Monitor
+
+from .fakes import FakeDockerClient
+
+GLUETUN_ID = "a" * 64
+
+
+def _mon(fake: FakeDockerClient, deps: str) -> tuple[Monitor, io.StringIO]:
+    stream = io.StringIO()
+    cfg = Config(config_file="/dev/null", gluetun_container="gluetun", dependent_containers=deps)
+    logger = Logger(log_file=None, level="DEBUG", stream=stream)
+    return Monitor(fake, cfg, logger, rng=random.Random(0), sleep=lambda _s: None), stream
+
+
+def test_missing_explicit_dependent_warns_and_is_dropped() -> None:
+    fake = FakeDockerClient()
+    fake.add_container("gluetun", id=GLUETUN_ID)
+    mon, stream = _mon(fake, "ghost")
+    assert mon._resolve_dependents() == []  # pruned (doesn't exist)
+    assert "Configured dependent 'ghost' not found" in stream.getvalue()
+
+
+def test_missing_explicit_dependent_warns_only_once() -> None:
+    fake = FakeDockerClient()
+    fake.add_container("gluetun", id=GLUETUN_ID)
+    mon, stream = _mon(fake, "ghost")
+    mon._resolve_dependents()
+    mon._resolve_dependents()
+    assert stream.getvalue().count("Configured dependent 'ghost' not found") == 1
+
+
+def test_present_explicit_dependent_does_not_warn() -> None:
+    fake = FakeDockerClient()
+    fake.add_container("gluetun", id=GLUETUN_ID)
+    fake.add_container("qbittorrent", network_mode=f"container:{GLUETUN_ID}")
+    mon, stream = _mon(fake, "qbittorrent")
+    assert mon._resolve_dependents() == ["qbittorrent"]
+    assert "not found" not in stream.getvalue()

--- a/tests/test_monitor.py
+++ b/tests/test_monitor.py
@@ -1,0 +1,183 @@
+"""End-to-end state machine via Monitor.run_once against the fake daemon."""
+
+from __future__ import annotations
+
+import io
+import random
+from pathlib import Path
+
+import pytest
+
+from gluetun_monitor.config import Config
+from gluetun_monitor.docker_client import ExecResult
+from gluetun_monitor.logging_setup import Logger
+from gluetun_monitor.monitor import Monitor
+
+from .fakes import FakeDockerClient
+
+GLUETUN_ID = "a" * 64
+OLD_ID = "b" * 64
+NEW_ID = "c" * 64
+
+
+@pytest.fixture
+def sites_file(tmp_path: Path) -> str:
+    conf = tmp_path / "sites.conf"
+    conf.write_text("https://www.google.com\nhttps://cloudflare.com\nhttps://1.1.1.1\n")
+    return str(conf)
+
+
+def _monitor(fake: FakeDockerClient, sites_file: str, **cfg_overrides) -> Monitor:
+    cfg = Config(config_file=sites_file, gluetun_container="gluetun", **cfg_overrides)
+    logger = Logger(log_file=None, level="DEBUG", stream=io.StringIO())
+    return Monitor(fake, cfg, logger, rng=random.Random(0), sleep=lambda _s: None)
+
+
+def test_gluetun_not_running_does_nothing(sites_file: str) -> None:
+    fake = FakeDockerClient()
+    fake.add_container("gluetun", id=GLUETUN_ID, running=False)
+    _monitor(fake, sites_file).run_once()
+    assert fake.restarted == []
+
+
+def test_healthy_no_dependents_is_quiet(sites_file: str) -> None:
+    fake = FakeDockerClient()
+    fake.add_container("gluetun", id=GLUETUN_ID)
+    fake.on_exec = lambda name, cmd: ExecResult(0, "")  # all wget pass
+    _monitor(fake, sites_file).run_once()
+    assert fake.restarted == []
+    assert fake.created == []
+
+
+def test_healthy_dependent_passes_viability(sites_file: str) -> None:
+    fake = FakeDockerClient()
+    fake.add_container("gluetun", id=GLUETUN_ID)
+    fake.add_container("dep", network_mode=f"container:{GLUETUN_ID}")
+
+    def handler(name: str, cmd: list[str]) -> ExecResult:
+        if cmd[:2] == ["ls", "/sys/class/net"]:
+            return ExecResult(0, "eth0\nlo\n")  # LIVE
+        return ExecResult(0, "")  # wget passes
+
+    fake.on_exec = handler
+    _monitor(fake, sites_file).run_once()
+    assert fake.restarted == []
+
+
+def test_stranded_dependent_is_restarted(sites_file: str) -> None:
+    fake = FakeDockerClient()
+    fake.add_container("gluetun", id=GLUETUN_ID)
+    fake.add_container("dep", network_mode=f"container:{GLUETUN_ID}")
+
+    def handler(name: str, cmd: list[str]) -> ExecResult:
+        if cmd[:2] == ["ls", "/sys/class/net"]:
+            # Stranded until restarted, then live (so the verify passes).
+            if "dep" in fake.restarted:
+                return ExecResult(0, "eth0\nlo\n")
+            return ExecResult(0, "lo\n")
+        return ExecResult(0, "")
+
+    fake.on_exec = handler
+    _monitor(fake, sites_file).run_once()
+    assert fake.restarted == ["dep"]  # same-id strand -> restart
+    assert fake.created == []
+
+
+def test_stranded_dependent_with_moved_gluetun_id_is_recreated(sites_file: str) -> None:
+    fake = FakeDockerClient()
+    fake.add_container("gluetun", id=GLUETUN_ID)
+    # Dependent still points at the OLD gluetun id -> recreate, not restart.
+    # It predates the monitor and its NetworkMode no longer matches the current
+    # gluetun id, so it's named explicitly (the documented path for this case).
+    fake.add_container("dep", network_mode=f"container:{OLD_ID}")
+
+    def handler(name: str, cmd: list[str]) -> ExecResult:
+        if cmd[:2] == ["ls", "/sys/class/net"]:
+            if fake.created:  # after recreate
+                return ExecResult(0, "eth0\nlo\n")
+            return ExecResult(0, "lo\n")
+        return ExecResult(0, "")
+
+    fake.on_exec = handler
+    _monitor(fake, sites_file, dependent_containers="dep").run_once()
+    assert len(fake.created) == 1
+    assert fake.removed == [("dep", False)]
+    assert fake.restarted == []
+
+
+def test_remembered_dependent_recreated_after_live_gluetun_recreate(sites_file: str) -> None:
+    """A dependent discovered while healthy is still tracked (and recreated) after
+    gluetun is recreated under it — the remembered-set path, no explicit list."""
+    fake = FakeDockerClient()
+    fake.add_container("gluetun", id=GLUETUN_ID)
+    fake.add_container("dep", network_mode=f"container:{GLUETUN_ID}")
+
+    state = {"gluetun_recreated": False}
+
+    def handler(name: str, cmd: list[str]) -> ExecResult:
+        if cmd[:2] == ["ls", "/sys/class/net"]:
+            if state["gluetun_recreated"] and not fake.created:
+                return ExecResult(0, "lo\n")  # stranded until recreated
+            return ExecResult(0, "eth0\nlo\n")
+        return ExecResult(0, "")
+
+    fake.on_exec = handler
+    mon = _monitor(fake, sites_file)
+
+    mon.run_once()  # loop 1: dep healthy, remembered
+    assert fake.created == []
+    assert "dep" in mon._known_dependents
+
+    # Gluetun is recreated out of band: new id, dep left pointing at the old one.
+    fake.remove("gluetun", volumes=False)
+    fake.add_container("gluetun", id=NEW_ID)
+    state["gluetun_recreated"] = True
+
+    mon.run_once()  # loop 2: dep no longer matches current id, but is remembered
+    assert len(fake.created) == 1  # recreated onto the new gluetun id
+    assert fake.removed[-1] == ("dep", False)
+
+
+def test_viability_failure_accumulates_to_threshold(sites_file: str) -> None:
+    fake = FakeDockerClient()
+    fake.add_container("gluetun", id=GLUETUN_ID)
+    fake.add_container("dep", network_mode=f"container:{GLUETUN_ID}")
+
+    def handler(name: str, cmd: list[str]) -> ExecResult:
+        if cmd[:2] == ["ls", "/sys/class/net"]:
+            return ExecResult(0, "eth0\nlo\n")  # always LIVE
+        if name == "gluetun":
+            return ExecResult(0, "")  # gluetun root test passes
+        return ExecResult(4, "")  # dependent's viability wget fails (DNS/connect)
+
+    fake.on_exec = handler
+    mon = _monitor(fake, sites_file, dependent_container_failures=2)
+
+    mon.run_once()  # fail 1/2 — no remediation yet
+    assert fake.restarted == []
+    assert mon.dependent_failures.get("dep") == 1
+
+    mon.run_once()  # fail 2/2 — remediate
+    assert fake.restarted == ["dep"]
+
+
+def test_gluetun_failure_triggers_restart_then_reverify(sites_file: str) -> None:
+    fake = FakeDockerClient()
+    fake.add_container("gluetun", id=GLUETUN_ID)
+
+    def handler(name: str, cmd: list[str]) -> ExecResult:
+        if cmd[:2] == ["ls", "/sys/class/net"]:
+            return ExecResult(0, "eth0\nlo\n")
+        # gluetun site wget fails until gluetun is restarted, then passes.
+        if name == "gluetun" and "gluetun" not in fake.restarted:
+            return ExecResult(4, "")
+        return ExecResult(0, "")
+
+    fake.on_exec = handler
+    mon = _monitor(fake, sites_file, fail_threshold=2)
+
+    mon.run_once()  # sites fail 1/2 — below threshold, no restart
+    assert fake.restarted == []
+
+    mon.run_once()  # sites fail 2/2 — breach -> restart gluetun, then re-verify passes
+    assert fake.restarted == ["gluetun"]

--- a/tests/test_monitor.py
+++ b/tests/test_monitor.py
@@ -1,4 +1,11 @@
-"""End-to-end state machine via Monitor.run_once against the fake daemon."""
+"""End-to-end state machine via Monitor.run_once against the fake daemon.
+
+Why: these are the integration tests for the ADR-0006 per-loop state machine —
+they exercise the real decision flow (gluetun root test → restart/re-verify →
+per-dependent strand/viability → restart-vs-recreate) end to end, which the unit
+tests only cover piecewise. They're the closest thing to "does the #20 fix
+actually work" without a live daemon.
+"""
 
 from __future__ import annotations
 
@@ -34,6 +41,8 @@ def _monitor(fake: FakeDockerClient, sites_file: str, **cfg_overrides) -> Monito
 
 
 def test_gluetun_not_running_does_nothing(sites_file: str) -> None:
+    """A stopped gluetun → log + take no action this loop (don't restart a
+    gluetun that's deliberately down; the next loop re-checks)."""
     fake = FakeDockerClient()
     fake.add_container("gluetun", id=GLUETUN_ID, running=False)
     _monitor(fake, sites_file).run_once()
@@ -41,6 +50,8 @@ def test_gluetun_not_running_does_nothing(sites_file: str) -> None:
 
 
 def test_healthy_no_dependents_is_quiet(sites_file: str) -> None:
+    """Healthy gluetun, no dependents → no restarts/recreates: the steady state
+    must be completely passive (no churn on a healthy stack)."""
     fake = FakeDockerClient()
     fake.add_container("gluetun", id=GLUETUN_ID)
     fake.on_exec = lambda name, cmd: ExecResult(0, "")  # all wget pass
@@ -50,6 +61,8 @@ def test_healthy_no_dependents_is_quiet(sites_file: str) -> None:
 
 
 def test_healthy_dependent_passes_viability(sites_file: str) -> None:
+    """A live dependent whose viability probe passes is left alone — a working
+    dependent is never touched."""
     fake = FakeDockerClient()
     fake.add_container("gluetun", id=GLUETUN_ID)
     fake.add_container("dep", network_mode=f"container:{GLUETUN_ID}")
@@ -65,6 +78,8 @@ def test_healthy_dependent_passes_viability(sites_file: str) -> None:
 
 
 def test_stranded_dependent_is_restarted(sites_file: str) -> None:
+    """The headline #20 case: a loopback-stranded dependent on gluetun's *current*
+    id is healed by a restart (not a recreate), and the verify then passes."""
     fake = FakeDockerClient()
     fake.add_container("gluetun", id=GLUETUN_ID)
     fake.add_container("dep", network_mode=f"container:{GLUETUN_ID}")
@@ -84,6 +99,8 @@ def test_stranded_dependent_is_restarted(sites_file: str) -> None:
 
 
 def test_stranded_dependent_with_moved_gluetun_id_is_recreated(sites_file: str) -> None:
+    """The Watchtower case: gluetun was recreated (new id), so the strand is
+    healed by a volume-preserving recreate (rm without -v), not a restart."""
     fake = FakeDockerClient()
     fake.add_container("gluetun", id=GLUETUN_ID)
     # Dependent still points at the OLD gluetun id -> recreate, not restart.
@@ -139,6 +156,9 @@ def test_remembered_dependent_recreated_after_live_gluetun_recreate(sites_file: 
 
 
 def test_viability_failure_accumulates_to_threshold(sites_file: str) -> None:
+    """A live dependent failing its viability probe isn't remediated on the first
+    failure — it must reach DEPENDENT_CONTAINER_FAILURES consecutive loops first
+    (Tenet 8, under-react to noise)."""
     fake = FakeDockerClient()
     fake.add_container("gluetun", id=GLUETUN_ID)
     fake.add_container("dep", network_mode=f"container:{GLUETUN_ID}")
@@ -162,6 +182,9 @@ def test_viability_failure_accumulates_to_threshold(sites_file: str) -> None:
 
 
 def test_gluetun_failure_triggers_restart_then_reverify(sites_file: str) -> None:
+    """gluetun's own site failures must breach FAIL_THRESHOLD before it's
+    restarted; the ordered-recovery path then restarts gluetun and re-verifies
+    (ADR-0003) — no single-blip restarts."""
     fake = FakeDockerClient()
     fake.add_container("gluetun", id=GLUETUN_ID)
 

--- a/tests/test_monitor.py
+++ b/tests/test_monitor.py
@@ -168,7 +168,7 @@ def test_viability_failure_accumulates_to_threshold(sites_file: str) -> None:
             return ExecResult(0, "eth0\nlo\n")  # always LIVE
         if name == "gluetun":
             return ExecResult(0, "")  # gluetun root test passes
-        return ExecResult(4, "")  # dependent's viability wget fails (DNS/connect)
+        return ExecResult(1, "wget: bad address 'site'")  # dependent DNS failure
 
     fake.on_exec = handler
     mon = _monitor(fake, sites_file, dependent_container_failures=2)

--- a/tests/test_monitor_branches.py
+++ b/tests/test_monitor_branches.py
@@ -1,0 +1,148 @@
+"""Coverage for monitor decision/observability branches not hit elsewhere.
+
+Interface flap-recovery, the "no test URLs" and all-DNS-unvalidated probe
+outcomes, the UNKNOWN-and-not-running remediation trigger, stale-stat pruning,
+the announce() discovery lines, and the dangling-orphan name-form skip.
+"""
+
+from __future__ import annotations
+
+import io
+import random
+
+from gluetun_monitor.config import Config
+from gluetun_monitor.docker_client import ExecResult
+from gluetun_monitor.logging_setup import Logger
+from gluetun_monitor.monitor import Monitor
+from gluetun_monitor.site_stats import SiteStatsStore
+from gluetun_monitor.state import InterfaceStatus
+
+from .fakes import FakeDockerClient
+
+GLUETUN_ID = "a" * 64
+OLD_ID = "b" * 64
+
+
+def _mon(fake: FakeDockerClient, *, stats: SiteStatsStore | None = None, **cfg: object) -> Monitor:
+    cfg.setdefault("config_file", "/dev/null")
+    cfg.setdefault("gluetun_container", "gluetun")
+    logger = Logger(log_file=None, level="DEBUG", stream=io.StringIO())
+    return Monitor(fake, Config(**cfg), logger, rng=random.Random(0),
+                   sleep=lambda _s: None, stats=stats or SiteStatsStore(None))
+
+
+def _stream(mon: Monitor) -> io.StringIO:
+    stream = mon.log._logger.handlers[0].stream  # type: ignore[attr-defined]
+    assert isinstance(stream, io.StringIO)
+    return stream
+
+
+# ----- _probe_dependent: flap-recovery (monitor.py:188-189) -----
+
+def test_stranded_then_recovered_on_recheck() -> None:
+    fake = FakeDockerClient()
+    fake.add_container("dep", network_mode=f"container:{GLUETUN_ID}")
+    calls = {"n": 0}
+
+    def handler(name: str, cmd: list[str]) -> ExecResult:
+        if cmd[:2] == ["ls", "/sys/class/net"]:
+            calls["n"] += 1
+            return ExecResult(0, "lo\n") if calls["n"] == 1 else ExecResult(0, "eth0\nlo\n")
+        return ExecResult(0, "  HTTP/1.1 200 OK\n")
+
+    fake.on_exec = handler
+    probe = _mon(fake)._probe_dependent("dep", GLUETUN_ID, ["https://x.example"], [])
+    assert probe.status is InterfaceStatus.LIVE
+    assert probe.reason == "recovered on re-check"
+
+
+# ----- _probe_dependent: no test URLs (monitor.py:231) -----
+
+def test_live_dependent_with_no_test_urls() -> None:
+    fake = FakeDockerClient()
+    fake.add_container("dep", network_mode=f"container:{GLUETUN_ID}")
+    fake.on_exec = lambda n, c: ExecResult(0, "eth0\nlo\n")  # LIVE; pools empty below
+    probe = _mon(fake)._probe_dependent("dep", GLUETUN_ID, [], [])
+    assert probe.viability_ok is None
+    assert probe.reason == "no test URLs"
+
+
+# ----- all sampled sites UNVALIDATED + the loud warn (monitor.py:270-271, 342-346) -----
+
+def test_dns_unvalidated_warns_once_and_relies_on_interface() -> None:
+    fake = FakeDockerClient()
+    fake.add_container("gluetun", id=GLUETUN_ID)
+    fake.add_container("dep", network_mode=f"container:{GLUETUN_ID}")
+
+    def handler(name: str, cmd: list[str]) -> ExecResult:
+        if cmd[:2] == ["ls", "/sys/class/net"]:
+            return ExecResult(0, "eth0\nlo\n")  # LIVE
+        return ExecResult(127, "not found")  # wget/getent/ping all absent -> UNVALIDATED
+
+    fake.on_exec = handler
+    mon = _mon(fake, dependent_containers="dep")
+    mon.run_dependent_phase(GLUETUN_ID, ["https://x.example"])
+    mon.run_dependent_phase(GLUETUN_ID, ["https://x.example"])  # second loop: no re-warn
+    log = _stream(mon).getvalue()
+    assert log.count("cannot validate DNS") == 1
+    assert fake.restarted == [] and fake.created == []  # never churned (Tenet 1)
+
+
+# ----- UNKNOWN + not running -> remediate (monitor.py:334-337) -----
+
+def test_unknown_and_not_running_is_remediated() -> None:
+    fake = FakeDockerClient()
+    fake.add_container("gluetun", id=GLUETUN_ID)
+    # No shell (UNKNOWN) + not running + same id (so inspect fallback won't RECREATE).
+    fake.add_container("dep", network_mode=f"container:{GLUETUN_ID}", running=False)
+    fake.on_exec = lambda n, c: ExecResult(1, "")  # distroless
+    mon = _mon(fake, dependent_containers="dep")
+    mon.run_dependent_phase(GLUETUN_ID, ["https://x.example"])
+    assert fake.restarted == ["dep"]  # restarted (same-id strand)
+
+
+# ----- prune-stale logging (monitor.py:490-493) -----
+
+def test_save_stats_logs_pruned_sites() -> None:
+    clock = {"t": 1_000_000.0}
+    store = SiteStatsStore(None, clock=lambda: clock["t"])
+    store.record_poll("https://old.example", ok=True, duration_ms=5, reason="")
+    clock["t"] += 100 * 86400  # 100 days later -> beyond 90d retention
+    fake = FakeDockerClient()
+    mon = _mon(fake, stats=store, stats_retention_days=90)
+    mon._save_stats()
+    assert "Pruned 1 stale site" in _stream(mon).getvalue()
+    assert "https://old.example" not in store.sites
+
+
+# ----- announce() discovery lines (monitor.py:505, 509) -----
+
+def test_announce_auto_discovery_lists_dependents() -> None:
+    fake = FakeDockerClient()
+    fake.add_container("gluetun", id=GLUETUN_ID)
+    fake.add_container("dep", network_mode=f"container:{GLUETUN_ID}")
+    mon = _mon(fake, dependent_containers="auto")
+    mon.announce()
+    assert "auto-discovery): dep" in _stream(mon).getvalue()
+
+
+def test_announce_manual_lists_dependents() -> None:
+    fake = FakeDockerClient()
+    fake.add_container("gluetun", id=GLUETUN_ID)
+    fake.add_container("dep", network_mode=f"container:{GLUETUN_ID}")
+    mon = _mon(fake, dependent_containers="dep")
+    mon.announce()
+    assert "(manual): dep" in _stream(mon).getvalue()
+
+
+# ----- dangling-orphan name-form skip (monitor.py:542-546) -----
+
+def test_orphan_warn_skips_nameform_target() -> None:
+    fake = FakeDockerClient()
+    fake.add_container("gluetun", id=GLUETUN_ID)
+    # Running container whose netns target is a *name* (resolves normally) — not a
+    # dangling id, so no orphan warning.
+    fake.add_container("buddy", network_mode="container:gluetun")
+    mon = _mon(fake, dependent_containers="auto")
+    mon._warn_dangling_orphans()
+    assert "no longer exists" not in _stream(mon).getvalue()

--- a/tests/test_monitor_branches.py
+++ b/tests/test_monitor_branches.py
@@ -84,7 +84,8 @@ def test_dns_unvalidated_warns_once_and_relies_on_interface() -> None:
     mon.run_dependent_phase(GLUETUN_ID, ["https://x.example"])
     mon.run_dependent_phase(GLUETUN_ID, ["https://x.example"])  # second loop: no re-warn
     log = _stream(mon).getvalue()
-    assert log.count("cannot validate DNS") == 1
+    assert log.count("using link check only") == 1  # warned once, not per-loop
+    assert "reach ?:" in log
     assert fake.restarted == [] and fake.created == []  # never churned (Tenet 1)
 
 

--- a/tests/test_monitor_edges.py
+++ b/tests/test_monitor_edges.py
@@ -55,25 +55,17 @@ def test_probe_unknown_running_is_not_remediated() -> None:
     assert probe.viability_ok is None  # not tested
 
 
-def test_probe_ip_only_fallback_uses_ip_pool() -> None:
-    """With no resolvable names, the viability probe falls back to an IP literal
-    (connectivity-only) instead of skipping — ADR-0006 degradation."""
+def test_probe_ip_only_pool_is_not_dns_validated() -> None:
+    """With only IP-literal sites there's nothing to resolve, so viability is
+    'not tested' (None) rather than a bogus DNS pass — the phase already WARNs
+    that dependent DNS can't be validated in an IP-only config (ADR-0006)."""
     fake = FakeDockerClient()
     fake.add_container("dep", network_mode=f"container:{GLUETUN_ID}")
-
-    seen: list[str] = []
-
-    def handler(name: str, cmd: list[str]) -> ExecResult:
-        if cmd[:2] == ["ls", "/sys/class/net"]:
-            return ExecResult(0, "eth0\nlo\n")
-        seen.append(cmd[-1])  # the wget URL
-        return ExecResult(0, "")
-
-    fake.on_exec = handler
+    fake.on_exec = lambda name, cmd: ExecResult(0, "eth0\nlo\n")  # LIVE; nothing else probed
     mon, _ = _mon(fake, "/dev/null")
     probe = mon._probe_dependent("dep", GLUETUN_ID, [], ["https://1.1.1.1"])
-    assert probe.viability_ok is True
-    assert seen == ["https://1.1.1.1"]
+    assert probe.viability_ok is None  # IP literal -> no DNS to validate
+    assert "IP literal" in probe.reason
 
 
 # ----- run_dependent_phase IP-only WARN -----

--- a/tests/test_monitor_edges.py
+++ b/tests/test_monitor_edges.py
@@ -40,7 +40,8 @@ def test_probe_unknown_running_is_not_remediated() -> None:
     fake.add_container("distroless", network_mode=f"container:{GLUETUN_ID}")
     fake.on_exec = lambda name, cmd: ExecResult(1, "")  # no shell -> exec fails
     mon, _ = _mon(fake, "/dev/null")
-    probe = mon._probe_dependent("distroless", ["https://x"], [])
+    # Same id as current gluetun -> shares the live netns -> left alone (healthy).
+    probe = mon._probe_dependent("distroless", GLUETUN_ID, ["https://x"], [])
     assert probe.status is InterfaceStatus.UNKNOWN
     assert probe.running is True
     assert probe.viability_ok is None  # not tested
@@ -60,7 +61,7 @@ def test_probe_ip_only_fallback_uses_ip_pool() -> None:
 
     fake.on_exec = handler
     mon, _ = _mon(fake, "/dev/null")
-    probe = mon._probe_dependent("dep", [], ["https://1.1.1.1"])
+    probe = mon._probe_dependent("dep", GLUETUN_ID, [], ["https://1.1.1.1"])
     assert probe.viability_ok is True
     assert seen == ["https://1.1.1.1"]
 
@@ -125,7 +126,9 @@ def test_gluetun_reverify_still_failing_leaves_dependents_untouched(tmp_path: Pa
 
 
 @pytest.mark.parametrize("sites_body", ["", "# only comments\n"])
-def test_no_sites_is_handled(tmp_path: Path, sites_body: str) -> None:
+def test_no_sites_warns_and_takes_no_action(tmp_path: Path, sites_body: str) -> None:
+    # V1 contract: an empty sites.conf tests nothing for gluetun and never
+    # triggers a restart (no site can fail). We do NOT guess substitute targets.
     fake = FakeDockerClient()
     fake.add_container("gluetun", id=GLUETUN_ID)
     sites = _write(tmp_path, sites_body)
@@ -133,3 +136,4 @@ def test_no_sites_is_handled(tmp_path: Path, sites_body: str) -> None:
     mon.run_once()
     assert "No sites configured" in stream.getvalue()
     assert fake.restarted == []
+    assert fake.created == []

--- a/tests/test_monitor_edges.py
+++ b/tests/test_monitor_edges.py
@@ -1,0 +1,135 @@
+"""Degradation + failure-path branches of the monitor (ADR-0006 degradation)."""
+
+from __future__ import annotations
+
+import io
+import random
+from pathlib import Path
+
+import pytest
+
+from gluetun_monitor.config import Config
+from gluetun_monitor.docker_client import ExecResult
+from gluetun_monitor.logging_setup import Logger
+from gluetun_monitor.monitor import Monitor
+from gluetun_monitor.state import InterfaceStatus
+
+from .fakes import FakeDockerClient
+
+GLUETUN_ID = "a" * 64
+
+
+def _mon(fake: FakeDockerClient, sites_file: str, **cfg) -> tuple[Monitor, io.StringIO]:
+    stream = io.StringIO()
+    config = Config(config_file=sites_file, gluetun_container="gluetun", **cfg)
+    logger = Logger(log_file=None, level="DEBUG", stream=stream)
+    return Monitor(fake, config, logger, rng=random.Random(0), sleep=lambda _s: None), stream
+
+
+def _write(tmp_path: Path, body: str) -> str:
+    conf = tmp_path / "sites.conf"
+    conf.write_text(body)
+    return str(conf)
+
+
+# ----- _probe_dependent degradation -----
+
+
+def test_probe_unknown_running_is_not_remediated() -> None:
+    fake = FakeDockerClient()
+    fake.add_container("distroless", network_mode=f"container:{GLUETUN_ID}")
+    fake.on_exec = lambda name, cmd: ExecResult(1, "")  # no shell -> exec fails
+    mon, _ = _mon(fake, "/dev/null")
+    probe = mon._probe_dependent("distroless", ["https://x"], [])
+    assert probe.status is InterfaceStatus.UNKNOWN
+    assert probe.running is True
+    assert probe.viability_ok is None  # not tested
+
+
+def test_probe_ip_only_fallback_uses_ip_pool() -> None:
+    fake = FakeDockerClient()
+    fake.add_container("dep", network_mode=f"container:{GLUETUN_ID}")
+
+    seen: list[str] = []
+
+    def handler(name: str, cmd: list[str]) -> ExecResult:
+        if cmd[:2] == ["ls", "/sys/class/net"]:
+            return ExecResult(0, "eth0\nlo\n")
+        seen.append(cmd[-1])  # the wget URL
+        return ExecResult(0, "")
+
+    fake.on_exec = handler
+    mon, _ = _mon(fake, "/dev/null")
+    probe = mon._probe_dependent("dep", [], ["https://1.1.1.1"])
+    assert probe.viability_ok is True
+    assert seen == ["https://1.1.1.1"]
+
+
+# ----- run_dependent_phase IP-only WARN -----
+
+
+def test_ip_only_sites_log_dns_warning(tmp_path: Path) -> None:
+    fake = FakeDockerClient()
+    fake.add_container("gluetun", id=GLUETUN_ID)
+    fake.add_container("dep", network_mode=f"container:{GLUETUN_ID}")
+    fake.on_exec = lambda name, cmd: (
+        ExecResult(0, "eth0\nlo\n") if cmd[:2] == ["ls", "/sys/class/net"] else ExecResult(0, "")
+    )
+    sites = _write(tmp_path, "https://1.1.1.1\n")  # IP literal only
+    mon, stream = _mon(fake, sites)
+    mon.run_once()
+    assert "dependent DNS cannot be validated" in stream.getvalue()
+
+
+# ----- gluetun recovery failure paths -----
+
+
+def test_gluetun_restart_failure_skips_dependents(tmp_path: Path) -> None:
+    fake = FakeDockerClient()
+    fake.add_container("gluetun", id=GLUETUN_ID, health="unhealthy")  # never becomes healthy
+    fake.add_container("dep", network_mode=f"container:{GLUETUN_ID}")
+    fake.on_exec = lambda name, cmd: (
+        ExecResult(0, "eth0\nlo\n") if cmd[:2] == ["ls", "/sys/class/net"] else ExecResult(4, "")
+    )
+    sites = _write(tmp_path, "https://www.google.com\n")
+    mon, stream = _mon(fake, sites, fail_threshold=1, healthy_wait_timeout=10)
+    mon.run_once()
+    assert fake.restarted == ["gluetun"]  # tried to restart gluetun
+    assert "Recovery failed" in stream.getvalue()
+    assert fake.created == []  # dependents never touched
+
+
+def test_gluetun_reverify_still_failing_leaves_dependents_untouched(tmp_path: Path) -> None:
+    fake = FakeDockerClient()
+    fake.add_container("gluetun", id=GLUETUN_ID, health="healthy")
+    fake.add_container("dep", network_mode=f"container:{GLUETUN_ID}")
+
+    def handler(name: str, cmd: list[str]) -> ExecResult:
+        if cmd[:2] == ["ls", "/sys/class/net"]:
+            return ExecResult(0, "eth0\nlo\n")
+        if cmd[0] == "nslookup":
+            return ExecResult(0, "")  # DNS wait passes
+        # All site probes keep failing, even after the restart.
+        if name == "gluetun" and "https://1.1.1.1" in cmd:
+            return ExecResult(0, "")  # the dns-stability 1.1.1.1 probe
+        return ExecResult(4, "")
+
+    fake.on_exec = handler
+    sites = _write(tmp_path, "https://www.google.com\n")
+    mon, stream = _mon(fake, sites, fail_threshold=1)
+    mon.run_once()
+    assert fake.restarted == ["gluetun"]
+    assert "still failing after restart" in stream.getvalue()
+    assert fake.created == []
+    assert "dep" not in fake.restarted
+
+
+@pytest.mark.parametrize("sites_body", ["", "# only comments\n"])
+def test_no_sites_is_handled(tmp_path: Path, sites_body: str) -> None:
+    fake = FakeDockerClient()
+    fake.add_container("gluetun", id=GLUETUN_ID)
+    sites = _write(tmp_path, sites_body)
+    mon, stream = _mon(fake, sites)
+    mon.run_once()
+    assert "No sites configured" in stream.getvalue()
+    assert fake.restarted == []

--- a/tests/test_monitor_edges.py
+++ b/tests/test_monitor_edges.py
@@ -1,4 +1,10 @@
-"""Degradation + failure-path branches of the monitor (ADR-0006 degradation)."""
+"""Degradation + failure-path branches of the monitor (ADR-0006 degradation).
+
+Why: the happy paths are in test_monitor; these pin the *edges* where it's easy
+to do the wrong thing — distroless/IP-only degradation, and the recovery gates
+that must NOT touch dependents when gluetun can't be restored (Tenet 5: don't
+churn dependents into a dead tunnel).
+"""
 
 from __future__ import annotations
 
@@ -36,6 +42,8 @@ def _write(tmp_path: Path, body: str) -> str:
 
 
 def test_probe_unknown_running_is_not_remediated() -> None:
+    """A distroless dependent (exec fails → UNKNOWN) on the *current* gluetun id is
+    left alone — we don't churn a container we can't prove is broken (Tenet 1)."""
     fake = FakeDockerClient()
     fake.add_container("distroless", network_mode=f"container:{GLUETUN_ID}")
     fake.on_exec = lambda name, cmd: ExecResult(1, "")  # no shell -> exec fails
@@ -48,6 +56,8 @@ def test_probe_unknown_running_is_not_remediated() -> None:
 
 
 def test_probe_ip_only_fallback_uses_ip_pool() -> None:
+    """With no resolvable names, the viability probe falls back to an IP literal
+    (connectivity-only) instead of skipping — ADR-0006 degradation."""
     fake = FakeDockerClient()
     fake.add_container("dep", network_mode=f"container:{GLUETUN_ID}")
 
@@ -70,6 +80,8 @@ def test_probe_ip_only_fallback_uses_ip_pool() -> None:
 
 
 def test_ip_only_sites_log_dns_warning(tmp_path: Path) -> None:
+    """An IP-literal-only sites set logs a WARN that dependent DNS can't be
+    validated — a documented limitation must be surfaced, not silent."""
     fake = FakeDockerClient()
     fake.add_container("gluetun", id=GLUETUN_ID)
     fake.add_container("dep", network_mode=f"container:{GLUETUN_ID}")
@@ -86,6 +98,8 @@ def test_ip_only_sites_log_dns_warning(tmp_path: Path) -> None:
 
 
 def test_gluetun_restart_failure_skips_dependents(tmp_path: Path) -> None:
+    """If gluetun won't come back healthy after its restart, recovery reports
+    FAILED and does NOT touch dependents (Tenet 5 — no churn into a dead tunnel)."""
     fake = FakeDockerClient()
     fake.add_container("gluetun", id=GLUETUN_ID, health="unhealthy")  # never becomes healthy
     fake.add_container("dep", network_mode=f"container:{GLUETUN_ID}")
@@ -101,6 +115,9 @@ def test_gluetun_restart_failure_skips_dependents(tmp_path: Path) -> None:
 
 
 def test_gluetun_reverify_still_failing_leaves_dependents_untouched(tmp_path: Path) -> None:
+    """gluetun restarts and becomes healthy, but sites still fail on re-verify →
+    leave dependents untouched and reset counters (don't act on a tunnel that
+    came back unhealthy)."""
     fake = FakeDockerClient()
     fake.add_container("gluetun", id=GLUETUN_ID, health="healthy")
     fake.add_container("dep", network_mode=f"container:{GLUETUN_ID}")
@@ -127,8 +144,9 @@ def test_gluetun_reverify_still_failing_leaves_dependents_untouched(tmp_path: Pa
 
 @pytest.mark.parametrize("sites_body", ["", "# only comments\n"])
 def test_no_sites_warns_and_takes_no_action(tmp_path: Path, sites_body: str) -> None:
-    # V1 contract: an empty sites.conf tests nothing for gluetun and never
-    # triggers a restart (no site can fail). We do NOT guess substitute targets.
+    """V1 contract at runtime: an empty sites set tests nothing for gluetun and
+    never triggers a restart (no site can fail). We do NOT guess substitute
+    targets — startup validation is what rejects an empty config (Tenet 1)."""
     fake = FakeDockerClient()
     fake.add_container("gluetun", id=GLUETUN_ID)
     sites = _write(tmp_path, sites_body)

--- a/tests/test_orphan_warn.py
+++ b/tests/test_orphan_warn.py
@@ -1,0 +1,74 @@
+"""A2: warn (don't recreate) about a running container on a dead netns parent.
+
+Why: a dependent recreate-stranded *before* the monitor started points at
+gluetun's old, now-gone id, so current-id discovery can't see it. We surface it
+with an actionable WARN suggesting DEPENDENT_CONTAINERS — but we deliberately do
+NOT auto-recreate it, because an orphan whose parent is gone can't be confirmed
+as *this* gluetun's dependent (Tenet 1, first do no harm).
+"""
+
+from __future__ import annotations
+
+import io
+import random
+
+from gluetun_monitor.config import Config
+from gluetun_monitor.logging_setup import Logger
+from gluetun_monitor.monitor import Monitor
+
+from .fakes import FakeDockerClient
+
+GLUETUN_ID = "a" * 64
+DEAD_ID = "d" * 64
+
+
+def _mon(fake: FakeDockerClient, **cfg: object) -> tuple[Monitor, io.StringIO]:
+    cfg.setdefault("config_file", "/dev/null")
+    cfg.setdefault("gluetun_container", "gluetun")
+    stream = io.StringIO()
+    logger = Logger(log_file=None, level="DEBUG", stream=stream)
+    return Monitor(fake, Config(**cfg), logger, rng=random.Random(0), sleep=lambda _s: None), stream
+
+
+def test_warns_about_dangling_orphan_but_does_not_recreate() -> None:
+    fake = FakeDockerClient()
+    fake.add_container("gluetun", id=GLUETUN_ID)
+    # 'orphan' points at a container id that doesn't exist (dead netns parent).
+    fake.add_container("orphan", network_mode=f"container:{DEAD_ID}")
+    mon, stream = _mon(fake)
+    mon._warn_dangling_orphans()
+    out = stream.getvalue()
+    assert "orphan" in out and "no longer exists" in out
+    assert "DEPENDENT_CONTAINERS" in out
+    assert fake.created == [] and fake.removed == []  # warned, not acted on
+
+
+def test_no_warn_when_netns_parent_exists() -> None:
+    """A dependent on gluetun's *current* (live) id is healthy, not an orphan."""
+    fake = FakeDockerClient()
+    fake.add_container("gluetun", id=GLUETUN_ID)
+    fake.add_container("dep", network_mode=f"container:{GLUETUN_ID}")
+    mon, stream = _mon(fake)
+    mon._warn_dangling_orphans()
+    assert "no longer exists" not in stream.getvalue()
+
+
+def test_no_warn_for_excluded_or_listed() -> None:
+    """An orphan the operator excluded (or explicitly listed) isn't warned about —
+    we either won't touch it or already manage it."""
+    fake = FakeDockerClient()
+    fake.add_container("gluetun", id=GLUETUN_ID)
+    fake.add_container("orphan", network_mode=f"container:{DEAD_ID}")
+    mon, stream = _mon(fake, exclude_containers="orphan")
+    mon._warn_dangling_orphans()
+    assert "no longer exists" not in stream.getvalue()
+
+
+def test_orphan_warning_dedups() -> None:
+    fake = FakeDockerClient()
+    fake.add_container("gluetun", id=GLUETUN_ID)
+    fake.add_container("orphan", network_mode=f"container:{DEAD_ID}")
+    mon, stream = _mon(fake)
+    mon._warn_dangling_orphans()
+    mon._warn_dangling_orphans()
+    assert stream.getvalue().count("no longer exists") == 1

--- a/tests/test_prereq_strict.py
+++ b/tests/test_prereq_strict.py
@@ -1,0 +1,87 @@
+"""Strict startup validation: malformed/incomplete config is fatal, never guessed."""
+
+from __future__ import annotations
+
+import io
+from pathlib import Path
+
+import pytest
+
+from gluetun_monitor import cli
+from gluetun_monitor.config import Config
+from gluetun_monitor.logging_setup import Logger
+
+from .fakes import FakeDockerClient
+
+GLUETUN_ID = "a" * 64
+
+
+def _logger() -> Logger:
+    return Logger(log_file=None, level="DEBUG", stream=io.StringIO())
+
+
+def _sites(tmp_path: Path, body: str) -> str:
+    conf = tmp_path / "sites.conf"
+    conf.write_text(body)
+    return str(conf)
+
+
+def _stack(tmp_path: Path, body: str = "https://www.google.com\n", **cfg: object) -> tuple:
+    fake = FakeDockerClient()
+    fake.add_container("gluetun", id=GLUETUN_ID)
+    config = Config(config_file=_sites(tmp_path, body), gluetun_container="gluetun", **cfg)
+    return fake, config
+
+
+# ----- sites.conf must have testable entries -----
+
+
+def test_prereq_passes_with_sites(tmp_path: Path) -> None:
+    fake, config = _stack(tmp_path)
+    assert cli.check_prerequisites(fake, config, _logger()) is True
+
+
+@pytest.mark.parametrize("body", ["", "# only comments\n", "   \n\n"])
+def test_prereq_fatal_on_empty_sites(tmp_path: Path, body: str) -> None:
+    fake, config = _stack(tmp_path, body)
+    stream = io.StringIO()
+    logger = Logger(log_file=None, level="DEBUG", stream=stream)
+    assert cli.check_prerequisites(fake, config, logger) is False
+    assert "No testable sites" in stream.getvalue()
+
+
+# ----- explicit DEPENDENT_CONTAINERS must name existing containers -----
+
+
+def test_prereq_fatal_on_missing_explicit_dependent(tmp_path: Path) -> None:
+    fake, config = _stack(tmp_path, dependent_containers="qbittorrent,ghost")
+    fake.add_container("qbittorrent", network_mode=f"container:{GLUETUN_ID}")  # ghost absent
+    stream = io.StringIO()
+    assert cli.check_prerequisites(fake, config, Logger(log_file=None, stream=stream)) is False
+    assert "ghost" in stream.getvalue()
+
+
+def test_prereq_fatal_on_empty_explicit_list(tmp_path: Path) -> None:
+    fake, config = _stack(tmp_path, dependent_containers=" , ,")
+    assert cli.check_prerequisites(fake, config, _logger()) is False
+
+
+def test_prereq_passes_with_all_explicit_dependents_present(tmp_path: Path) -> None:
+    fake, config = _stack(tmp_path, dependent_containers="qbittorrent")
+    fake.add_container("qbittorrent", network_mode=f"container:{GLUETUN_ID}")
+    assert cli.check_prerequisites(fake, config, _logger()) is True
+
+
+def test_prereq_auto_with_no_dependents_is_not_fatal(tmp_path: Path) -> None:
+    fake, config = _stack(tmp_path, dependent_containers="auto")
+    assert cli.check_prerequisites(fake, config, _logger()) is True
+
+
+# ----- malformed env is fatal in main() -----
+
+
+def test_main_fatal_on_malformed_env(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    monkeypatch.setenv("CHECK_INTERVAL", "abc")  # malformed -> Config.errors -> exit 1
+    monkeypatch.setenv("LOG_FILE", str(tmp_path / "m.log"))
+    monkeypatch.setenv("CONFIG_FILE", str(tmp_path / "sites.conf"))
+    assert cli.main() == 1  # returns before touching Docker

--- a/tests/test_prereq_strict.py
+++ b/tests/test_prereq_strict.py
@@ -50,6 +50,18 @@ def test_prereq_fatal_on_empty_sites(tmp_path: Path, body: str) -> None:
     assert "No testable sites" in stream.getvalue()
 
 
+def test_prereq_fatal_clean_when_config_is_a_directory(tmp_path: Path) -> None:
+    """A CONFIG_FILE that's a directory (the classic missing-bind-mount-source
+    that Docker silently turns into a dir) must fail loud and cleanly, not crash
+    with an IsADirectoryError traceback (Tenet 7). Found by the upgrade test."""
+    fake = FakeDockerClient()
+    fake.add_container("gluetun", id=GLUETUN_ID)
+    cfg = Config(config_file=str(tmp_path), gluetun_container="gluetun")  # a dir
+    stream = io.StringIO()
+    assert cli.check_prerequisites(fake, cfg, Logger(log_file=None, stream=stream)) is False
+    assert "Cannot read sites config" in stream.getvalue()
+
+
 # ----- explicit DEPENDENT_CONTAINERS must name existing containers -----
 
 

--- a/tests/test_recovery.py
+++ b/tests/test_recovery.py
@@ -1,0 +1,153 @@
+"""Recovery: gluetun health/DNS waits and the dependent remediation matrix."""
+
+from __future__ import annotations
+
+import io
+
+from gluetun_monitor.config import Config
+from gluetun_monitor.docker_client import ExecResult
+from gluetun_monitor.logging_setup import Logger
+from gluetun_monitor.recovery import (
+    remediate_dependent,
+    restart_gluetun,
+    verify_dependent,
+    wait_for_dns,
+    wait_for_healthy,
+)
+
+from .fakes import FakeDockerClient
+
+GLUETUN_ID = "a" * 64
+OLD_ID = "b" * 64
+
+
+def _logger() -> Logger:
+    return Logger(log_file=None, level="DEBUG", stream=io.StringIO())
+
+
+def _live_exec(name: str, cmd: list[str]) -> ExecResult:
+    """Interface check -> LIVE; everything else -> success."""
+    if cmd[:2] == ["ls", "/sys/class/net"]:
+        return ExecResult(0, "eth0\nlo\ntun0\n")
+    return ExecResult(0, "")
+
+
+# ----- wait_for_healthy -----
+
+
+def test_wait_for_healthy_succeeds_after_poll() -> None:
+    fake = FakeDockerClient()
+    fake.add_container("gluetun", id=GLUETUN_ID, health="starting")
+
+    def flip_to_healthy(_seconds: float) -> None:
+        fake._resolve("gluetun")["State"]["Health"]["Status"] = "healthy"
+
+    assert wait_for_healthy(fake, "gluetun", 60, _logger(), sleep=flip_to_healthy) is True
+
+
+def test_wait_for_healthy_times_out() -> None:
+    fake = FakeDockerClient()
+    fake.add_container("gluetun", id=GLUETUN_ID, health="starting")
+    assert wait_for_healthy(fake, "gluetun", 10, _logger(), sleep=lambda _s: None) is False
+
+
+# ----- wait_for_dns -----
+
+
+def test_wait_for_dns_succeeds() -> None:
+    fake = FakeDockerClient()
+    fake.add_container("gluetun", id=GLUETUN_ID)
+    fake.on_exec = lambda name, cmd: ExecResult(0, "")
+    assert wait_for_dns(fake, "gluetun", 30, _logger(), sleep=lambda _s: None) is True
+
+
+def test_wait_for_dns_times_out_but_proceeds() -> None:
+    fake = FakeDockerClient()
+    fake.add_container("gluetun", id=GLUETUN_ID)
+    fake.on_exec = lambda name, cmd: ExecResult(1, "")
+    assert wait_for_dns(fake, "gluetun", 4, _logger(), sleep=lambda _s: None) is False
+
+
+# ----- restart_gluetun -----
+
+
+def test_restart_gluetun_success() -> None:
+    fake = FakeDockerClient()
+    fake.add_container("gluetun", id=GLUETUN_ID, health="healthy")
+    fake.on_exec = lambda name, cmd: ExecResult(0, "")
+    cfg = Config()
+    assert restart_gluetun(fake, cfg, _logger(), sleep=lambda _s: None) is True
+    assert fake.restarted == ["gluetun"]
+
+
+def test_restart_gluetun_fails_if_never_healthy() -> None:
+    fake = FakeDockerClient()
+    fake.add_container("gluetun", id=GLUETUN_ID, health="unhealthy")
+    cfg = Config(healthy_wait_timeout=10)
+    assert restart_gluetun(fake, cfg, _logger(), sleep=lambda _s: None) is False
+
+
+# ----- verify_dependent -----
+
+
+def test_verify_dependent_live() -> None:
+    fake = FakeDockerClient()
+    fake.add_container("dep", network_mode=f"container:{GLUETUN_ID}")
+    fake.on_exec = _live_exec
+    assert verify_dependent(fake, "dep") is True
+
+
+def test_verify_dependent_stranded_fails() -> None:
+    fake = FakeDockerClient()
+    fake.add_container("dep", network_mode=f"container:{GLUETUN_ID}")
+    fake.on_exec = lambda name, cmd: ExecResult(0, "lo\n")
+    assert verify_dependent(fake, "dep") is False
+
+
+# ----- remediate_dependent matrix -----
+
+
+def test_remediate_restart_path() -> None:
+    fake = FakeDockerClient()
+    fake.add_container("gluetun", id=GLUETUN_ID)
+    fake.add_container("dep", network_mode=f"container:{GLUETUN_ID}")
+    fake.on_exec = _live_exec
+    ok = remediate_dependent(fake, "dep", GLUETUN_ID, Config(), _logger(), sleep=lambda _s: None)
+    assert ok is True
+    assert fake.restarted == ["dep"]
+    assert fake.created == []  # restart, not recreate
+
+
+def test_remediate_recreate_path() -> None:
+    fake = FakeDockerClient()
+    fake.add_container("dep", network_mode=f"container:{OLD_ID}")  # gluetun id moved
+    fake.on_exec = _live_exec
+    ok = remediate_dependent(fake, "dep", GLUETUN_ID, Config(), _logger(), sleep=lambda _s: None)
+    assert ok is True
+    assert fake.removed == [("dep", False)]
+    assert len(fake.created) == 1
+    assert fake.restarted == []  # recreate, not restart
+
+
+def test_remediate_recreate_disabled_is_failed() -> None:
+    fake = FakeDockerClient()
+    fake.add_container("dep", network_mode=f"container:{OLD_ID}")
+    fake.on_exec = _live_exec
+    cfg = Config(auto_recreate=False)
+    ok = remediate_dependent(fake, "dep", GLUETUN_ID, cfg, _logger(), sleep=lambda _s: None)
+    assert ok is False
+    assert fake.removed == []  # nothing destroyed when disabled
+
+
+def test_remediate_try_restart_escalates_to_recreate() -> None:
+    fake = FakeDockerClient()
+    fake.add_container("dep", network_mode="container:gluetun")  # name form -> TRY_RESTART
+    fake.on_exec = _live_exec
+
+    def failing_restart(_name: str) -> None:
+        raise RuntimeError("cannot restart into vanished netns")
+
+    fake.restart = failing_restart  # type: ignore[method-assign]
+    ok = remediate_dependent(fake, "dep", GLUETUN_ID, Config(), _logger(), sleep=lambda _s: None)
+    assert ok is True
+    assert len(fake.created) == 1  # escalated to recreate

--- a/tests/test_recovery.py
+++ b/tests/test_recovery.py
@@ -1,4 +1,11 @@
-"""Recovery: gluetun health/DNS waits and the dependent remediation matrix."""
+"""Recovery: gluetun health/DNS waits and the dependent remediation matrix.
+
+Why: recovery is where the monitor *acts* on the system, so the branch selection
+must be exactly right (ADR-0003/0004): restart when the dependent can rejoin,
+recreate when gluetun's id moved, escalate when a name-form target's restart
+fails, and refuse (FAILED) when recreate is disabled. The 2x2 of
+restart-vs-recreate is the heart of the #20 fix; getting it wrong either fails to
+heal or churns containers needlessly (Tenets 1, 5)."""
 
 from __future__ import annotations
 
@@ -36,6 +43,8 @@ def _live_exec(name: str, cmd: list[str]) -> ExecResult:
 
 
 def test_wait_for_healthy_succeeds_after_poll() -> None:
+    """Polls until gluetun reports healthy (here it flips during the first sleep)
+    — gates the post-restart re-verify so we don't test a still-starting tunnel."""
     fake = FakeDockerClient()
     fake.add_container("gluetun", id=GLUETUN_ID, health="starting")
 
@@ -46,6 +55,8 @@ def test_wait_for_healthy_succeeds_after_poll() -> None:
 
 
 def test_wait_for_healthy_times_out() -> None:
+    """If gluetun never becomes healthy, the wait returns False (→ recovery
+    reports FAILED rather than churning dependents into a dead tunnel)."""
     fake = FakeDockerClient()
     fake.add_container("gluetun", id=GLUETUN_ID, health="starting")
     assert wait_for_healthy(fake, "gluetun", 10, _logger(), sleep=lambda _s: None) is False
@@ -55,6 +66,7 @@ def test_wait_for_healthy_times_out() -> None:
 
 
 def test_wait_for_dns_succeeds() -> None:
+    """DNS+connectivity probe passing returns True (DNS settled after restart)."""
     fake = FakeDockerClient()
     fake.add_container("gluetun", id=GLUETUN_ID)
     fake.on_exec = lambda name, cmd: ExecResult(0, "")
@@ -62,6 +74,8 @@ def test_wait_for_dns_succeeds() -> None:
 
 
 def test_wait_for_dns_times_out_but_proceeds() -> None:
+    """DNS not settling is non-fatal: we warn and proceed (False) rather than
+    block recovery forever — DNS often lags healthy by a beat."""
     fake = FakeDockerClient()
     fake.add_container("gluetun", id=GLUETUN_ID)
     fake.on_exec = lambda name, cmd: ExecResult(1, "")
@@ -72,6 +86,7 @@ def test_wait_for_dns_times_out_but_proceeds() -> None:
 
 
 def test_restart_gluetun_success() -> None:
+    """Happy path: restart issued and gluetun comes back healthy → True."""
     fake = FakeDockerClient()
     fake.add_container("gluetun", id=GLUETUN_ID, health="healthy")
     fake.on_exec = lambda name, cmd: ExecResult(0, "")
@@ -81,6 +96,8 @@ def test_restart_gluetun_success() -> None:
 
 
 def test_restart_gluetun_fails_if_never_healthy() -> None:
+    """Restart that doesn't recover → False, so the loop doesn't proceed to
+    dependents on a still-broken tunnel (Tenet 5)."""
     fake = FakeDockerClient()
     fake.add_container("gluetun", id=GLUETUN_ID, health="unhealthy")
     cfg = Config(healthy_wait_timeout=10)
@@ -91,6 +108,7 @@ def test_restart_gluetun_fails_if_never_healthy() -> None:
 
 
 def test_verify_dependent_live() -> None:
+    """Post-remediation verify passes when the dependent is running + non-lo."""
     fake = FakeDockerClient()
     fake.add_container("dep", network_mode=f"container:{GLUETUN_ID}")
     fake.on_exec = _live_exec
@@ -98,6 +116,8 @@ def test_verify_dependent_live() -> None:
 
 
 def test_verify_dependent_stranded_fails() -> None:
+    """Verify fails if the dependent is still loopback-only after remediation →
+    the action didn't stick → FAILED."""
     fake = FakeDockerClient()
     fake.add_container("dep", network_mode=f"container:{GLUETUN_ID}")
     fake.on_exec = lambda name, cmd: ExecResult(0, "lo\n")
@@ -108,6 +128,7 @@ def test_verify_dependent_stranded_fails() -> None:
 
 
 def test_remediate_restart_path() -> None:
+    """Same-id strand → docker restart (cheap rejoin), not a recreate."""
     fake = FakeDockerClient()
     fake.add_container("gluetun", id=GLUETUN_ID)
     fake.add_container("dep", network_mode=f"container:{GLUETUN_ID}")
@@ -119,6 +140,8 @@ def test_remediate_restart_path() -> None:
 
 
 def test_remediate_recreate_path() -> None:
+    """Moved-id strand → recreate (rm WITHOUT -v, then create), not restart —
+    the volume-preserving #20 B2 path."""
     fake = FakeDockerClient()
     fake.add_container("dep", network_mode=f"container:{OLD_ID}")  # gluetun id moved
     fake.on_exec = _live_exec
@@ -130,6 +153,8 @@ def test_remediate_recreate_path() -> None:
 
 
 def test_remediate_recreate_disabled_is_failed() -> None:
+    """AUTO_RECREATE=0 + a moved-id strand → FAILED, and crucially nothing is
+    removed/destroyed (Tenet 1 — don't act when the operator opted out)."""
     fake = FakeDockerClient()
     fake.add_container("dep", network_mode=f"container:{OLD_ID}")
     fake.on_exec = _live_exec
@@ -140,6 +165,8 @@ def test_remediate_recreate_disabled_is_failed() -> None:
 
 
 def test_remediate_try_restart_escalates_to_recreate() -> None:
+    """Name-form target: try restart first, and if that fails (dead netns),
+    escalate to recreate — ADR-0004's safe path for the untested name form."""
     fake = FakeDockerClient()
     fake.add_container("dep", network_mode="container:gluetun")  # name form -> TRY_RESTART
     fake.on_exec = _live_exec

--- a/tests/test_recreate.py
+++ b/tests/test_recreate.py
@@ -1,0 +1,161 @@
+"""The recreate path (ADR-0005) — the highest-risk logic, tested hardest.
+
+build_create_body is pure, so the netns-field surgery and the anonymous-volume
+data-preservation guarantee are fully unit-testable against a fixed inspect dict.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from gluetun_monitor.logging_setup import Logger
+from gluetun_monitor.recreate import build_create_body, recreate_dependent
+
+from .fakes import FakeDockerClient, make_inspect
+
+NEW_GLUETUN_ID = "f" * 64
+OLD_GLUETUN_ID = "a" * 64
+
+
+def _dep_inspect(**overrides: Any) -> dict[str, Any]:
+    """A realistic dependent inspect that shared gluetun's (old) netns."""
+    raw = make_inspect(
+        "qbittorrent",
+        id="dep123",
+        network_mode=f"container:{OLD_GLUETUN_ID}",
+        config={
+            "Image": "lscr.io/linuxserver/qbittorrent:latest",
+            "Env": ["PUID=1000", "PGID=1000"],
+            "Cmd": ["/init"],
+            "Labels": {"com.example": "x"},
+            "Hostname": "dep123",
+            "Domainname": "lan",
+            "ExposedPorts": {"8080/tcp": {}},
+            "MacAddress": "02:42:ac:11:00:02",
+            "Volumes": {"/downloads": {}},
+        },
+        host_config={
+            "PortBindings": {"8080/tcp": [{"HostPort": "8080"}]},
+            "PublishAllPorts": False,
+            "Dns": ["1.1.1.1"],
+            "DnsSearch": ["lan"],
+            "DnsOptions": ["ndots:1"],
+            "ExtraHosts": ["a:1.2.3.4"],
+            "Links": ["other:other"],
+            "Binds": ["/host/config:/config"],
+            "RestartPolicy": {"Name": "unless-stopped"},
+        },
+        mounts=[
+            # named volume
+            {"Type": "volume", "Name": "qbt_config", "Destination": "/config", "RW": True},
+            # anonymous volume (image VOLUME) — the data-loss risk
+            {"Type": "volume", "Name": "anon0abc", "Destination": "/downloads", "RW": True},
+            # bind mount
+            {"Type": "bind", "Source": "/host/media", "Destination": "/media", "RW": False},
+        ],
+    )
+    raw.update(overrides)
+    return raw
+
+
+def test_network_mode_repointed() -> None:
+    body = build_create_body(_dep_inspect(), NEW_GLUETUN_ID)
+    assert body["HostConfig"]["NetworkMode"] == f"container:{NEW_GLUETUN_ID}"
+
+
+def test_netns_conflicting_config_fields_stripped() -> None:
+    body = build_create_body(_dep_inspect(), NEW_GLUETUN_ID)
+    for field in ("Hostname", "Domainname", "ExposedPorts", "MacAddress", "Volumes"):
+        assert field not in body, f"{field} should be stripped from Config"
+
+
+def test_netns_conflicting_hostconfig_fields_stripped() -> None:
+    hc = build_create_body(_dep_inspect(), NEW_GLUETUN_ID)["HostConfig"]
+    for field in ("PortBindings", "PublishAllPorts", "Dns", "DnsSearch",
+                  "DnsOptions", "ExtraHosts", "Links", "Binds"):
+        assert field not in hc, f"{field} should be stripped from HostConfig"
+
+
+def test_preserved_fields_survive() -> None:
+    body = build_create_body(_dep_inspect(), NEW_GLUETUN_ID)
+    assert body["Image"] == "lscr.io/linuxserver/qbittorrent:latest"
+    assert body["Env"] == ["PUID=1000", "PGID=1000"]
+    assert body["Cmd"] == ["/init"]
+    assert body["HostConfig"]["RestartPolicy"] == {"Name": "unless-stopped"}
+
+
+def test_anonymous_volume_carried_by_name() -> None:
+    """The crux: the anon volume must be re-bound by its existing id, so a
+    subsequent `rm` without -v preserves its data."""
+    mounts = build_create_body(_dep_inspect(), NEW_GLUETUN_ID)["HostConfig"]["Mounts"]
+    anon = [m for m in mounts if m.get("Source") == "anon0abc"]
+    assert len(anon) == 1
+    assert anon[0] == {
+        "Type": "volume", "Source": "anon0abc", "Target": "/downloads", "ReadOnly": False
+    }
+
+
+def test_named_volume_and_bind_carried() -> None:
+    mounts = build_create_body(_dep_inspect(), NEW_GLUETUN_ID)["HostConfig"]["Mounts"]
+    by_target = {m["Target"]: m for m in mounts}
+    assert by_target["/config"] == {
+        "Type": "volume", "Source": "qbt_config", "Target": "/config", "ReadOnly": False
+    }
+    assert by_target["/media"] == {
+        "Type": "bind", "Source": "/host/media", "Target": "/media", "ReadOnly": True
+    }
+
+
+def test_tmpfs_mount_carried() -> None:
+    raw = _dep_inspect(Mounts=[{"Type": "tmpfs", "Destination": "/tmp"}])
+    mounts = build_create_body(raw, NEW_GLUETUN_ID)["HostConfig"]["Mounts"]
+    assert mounts == [{"Type": "tmpfs", "Target": "/tmp"}]
+
+
+def test_networkingconfig_dropped() -> None:
+    raw = _dep_inspect()
+    raw["NetworkingConfig"] = {"EndpointsConfig": {"bridge": {}}}
+    body = build_create_body(raw, NEW_GLUETUN_ID)
+    assert "NetworkingConfig" not in body
+
+
+def test_build_does_not_mutate_input() -> None:
+    raw = _dep_inspect()
+    before = raw["HostConfig"]["NetworkMode"]
+    build_create_body(raw, NEW_GLUETUN_ID)
+    assert raw["HostConfig"]["NetworkMode"] == before  # deepcopy, not in-place
+
+
+def test_no_mounts_means_no_mounts_key() -> None:
+    raw = _dep_inspect(Mounts=[])
+    hc = build_create_body(raw, NEW_GLUETUN_ID)["HostConfig"]
+    assert "Mounts" not in hc
+
+
+# ----- recreate_dependent orchestration -----
+
+
+def _logger() -> Logger:
+    import io
+
+    return Logger(log_file=None, level="DEBUG", stream=io.StringIO())
+
+
+def test_recreate_dependent_removes_without_volumes_then_creates() -> None:
+    fake = FakeDockerClient()
+    fake.add(_dep_inspect())
+    ok = recreate_dependent(fake, "qbittorrent", NEW_GLUETUN_ID, _logger())
+    assert ok is True
+    # The data-preservation guarantee: remove must NOT delete volumes.
+    assert fake.removed == [("qbittorrent", False)]
+    assert len(fake.created) == 1
+    body, name = fake.created[0]
+    assert name == "qbittorrent"
+    assert body["HostConfig"]["NetworkMode"] == f"container:{NEW_GLUETUN_ID}"
+    assert len(fake.started) == 1
+
+
+def test_recreate_dependent_missing_container() -> None:
+    fake = FakeDockerClient()
+    assert recreate_dependent(fake, "ghost", NEW_GLUETUN_ID, _logger()) is False
+    assert fake.removed == []

--- a/tests/test_remediation_branches.py
+++ b/tests/test_remediation_branches.py
@@ -1,0 +1,106 @@
+"""Failure-path coverage for remediation decisions (recovery + recreate).
+
+These are the load-bearing "things went wrong" branches: a restart that raises, an
+escalation that also fails, a recreate whose spec can't be built, and verifying a
+container that vanished. They must fail closed (return False, log loudly) and
+never crash the loop.
+"""
+
+from __future__ import annotations
+
+import io
+from typing import Any
+
+from gluetun_monitor.config import Config
+from gluetun_monitor.docker_client import ExecResult
+from gluetun_monitor.logging_setup import Logger
+from gluetun_monitor.recovery import remediate_dependent, verify_dependent
+from gluetun_monitor.recreate import recreate_dependent
+
+from .fakes import FakeDockerClient, make_inspect
+
+GLUETUN_ID = "a" * 64
+OLD_ID = "b" * 64
+
+
+def _logger() -> Logger:
+    return Logger(log_file=None, level="DEBUG", stream=io.StringIO())
+
+
+def _cfg(**kw: object) -> Config:
+    kw.setdefault("config_file", "/dev/null")
+    kw.setdefault("gluetun_container", "gluetun")
+    return Config(**kw)
+
+
+class _RestartRaises(FakeDockerClient):
+    """A daemon where restart always errors (e.g. container wedged)."""
+
+    def restart(self, name_or_id: str) -> None:
+        raise RuntimeError("simulated restart failure")
+
+
+# ----- verify_dependent (recovery.py:133) -----
+
+def test_verify_dependent_false_when_missing() -> None:
+    fake = FakeDockerClient()
+    assert verify_dependent(fake, "ghost") is False
+
+
+def test_verify_dependent_false_when_not_running() -> None:
+    fake = FakeDockerClient()
+    fake.add_container("dep", network_mode=f"container:{GLUETUN_ID}", running=False)
+    assert verify_dependent(fake, "dep") is False
+
+
+# ----- remediate_dependent restart-fails (recovery.py:183) -----
+
+def test_remediate_restart_failure_returns_false() -> None:
+    fake = _RestartRaises()
+    fake.add_container("dep", network_mode=f"container:{GLUETUN_ID}")  # same id -> RESTART
+    fake.on_exec = lambda n, c: ExecResult(1, "")
+    assert remediate_dependent(fake, "dep", GLUETUN_ID, _cfg(), _logger(),
+                               sleep=lambda _s: None) is False
+
+
+# ----- TRY_RESTART escalates, recreate disabled -> fails (recovery.py:188-189) -----
+
+def test_remediate_nameform_restart_fail_escalates_to_disabled_recreate() -> None:
+    fake = _RestartRaises()
+    fake.add_container("dep", network_mode="container:gluetun")  # name form -> TRY_RESTART
+    assert remediate_dependent(fake, "dep", GLUETUN_ID, _cfg(auto_recreate=False),
+                               _logger(), sleep=lambda _s: None) is False
+
+
+def test_remediate_missing_container_returns_false() -> None:
+    fake = FakeDockerClient()
+    assert remediate_dependent(fake, "ghost", GLUETUN_ID, _cfg(), _logger(),
+                               sleep=lambda _s: None) is False
+
+
+# ----- recreate spec-build failure (recreate.py:135-137) -----
+
+def test_recreate_build_spec_failure_returns_false() -> None:
+    """A malformed inspect payload (Config is a list) makes build_create_body
+    raise; recreate must catch it and fail closed WITHOUT removing the container."""
+    fake = FakeDockerClient()
+    raw: dict[str, Any] = make_inspect("dep", id="c" * 64,
+                                       network_mode=f"container:{OLD_ID}")
+    raw["Config"] = ["not", "a", "dict"]  # build_create_body will choke on .pop()
+    fake.add(raw)
+    assert recreate_dependent(fake, "dep", GLUETUN_ID, _logger()) is False
+    assert fake.removed == []  # fail-closed: never removed the container
+
+
+class _CreateRaises(FakeDockerClient):
+    def create_from_config(self, config: dict[str, Any], name: str) -> str:
+        raise RuntimeError("simulated create failure")
+
+
+def test_recreate_create_failure_after_remove_returns_false() -> None:
+    """If create fails after the remove, recreate returns False (the dependent is
+    left removed — documented, hard to make atomic given Docker name reuse)."""
+    fake = _CreateRaises()
+    fake.add_container("dep", network_mode=f"container:{OLD_ID}")
+    assert recreate_dependent(fake, "dep", GLUETUN_ID, _logger()) is False
+    assert fake.removed == [("dep", False)]  # remove happened, with volumes preserved

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -80,6 +80,21 @@ def test_table_empty_store() -> None:
     assert "no sites recorded yet" in table
 
 
+def test_report_includes_lifetime_latency() -> None:
+    rep = build_report(_store_with_data())
+    slow = next(r for r in rep["sites"] if r["site"] == "https://slow.com")
+    assert "lifetime_latency_ms" in slow
+    assert slow["lifetime_latency_ms"]["samples"] == 4  # 4 successful polls
+
+
+def test_table_lifetime_window_label_and_data() -> None:
+    rep = build_report(_store_with_data())
+    recent = format_table(rep, lifetime=False)
+    lifetime = format_table(rep, lifetime=True)
+    assert "latency window: recent" in recent
+    assert "latency window: all-time" in lifetime
+
+
 def test_main_json_output(tmp_path: Path, capsys) -> None:
     path = str(tmp_path / "stats.json")
     s = _store_with_data()

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -67,6 +67,14 @@ def test_table_sort_by_name() -> None:
     assert table.index("https://fast.com") < table.index("https://slow.com")
 
 
+def test_table_sort_by_eff_puts_na_last() -> None:
+    """--sort eff ranks by restart-effectiveness; sites with no restarts (n/a)
+    sort to the bottom rather than the top."""
+    table = format_table(build_report(_store_with_data()), sort="eff")
+    # slow.com has 100% effectiveness; fast.com has none (n/a) -> slow first.
+    assert table.index("https://slow.com") < table.index("https://fast.com")
+
+
 def test_table_empty_store() -> None:
     table = format_table(build_report(SiteStatsStore(None)))
     assert "no sites recorded yet" in table

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -1,0 +1,108 @@
+"""The gluetun-monitor-stats report renders the stats sidecar (read-only).
+
+Why: operators need the per-site matrix (latency percentiles, failure rate,
+restart-effectiveness) without parsing JSON by hand. build_report is the single
+source both the table and --json share, so the views can't drift; these tests pin
+the data shape, the table, the sorts, the n/a rendering, and the safe-on-bad-input
+behavior.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from gluetun_monitor.report import build_report, format_table, main
+from gluetun_monitor.site_stats import SiteStatsStore
+
+
+def _store_with_data() -> SiteStatsStore:
+    s = SiteStatsStore(None)
+    # fast.com: healthy, no restarts -> effectiveness n/a
+    for ms in (100, 110, 90, 120, 105):
+        s.record_poll("https://fast.com", True, duration_ms=ms)
+    # slow.com: slower + one failure + a restart that cleared
+    for ms in (900, 1100, 1000, 1200):
+        s.record_poll("https://slow.com", True, duration_ms=ms)
+    s.record_poll("https://slow.com", False, reason="timed out")
+    s.record_restart("https://slow.com")
+    s.record_restart_outcome("https://slow.com", cleared=True)
+    s.record_loop()
+    return s
+
+
+def test_build_report_shape() -> None:
+    rep = build_report(_store_with_data())
+    assert set(rep) == {"monitor", "sites"}
+    assert {r["site"] for r in rep["sites"]} == {"https://fast.com", "https://slow.com"}
+    slow = next(r for r in rep["sites"] if r["site"] == "https://slow.com")
+    assert slow["polls"] == 5 and slow["failures"] == 1
+    assert slow["restart_effectiveness"] == 1.0
+    assert slow["latency_ms"]["samples"] == 4
+    fast = next(r for r in rep["sites"] if r["site"] == "https://fast.com")
+    assert fast["restart_effectiveness"] is None  # no restarts
+
+
+def test_build_report_is_json_serializable() -> None:
+    rep = build_report(_store_with_data())
+    round_tripped = json.loads(json.dumps(rep))
+    assert round_tripped["sites"]
+
+
+def test_table_has_headers_and_na() -> None:
+    table = format_table(build_report(_store_with_data()))
+    for header in ("site", "p90", "p99", "rate%", "eff%", "last_fail"):
+        assert header in table
+    assert "n/a" in table  # fast.com has no restarts
+    assert "https://slow.com" in table
+
+
+def test_table_sort_p90_puts_slowest_first() -> None:
+    table = format_table(build_report(_store_with_data()), sort="p90")
+    assert table.index("https://slow.com") < table.index("https://fast.com")
+
+
+def test_table_sort_by_name() -> None:
+    table = format_table(build_report(_store_with_data()), sort="name")
+    assert table.index("https://fast.com") < table.index("https://slow.com")
+
+
+def test_table_empty_store() -> None:
+    table = format_table(build_report(SiteStatsStore(None)))
+    assert "no sites recorded yet" in table
+
+
+def test_main_json_output(tmp_path: Path, capsys) -> None:
+    path = str(tmp_path / "stats.json")
+    s = _store_with_data()
+    s._path = Path(path)  # type: ignore[attr-defined]
+    assert s.save() is True
+    rc = main(["--file", path, "--json"])
+    assert rc == 0
+    out = json.loads(capsys.readouterr().out)
+    assert out["sites"] and "monitor" in out
+
+
+def test_main_table_output(tmp_path: Path, capsys) -> None:
+    path = str(tmp_path / "stats.json")
+    s = _store_with_data()
+    s._path = Path(path)  # type: ignore[attr-defined]
+    s.save()
+    rc = main(["--file", path, "--sort", "avg"])
+    assert rc == 0
+    assert "https://slow.com" in capsys.readouterr().out
+
+
+def test_main_missing_file_is_clean_error(tmp_path: Path, capsys) -> None:
+    rc = main(["--file", str(tmp_path / "nope.json")])
+    assert rc == 1
+    assert "No stats file" in capsys.readouterr().err
+
+
+def test_main_tolerates_corrupt_file(tmp_path: Path, capsys) -> None:
+    """A garbage stats file yields an empty report, never a crash."""
+    p = tmp_path / "stats.json"
+    p.write_text("{ this is not json", encoding="utf-8")
+    rc = main(["--file", str(p)])
+    assert rc == 0
+    assert "no sites recorded yet" in capsys.readouterr().out

--- a/tests/test_resolve_dependents.py
+++ b/tests/test_resolve_dependents.py
@@ -1,0 +1,63 @@
+"""_resolve_dependents reuses existence it already learned this loop.
+
+Why: it inspects the current names to check existence, then prunes the remembered
+set. Re-inspecting a name it just checked is wasted Docker API work; this pins
+that a name that is both current and remembered is inspected once per loop, not
+twice — while a remembered-but-no-longer-current name is still inspected (and
+pruned if gone).
+"""
+
+from __future__ import annotations
+
+import io
+from collections import Counter
+
+from gluetun_monitor.config import Config
+from gluetun_monitor.docker_client import ContainerInfo
+from gluetun_monitor.logging_setup import Logger
+from gluetun_monitor.monitor import Monitor
+from gluetun_monitor.site_stats import SiteStatsStore
+
+from .fakes import FakeDockerClient
+
+GLUETUN_ID = "a" * 64
+
+
+class _CountingClient(FakeDockerClient):
+    """Counts inspect() calls per name."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.inspect_calls: Counter[str] = Counter()
+
+    def inspect(self, name_or_id: str) -> ContainerInfo | None:
+        self.inspect_calls[name_or_id] += 1
+        return super().inspect(name_or_id)
+
+
+def _mon(fake: FakeDockerClient, **cfg: object) -> Monitor:
+    cfg.setdefault("config_file", "/dev/null")
+    cfg.setdefault("gluetun_container", "gluetun")
+    logger = Logger(log_file=None, level="INFO", stream=io.StringIO())
+    return Monitor(fake, Config(**cfg), logger, sleep=lambda _s: None, stats=SiteStatsStore(None))
+
+
+def test_current_dependent_inspected_once_per_loop() -> None:
+    fake = _CountingClient()
+    fake.add_container("dep", network_mode=f"container:{GLUETUN_ID}")
+    mon = _mon(fake, dependent_containers="dep")  # manual -> no discovery inspects
+    result = mon._resolve_dependents()
+    assert result == ["dep"]
+    assert fake.inspect_calls["dep"] == 1  # not re-inspected during the prune
+
+
+def test_remembered_but_gone_dependent_is_pruned() -> None:
+    """A remembered name not in the current set is still inspected and, if gone,
+    dropped — the prune correctness the inspect-reuse must not break."""
+    fake = _CountingClient()
+    fake.add_container("dep", network_mode=f"container:{GLUETUN_ID}")
+    mon = _mon(fake, dependent_containers="dep")
+    assert mon._resolve_dependents() == ["dep"]  # dep now remembered
+
+    fake.remove("dep", volumes=False)  # disappears
+    assert mon._resolve_dependents() == []  # pruned from the remembered set

--- a/tests/test_rng_threadsafe.py
+++ b/tests/test_rng_threadsafe.py
@@ -1,0 +1,95 @@
+"""The load-bearing site shuffle stays sound when dependents are probed in a pool.
+
+Why: _probe_dependent runs across a ThreadPoolExecutor, and a single
+random.Random instance is not thread-safe — concurrent sample()/uniform() calls
+can interleave and corrupt generator state, silently biasing the shuffle that
+ADR-0006 leans on. The monitor guards every draw with a lock; this pins that the
+draws are actually serialized (never overlap) under concurrent probing.
+"""
+
+from __future__ import annotations
+
+import io
+import random
+import threading
+import time
+from concurrent.futures import ThreadPoolExecutor
+
+from gluetun_monitor.config import Config
+from gluetun_monitor.docker_client import ExecResult
+from gluetun_monitor.logging_setup import Logger
+from gluetun_monitor.monitor import Monitor
+from gluetun_monitor.site_stats import SiteStatsStore
+
+from .fakes import FakeDockerClient
+
+GLUETUN_ID = "a" * 64
+POOL = [f"https://s{i}.example" for i in range(8)]
+
+
+class _OverlapDetectingRandom(random.Random):
+    """Records the peak number of threads simultaneously inside a draw.
+
+    The tiny busy-window widens any unguarded overlap so it is observable; if the
+    monitor's lock works, only one thread is ever inside sample()/uniform() at a
+    time and max_concurrent stays 1.
+    """
+
+    def __init__(self) -> None:
+        super().__init__(0)
+        self._active = 0
+        self.max_concurrent = 0
+        self._barrier = threading.Barrier(8)
+
+    def _enter(self) -> None:
+        # Synchronize all workers to the same instant so an unguarded RNG would
+        # genuinely overlap, then observe how many are concurrently inside.
+        # When the lock works, only one thread is ever here, so the 8-party
+        # barrier never fills and the first draw times out (cheaply); when it is
+        # broken, all 8 arrive together and the barrier trips instantly.
+        try:
+            self._barrier.wait(timeout=0.3)
+        except threading.BrokenBarrierError:
+            pass
+        self._active += 1
+        self.max_concurrent = max(self.max_concurrent, self._active)
+        time.sleep(0.01)  # real yield: widens the window so any overlap is observed
+        self._active -= 1
+
+    def sample(self, population, k, *, counts=None):  # type: ignore[override]
+        self._enter()
+        return super().sample(population, k, counts=counts)
+
+
+def _live_exec(name: str, cmd: list[str]) -> ExecResult:
+    if cmd[:2] == ["ls", "/sys/class/net"]:
+        return ExecResult(0, "eth0\nlo\n")  # LIVE
+    return ExecResult(0, "  HTTP/1.1 200 OK\n")
+
+
+def test_rng_draws_are_serialized_under_concurrent_probing() -> None:
+    fake = FakeDockerClient()
+    fake.on_exec = _live_exec
+    rng = _OverlapDetectingRandom()
+    logger = Logger(log_file=None, level="INFO", stream=io.StringIO())
+    mon = Monitor(
+        fake,
+        Config(config_file="/dev/null", gluetun_container="gluetun"),
+        logger,
+        rng=rng,
+        sleep=lambda _s: None,
+        stats=SiteStatsStore(None),
+    )
+
+    with ThreadPoolExecutor(max_workers=8) as pool:
+        futures = [
+            pool.submit(mon._probe_dependent, f"dep{i}", GLUETUN_ID, POOL, [])
+            for i in range(8)
+        ]
+        for f in futures:
+            f.result()
+
+    assert rng.max_concurrent == 1, (
+        f"RNG draws overlapped (peak {rng.max_concurrent}) — the lock did not "
+        f"serialize them; the shuffle is not thread-safe"
+    )

--- a/tests/test_site_change_log.py
+++ b/tests/test_site_change_log.py
@@ -1,0 +1,119 @@
+"""Runtime sites.conf edits are logged by *name* (added/removed), including swaps.
+
+Why: sites.conf is re-read every loop, so an operator editing it should see what
+changed at INFO — not just "count changed", and especially not silence when a
+same-count swap leaves the count unchanged. A removed site also drops its live
+failure counter so a later re-add starts clean.
+"""
+
+from __future__ import annotations
+
+import io
+from pathlib import Path
+
+from gluetun_monitor.config import Config
+from gluetun_monitor.docker_client import ExecResult
+from gluetun_monitor.logging_setup import Logger
+from gluetun_monitor.monitor import Monitor
+from gluetun_monitor.site_stats import SiteStatsStore
+from gluetun_monitor.state import Counter
+
+from .fakes import FakeDockerClient
+
+GLUETUN_ID = "a" * 64
+A, B, C, D, E = (f"https://{x}.example" for x in "abcde")
+
+
+def _write(conf: Path, sites: list[str]) -> None:
+    conf.write_text("\n".join(sites) + "\n", encoding="utf-8")
+
+
+def _monitor(tmp_path: Path) -> tuple[Monitor, io.StringIO, FakeDockerClient, Path]:
+    fake = FakeDockerClient()
+    fake.add_container("gluetun", id=GLUETUN_ID)
+
+    def healthy(name: str, cmd: list[str]) -> ExecResult:
+        if cmd and cmd[0] == "wget":
+            return ExecResult(0, "  HTTP/1.1 200 OK\n")
+        return ExecResult(0, "eth0\nlo\n")
+
+    fake.on_exec = healthy
+    stream = io.StringIO()
+    logger = Logger(log_file=None, level="INFO", stream=stream)
+    conf = tmp_path / "sites.conf"
+    # Manual empty dependent set -> dependent phase no-ops, keeping output focused.
+    mon = Monitor(fake, Config(config_file=str(conf), gluetun_container="gluetun",
+                               dependent_containers=""),
+                  logger, sleep=lambda _s: None, stats=SiteStatsStore(None))
+    return mon, stream, fake, conf
+
+
+def _loop(mon: Monitor, conf: Path, sites: list[str]) -> None:
+    _write(conf, sites)
+    mon.run_once()
+
+
+def test_first_load_logs_count(tmp_path: Path) -> None:
+    mon, stream, _, conf = _monitor(tmp_path)
+    _loop(mon, conf, [A, B, C])
+    assert "Loaded 3 sites" in stream.getvalue()
+
+
+def test_add_logs_added_name(tmp_path: Path) -> None:
+    mon, stream, _, conf = _monitor(tmp_path)
+    _loop(mon, conf, [A, B, C])
+    _loop(mon, conf, [A, B, C, D])
+    assert f"Sites changed: added {D} (now 4)" in stream.getvalue()
+
+
+def test_remove_logs_removed_name(tmp_path: Path) -> None:
+    mon, stream, _, conf = _monitor(tmp_path)
+    _loop(mon, conf, [A, B, C])
+    _loop(mon, conf, [A, B])
+    assert f"Sites changed: removed {C} (now 2)" in stream.getvalue()
+
+
+def test_swap_same_count_is_logged(tmp_path: Path) -> None:
+    """The blind spot of count-only tracking: count stays 3, but the set changed."""
+    mon, stream, _, conf = _monitor(tmp_path)
+    _loop(mon, conf, [A, B, C])
+    _loop(mon, conf, [A, B, E])  # swap C -> E, still 3
+    assert f"Sites changed: added {E}; removed {C} (now 3)" in stream.getvalue()
+
+
+def test_no_change_logs_nothing(tmp_path: Path) -> None:
+    mon, stream, _, conf = _monitor(tmp_path)
+    _loop(mon, conf, [A, B, C])
+    before = len(stream.getvalue())
+    _loop(mon, conf, [A, B, C])  # identical sites.conf
+    assert "Sites changed" not in stream.getvalue()[before:]
+
+
+def test_removed_site_failure_counter_discarded(tmp_path: Path) -> None:
+    """A site failing below threshold, then removed, must not carry its count back
+    if re-added."""
+    mon, _stream, fake, conf = _monitor(tmp_path)
+
+    def b_fails(name: str, cmd: list[str]) -> ExecResult:
+        if cmd and cmd[0] == "wget" and B in cmd[-1]:
+            return ExecResult(4, "wget: bad address\n")  # no HTTP -> fail
+        if cmd and cmd[0] == "wget":
+            return ExecResult(0, "  HTTP/1.1 200 OK\n")
+        return ExecResult(0, "eth0\nlo\n")
+
+    fake.on_exec = b_fails
+    _loop(mon, conf, [A, B, C])
+    assert mon.site_failures.get(B) == 1  # B failed once (below threshold 2)
+
+    _loop(mon, conf, [A, C])  # remove B
+    assert mon.site_failures.get(B) == 0  # counter discarded, not lingering at 1
+
+
+def test_counter_discard() -> None:
+    c = Counter()
+    c.fail("x")
+    c.fail("x")
+    assert c.get("x") == 2
+    c.discard("x")
+    assert c.get("x") == 0  # forgotten
+    c.discard("never-seen")  # no error

--- a/tests/test_site_stats.py
+++ b/tests/test_site_stats.py
@@ -37,6 +37,64 @@ def test_episode_accounting_and_derived_metrics() -> None:
     assert st.failure_rate == 0.75
 
 
+def test_longest_fail_streak_tracks_the_worst_run() -> None:
+    """longest_fail_streak = the longest run of consecutive failed polls ever,
+    even after a recovery shortens the current streak."""
+    s = SiteStatsStore(None)
+    for ok in (False, False, False, True, False):  # runs of 3 then 1
+        s.record_poll("b.com", ok)
+    st = s.sites["b.com"]
+    assert st.longest_fail_streak == 3
+    assert st.current_fail_streak == 1
+
+
+def test_last_seen_updates_on_poll() -> None:
+    clock = _Clock(500.0)
+    s = SiteStatsStore(None, clock=clock)
+    s.record_poll("b.com", True)
+    assert s.sites["b.com"].last_seen == 500.0
+    clock.t = 900.0
+    s.record_poll("b.com", True)
+    assert s.sites["b.com"].last_seen == 900.0
+
+
+def test_prune_stale_drops_unseen_sites_keeps_fresh() -> None:
+    """A site not polled within retention (e.g. removed from sites.conf) is pruned;
+    a recently-polled one is kept."""
+    clock = _Clock(1_000_000.0)
+    s = SiteStatsStore(None, clock=clock)
+    s.record_poll("old.com", True)
+    s.record_poll("fresh.com", True)
+    clock.t += 100 * 86400  # 100 days later
+    s.record_poll("fresh.com", True)  # fresh.com seen again; old.com not
+    pruned = s.prune_stale(90 * 86400)
+    assert pruned == ["old.com"]
+    assert "old.com" not in s.sites
+    assert "fresh.com" in s.sites
+
+
+def test_prune_disabled_with_nonpositive_retention() -> None:
+    clock = _Clock(1_000_000.0)
+    s = SiteStatsStore(None, clock=clock)
+    s.record_poll("old.com", True)
+    clock.t += 1000 * 86400
+    assert s.prune_stale(0) == []  # 0 disables pruning
+    assert "old.com" in s.sites
+
+
+def test_save_is_atomic_no_leftover_tmp(tmp_path: Path) -> None:
+    """A successful save leaves the real file complete and no stray .tmp behind."""
+    path = tmp_path / "stats.json"
+    s = SiteStatsStore(str(path))
+    s.record_poll("b.com", False)
+    assert s.save() is True
+    assert path.exists()
+    assert not (tmp_path / "stats.json.tmp").exists()  # tmp renamed away
+    import json as _json
+    data = _json.loads(path.read_text())  # the file is complete, valid JSON
+    assert data["sites"]["b.com"]["total_failures"] == 1
+
+
 def test_advisory_fires_when_one_site_dominates() -> None:
     """>= min_restarts in window, one site >= dominance share -> Advisory."""
     s = SiteStatsStore(None)

--- a/tests/test_site_stats.py
+++ b/tests/test_site_stats.py
@@ -245,6 +245,38 @@ def test_restart_effectiveness_none_when_no_restarts() -> None:
     assert s.sites["b.com"].restart_effectiveness is None
 
 
+def test_lifetime_histogram_fed_and_persists(tmp_path: Path) -> None:
+    """Successful polls feed the all-time histogram, which survives a save/reload."""
+    path = str(tmp_path / "stats.json")
+    s1 = SiteStatsStore(path)
+    for ms in (100, 200, 300, 400, 500):
+        s1.record_poll("b.com", True, duration_ms=ms)
+    hist1 = s1.sites["b.com"].lifetime_latency
+    assert hist1.count == 5 and hist1.summary()["avg"] == 300
+    assert s1.save() is True
+
+    s2 = SiteStatsStore(path)
+    hist2 = s2.sites["b.com"].lifetime_latency
+    assert hist2.count == 5
+    assert hist2.summary() == hist1.summary()  # percentiles + exacts survive reload
+
+    # And the human-readable lifetime summary is in the JSON.
+    import json as _json
+    data = _json.loads((tmp_path / "stats.json").read_text())
+    assert "lifetime_latency_ms" in data["sites"]["b.com"]
+    assert data["sites"]["b.com"]["lifetime_latency_ms"]["samples"] == 5
+
+
+def test_lifetime_histogram_outlives_recent_ring(tmp_path: Path) -> None:
+    """The ring is bounded (recent view); the histogram keeps all-time count."""
+    s = SiteStatsStore(None, latency_ring_max=10)
+    for ms in range(1, 101):  # 100 successful polls
+        s.record_poll("b.com", True, duration_ms=ms * 10)
+    st = s.sites["b.com"]
+    assert len(st.recent_latencies) == 10  # ring capped
+    assert st.lifetime_latency.count == 100  # histogram kept them all
+
+
 def test_new_metrics_persist_round_trip(tmp_path: Path) -> None:
     path = str(tmp_path / "stats.json")
     s1 = SiteStatsStore(path)

--- a/tests/test_site_stats.py
+++ b/tests/test_site_stats.py
@@ -1,0 +1,122 @@
+"""Persistent per-site stats + flaky-site advisory (ADR-0008).
+
+Why: this is the lifetime/attribution data behind "this site keeps being flaky"
+and the advisory. The episode accounting (avg failure length), the windowed
+advisory (one site dominating recent restarts), and best-effort persistence
+(survives restart; corrupt file never crashes) are the load-bearing behaviors.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from gluetun_monitor.site_stats import SiteStatsStore, format_window
+
+
+class _Clock:
+    """Mutable fake clock."""
+
+    def __init__(self, t: float = 1000.0) -> None:
+        self.t = t
+
+    def __call__(self) -> float:
+        return self.t
+
+
+def test_episode_accounting_and_derived_metrics() -> None:
+    """fail,fail,pass,fail = 3 failures across 2 episodes (avg 1.5 polls); a pass
+    closes an episode so the next failure starts a new one."""
+    s = SiteStatsStore(None)
+    for ok in (False, False, True, False):
+        s.record_poll("b.com", ok)
+    st = s.sites["b.com"]
+    assert st.total_polls == 4
+    assert st.total_failures == 3
+    assert st.failure_episodes == 2
+    assert st.avg_episode_polls == 1.5
+    assert st.failure_rate == 0.75
+
+
+def test_advisory_fires_when_one_site_dominates() -> None:
+    """>= min_restarts in window, one site >= dominance share -> Advisory."""
+    s = SiteStatsStore(None)
+    for _ in range(4):
+        s.record_restart("b.com")
+    for _ in range(2):
+        s.record_restart("a.com")
+    adv = s.advisory(window_seconds=86400, min_restarts=5, dominance=0.5)
+    assert adv is not None
+    assert adv.site == "b.com"
+    assert adv.site_restarts == 4
+    assert adv.total_restarts == 6
+
+
+def test_advisory_silent_below_min_restarts() -> None:
+    s = SiteStatsStore(None)
+    for _ in range(3):
+        s.record_restart("b.com")
+    assert s.advisory(86400, 5, 0.5) is None
+
+
+def test_advisory_silent_when_no_site_dominates() -> None:
+    s = SiteStatsStore(None)
+    for _ in range(3):
+        s.record_restart("a.com")
+    for _ in range(3):
+        s.record_restart("b.com")
+    # 3/6 = 0.5 each; require >0.5 dominance -> nobody dominates.
+    assert s.advisory(86400, 5, 0.6) is None
+
+
+def test_advisory_respects_the_window() -> None:
+    """Restarts older than the window don't count."""
+    clock = _Clock(1000.0)
+    s = SiteStatsStore(None, clock=clock)
+    for _ in range(6):
+        s.record_restart("b.com")
+    clock.t = 1000.0 + 86400 + 1  # advance past the window
+    assert s.advisory(86400, 5, 0.5) is None
+
+
+def test_persistence_round_trip(tmp_path: Path) -> None:
+    """Stats survive a 'restart' — written by one store, loaded by the next."""
+    path = str(tmp_path / "stats.json")
+    s1 = SiteStatsStore(path)
+    s1.record_poll("b.com", False)
+    s1.record_poll("b.com", True)
+    s1.record_restart("b.com")
+    assert s1.save() is True
+
+    s2 = SiteStatsStore(path)
+    assert s2.sites["b.com"].total_polls == 2
+    assert s2.sites["b.com"].total_failures == 1
+    assert s2.sites["b.com"].restarts_triggered == 1
+    assert len(s2.recent_restarts) == 1
+
+
+def test_corrupt_file_is_non_fatal(tmp_path: Path) -> None:
+    """A garbage stats file degrades to empty in-memory, never raises."""
+    path = tmp_path / "stats.json"
+    path.write_text("{not valid json", encoding="utf-8")
+    s = SiteStatsStore(str(path))
+    assert s.sites == {}
+    assert s.recent_restarts == []
+
+
+def test_save_with_no_path_is_noop() -> None:
+    assert SiteStatsStore(None).save() is False
+
+
+def test_recent_restarts_bounded() -> None:
+    s = SiteStatsStore(None, recent_restarts_max=10)
+    for _ in range(25):
+        s.record_restart("b.com")
+    assert len(s.recent_restarts) == 10
+    assert s.sites["b.com"].restarts_triggered == 25  # lifetime count is not capped
+
+
+def test_format_window() -> None:
+    assert format_window(86400) == "1d"
+    assert format_window(3600) == "1h"
+    assert format_window(1800) == "30m"
+    assert format_window(90) == "90s"

--- a/tests/test_site_stats.py
+++ b/tests/test_site_stats.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from gluetun_monitor.site_stats import SiteStatsStore, format_window
+from gluetun_monitor.site_stats import SiteStatsStore, categorize_failure, format_window
 
 
 class _Clock:
@@ -171,6 +171,94 @@ def test_recent_restarts_bounded() -> None:
         s.record_restart("b.com")
     assert len(s.recent_restarts) == 10
     assert s.sites["b.com"].restarts_triggered == 25  # lifetime count is not capped
+
+
+def test_latency_summary_avg_min_max_and_percentiles() -> None:
+    """Successful-poll durations feed avg/min/max + p50/p75/p99 (median vs mean)."""
+    s = SiteStatsStore(None)
+    # 1..100 ms on passing polls (failures don't contribute latency).
+    for ms in range(1, 101):
+        s.record_poll("b.com", True, duration_ms=ms)
+    lat = s.sites["b.com"].latency_summary()
+    assert lat["samples"] == 100
+    assert lat["min"] == 1 and lat["max"] == 100
+    assert lat["avg"] == 50  # round(50.5) -> 50
+    assert lat["p50"] == 50
+    assert lat["p90"] == 90
+    assert lat["p99"] == 99
+
+
+def test_latency_ring_is_bounded() -> None:
+    s = SiteStatsStore(None, latency_ring_max=50)
+    for ms in range(1, 201):
+        s.record_poll("b.com", True, duration_ms=ms)
+    lat = s.sites["b.com"]
+    assert len(lat.recent_latencies) == 50
+    assert lat.recent_latencies[-1] == 200  # newest retained
+
+
+def test_failed_polls_do_not_add_latency() -> None:
+    s = SiteStatsStore(None)
+    s.record_poll("b.com", False, duration_ms=9999, reason="timed out")
+    assert s.sites["b.com"].recent_latencies == []
+
+
+def test_failure_reason_breakdown() -> None:
+    """Failures are bucketed by category from the reason text."""
+    s = SiteStatsStore(None)
+    s.record_poll("b.com", False, reason="Read error (Operation timed out)")
+    s.record_poll("b.com", False, reason="Unable to establish SSL connection")
+    s.record_poll("b.com", False, reason="wget: bad address 'b.com'")
+    s.record_poll("b.com", False, reason="can't connect: Connection refused")
+    fr = s.sites["b.com"].failure_reasons
+    assert fr == {"timeout": 1, "tls": 1, "dns": 1, "connection": 1}
+
+
+def test_categorize_failure_buckets() -> None:
+    assert categorize_failure("Read error (Operation timed out)") == "timeout"
+    assert categorize_failure("Unable to establish SSL connection") == "tls"
+    assert categorize_failure("wget: bad address 'x'") == "dns"
+    assert categorize_failure("Connection refused") == "connection"
+    assert categorize_failure("server returned error: HTTP/1.1 500") == "http-error"
+    assert categorize_failure("something weird") == "other"
+
+
+def test_restart_effectiveness() -> None:
+    """Of a site's restarts, the fraction that cleared it on re-verify."""
+    s = SiteStatsStore(None)
+    for _ in range(4):
+        s.record_restart("b.com")
+    s.record_restart_outcome("b.com", cleared=True)
+    s.record_restart_outcome("b.com", cleared=True)
+    s.record_restart_outcome("b.com", cleared=False)
+    s.record_restart_outcome("b.com", cleared=False)
+    st = s.sites["b.com"]
+    assert st.restarts_triggered == 4
+    assert st.restarts_cleared == 2
+    assert st.restart_effectiveness == 0.5
+
+
+def test_new_metrics_persist_round_trip(tmp_path: Path) -> None:
+    path = str(tmp_path / "stats.json")
+    s1 = SiteStatsStore(path)
+    s1.record_poll("b.com", True, duration_ms=42)
+    s1.record_poll("b.com", False, reason="timed out")
+    s1.record_restart("b.com")
+    s1.record_restart_outcome("b.com", cleared=True)
+    assert s1.save() is True
+
+    s2 = SiteStatsStore(path)
+    st = s2.sites["b.com"]
+    assert st.recent_latencies == [42]
+    assert st.failure_reasons == {"timeout": 1}
+    assert st.restarts_cleared == 1
+
+    # The saved JSON also carries human-readable computed metrics.
+    import json as _json
+    data = _json.loads((tmp_path / "stats.json").read_text())
+    site = data["sites"]["b.com"]
+    assert "latency_ms" in site and site["latency_ms"]["avg"] == 42
+    assert "restart_effectiveness" in site and "failure_rate" in site
 
 
 def test_format_window() -> None:

--- a/tests/test_site_stats.py
+++ b/tests/test_site_stats.py
@@ -238,6 +238,13 @@ def test_restart_effectiveness() -> None:
     assert st.restart_effectiveness == 0.5
 
 
+def test_restart_effectiveness_none_when_no_restarts() -> None:
+    """No restarts triggered -> None (callers render 'n/a', not a misleading 0%)."""
+    s = SiteStatsStore(None)
+    s.record_poll("b.com", True, duration_ms=10)
+    assert s.sites["b.com"].restart_effectiveness is None
+
+
 def test_new_metrics_persist_round_trip(tmp_path: Path) -> None:
     path = str(tmp_path / "stats.json")
     s1 = SiteStatsStore(path)

--- a/tests/test_site_stats.py
+++ b/tests/test_site_stats.py
@@ -261,6 +261,59 @@ def test_new_metrics_persist_round_trip(tmp_path: Path) -> None:
     assert "restart_effectiveness" in site and "failure_rate" in site
 
 
+def test_monitor_level_counters() -> None:
+    """Top-level (monitor-wide) counters: loops, restarts, remediations, advisories."""
+    s = SiteStatsStore(None)
+    for _ in range(3):
+        s.record_loop()
+    s.record_gluetun_restart()
+    s.record_gluetun_restart()
+    s.record_dependent_remediation()
+    s.record_advisory()
+    assert s.monitor.total_loops == 3
+    assert s.monitor.total_gluetun_restarts == 2
+    assert s.monitor.total_dependent_remediations == 1
+    assert s.monitor.total_advisories == 1
+    assert s.monitor.version  # stamped from the package version
+
+
+def test_monitor_runtime_accumulates_excluding_downtime() -> None:
+    """Runtime accrues between loops; the gap before the first loop of a process
+    doesn't count as runtime (the tick is set at start)."""
+    clock = _Clock(1000.0)
+    s = SiteStatsStore(None, clock=clock)
+    clock.t = 1005.0
+    s.record_loop()  # +5s
+    clock.t = 1008.0
+    s.record_loop()  # +3s
+    assert s.monitor.total_runtime_seconds == 8.0
+
+
+def test_monitor_stats_persist_and_first_started_is_stable(tmp_path: Path) -> None:
+    """Cumulative monitor counters survive a restart; first_started is set once,
+    last_started refreshes each process."""
+    path = str(tmp_path / "stats.json")
+    clock = _Clock(1000.0)
+    s1 = SiteStatsStore(path, clock=clock)
+    s1.record_loop()
+    s1.record_gluetun_restart()
+    assert s1.save() is True
+
+    clock.t = 5000.0  # "restart" later
+    s2 = SiteStatsStore(path, clock=clock)
+    assert s2.monitor.total_loops == 1  # carried over
+    assert s2.monitor.total_gluetun_restarts == 1
+    assert s2.monitor.first_started == 1000.0  # set once, preserved
+    assert s2.monitor.last_started == 5000.0  # this process
+
+    import json as _json
+    data = _json.loads((tmp_path / "stats.json").read_text())
+    assert "monitor" in data
+    s2.save()
+    data = _json.loads((tmp_path / "stats.json").read_text())
+    assert "current_uptime_seconds" in data["monitor"]
+
+
 def test_format_window() -> None:
     assert format_window(86400) == "1d"
     assert format_window(3600) == "1h"

--- a/tests/test_sites.py
+++ b/tests/test_sites.py
@@ -1,0 +1,84 @@
+"""sites.conf parsing, trim (incl. issue #17), and URL classification."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from gluetun_monitor.sites import (
+    hostname_of,
+    ip_pool,
+    is_ip_literal,
+    parse_sites_conf,
+    resolvable_pool,
+    trim,
+)
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        ("   hello world   ", "hello world"),
+        ("\t  hello\t", "hello"),
+        ("", ""),
+        ("     ", ""),
+        (" say \"hi\" ", 'say "hi"'),
+        # issue #17: xargs choked on this; trim must preserve the apostrophe.
+        (" Provence-Alpes-Cote-d'Azur ", "Provence-Alpes-Cote-d'Azur"),
+    ],
+)
+def test_trim(raw: str, expected: str) -> None:
+    assert trim(raw) == expected
+
+
+def test_parse_skips_comments_blanks_and_whitespace(tmp_path: Path) -> None:
+    conf = tmp_path / "sites.conf"
+    conf.write_text(
+        "# a comment\n"
+        "\n"
+        "   \n"
+        "https://www.google.com\n"
+        "  https://cloudflare.com  \n"
+        "   # indented comment\n"
+        "https://1.1.1.1\n"
+    )
+    assert parse_sites_conf(conf) == [
+        "https://www.google.com",
+        "https://cloudflare.com",
+        "https://1.1.1.1",
+    ]
+
+
+def test_parse_missing_file_raises(tmp_path: Path) -> None:
+    with pytest.raises(FileNotFoundError):
+        parse_sites_conf(tmp_path / "nope.conf")
+
+
+@pytest.mark.parametrize(
+    ("url", "host"),
+    [
+        ("https://www.google.com", "www.google.com"),
+        ("https://1.1.1.1", "1.1.1.1"),
+        ("http://example.com:8080/path", "example.com"),
+        ("https://[2606:4700:4700::1111]/x", "2606:4700:4700::1111"),
+        ("bare-host.example", "bare-host.example"),
+    ],
+)
+def test_hostname_of(url: str, host: str) -> None:
+    assert hostname_of(url) == host
+
+
+@pytest.mark.parametrize(
+    ("host", "expected"),
+    [("1.1.1.1", True), ("2606:4700:4700::1111", True),
+     ("www.google.com", False), ("", False)],
+)
+def test_is_ip_literal(host: str, expected: bool) -> None:
+    assert is_ip_literal(host) is expected
+
+
+def test_pools_split_resolvable_from_ip_literals() -> None:
+    sites = ["https://www.google.com", "https://1.1.1.1", "https://cloudflare.com"]
+    assert resolvable_pool(sites) == ["https://www.google.com", "https://cloudflare.com"]
+    assert ip_pool(sites) == ["https://1.1.1.1"]

--- a/tests/test_sites.py
+++ b/tests/test_sites.py
@@ -1,4 +1,9 @@
-"""sites.conf parsing, trim (incl. issue #17), and URL classification."""
+"""sites.conf parsing, trim (incl. issue #17), and URL classification.
+
+Why: parsing is the front door for the test targets, and the resolvable-vs-IP
+classification decides whether a dependent's DNS gets exercised (ADR-0006). trim
+carries a real regression (#17): the old xargs-based trim crashed on quotes.
+"""
 
 from __future__ import annotations
 
@@ -29,10 +34,14 @@ from gluetun_monitor.sites import (
     ],
 )
 def test_trim(raw: str, expected: str) -> None:
+    """trim strips surrounding whitespace but preserves quotes/apostrophes — the
+    last case is the #17 regression that crashed the v1 xargs-based trim."""
     assert trim(raw) == expected
 
 
 def test_parse_skips_comments_blanks_and_whitespace(tmp_path: Path) -> None:
+    """Only real URLs survive parsing: comments (incl. indented), blank, and
+    whitespace-only lines are dropped, and entries are trimmed."""
     conf = tmp_path / "sites.conf"
     conf.write_text(
         "# a comment\n"
@@ -51,6 +60,8 @@ def test_parse_skips_comments_blanks_and_whitespace(tmp_path: Path) -> None:
 
 
 def test_parse_missing_file_raises(tmp_path: Path) -> None:
+    """A missing file raises FileNotFoundError — load_sites() relies on this to
+    treat an absent file as "no contribution" rather than crashing."""
     with pytest.raises(FileNotFoundError):
         parse_sites_conf(tmp_path / "nope.conf")
 
@@ -66,6 +77,8 @@ def test_parse_missing_file_raises(tmp_path: Path) -> None:
     ],
 )
 def test_hostname_of(url: str, host: str) -> None:
+    """Host extraction handles ports, paths, IPv6 brackets, and scheme-less input
+    — the input to the IP-literal classification below."""
     assert hostname_of(url) == host
 
 
@@ -75,10 +88,14 @@ def test_hostname_of(url: str, host: str) -> None:
      ("www.google.com", False), ("", False)],
 )
 def test_is_ip_literal(host: str, expected: bool) -> None:
+    """IPv4/IPv6 literals are recognized as such; DNS names and empty are not —
+    this is what separates DNS-exercising URLs from connectivity-only ones."""
     assert is_ip_literal(host) is expected
 
 
 def test_pools_split_resolvable_from_ip_literals() -> None:
+    """The resolvable pool (hostnames) drives dependent DNS testing; the IP pool
+    is the connectivity-only fallback (ADR-0006)."""
     sites = ["https://www.google.com", "https://1.1.1.1", "https://cloudflare.com"]
     assert resolvable_pool(sites) == ["https://www.google.com", "https://cloudflare.com"]
     assert ip_pool(sites) == ["https://1.1.1.1"]

--- a/tests/test_sites_env.py
+++ b/tests/test_sites_env.py
@@ -1,0 +1,82 @@
+"""SITES env var: CSV test URLs, unioned + deduped with sites.conf."""
+
+from __future__ import annotations
+
+import io
+from pathlib import Path
+
+import pytest
+
+from gluetun_monitor import cli
+from gluetun_monitor.config import Config
+from gluetun_monitor.logging_setup import Logger
+from gluetun_monitor.sites import load_sites, parse_sites_csv
+
+from .fakes import FakeDockerClient
+
+GLUETUN_ID = "a" * 64
+
+
+def test_parse_sites_csv() -> None:
+    assert parse_sites_csv("https://a, https://b ,, https://c") == [
+        "https://a", "https://b", "https://c"
+    ]
+    assert parse_sites_csv("") == []
+
+
+def test_load_sites_file_only(tmp_path: Path) -> None:
+    conf = tmp_path / "s.conf"
+    conf.write_text("https://a\nhttps://b\n")
+    assert load_sites(str(conf), None) == ["https://a", "https://b"]
+
+
+def test_load_sites_env_only_missing_file(tmp_path: Path) -> None:
+    # No file present -> file contributes nothing; env supplies the set.
+    assert load_sites(str(tmp_path / "absent.conf"), "https://x,https://y") == [
+        "https://x", "https://y"
+    ]
+
+
+def test_load_sites_union_dedup(tmp_path: Path) -> None:
+    conf = tmp_path / "s.conf"
+    conf.write_text("https://a\nhttps://b\n")
+    # 'https://b' is in both -> deduped; file order first, then env-only.
+    assert load_sites(str(conf), "https://b,https://c") == [
+        "https://a", "https://b", "https://c"
+    ]
+
+
+def test_load_sites_empty_when_neither(tmp_path: Path) -> None:
+    assert load_sites(str(tmp_path / "absent.conf"), None) == []
+
+
+# ----- prereq + end-to-end -----
+
+
+def _logger() -> Logger:
+    return Logger(log_file=None, level="DEBUG", stream=io.StringIO())
+
+
+def test_prereq_passes_with_sites_env_and_no_file(tmp_path: Path) -> None:
+    fake = FakeDockerClient()
+    fake.add_container("gluetun", id=GLUETUN_ID)
+    config = Config(
+        config_file=str(tmp_path / "absent.conf"),  # no file mounted
+        gluetun_container="gluetun",
+        sites_env="https://only-env.example",
+    )
+    assert cli.check_prerequisites(fake, config, _logger()) is True
+
+
+def test_prereq_fatal_when_no_file_and_no_sites_env(tmp_path: Path) -> None:
+    fake = FakeDockerClient()
+    fake.add_container("gluetun", id=GLUETUN_ID)
+    config = Config(config_file=str(tmp_path / "absent.conf"), gluetun_container="gluetun")
+    stream = io.StringIO()
+    assert cli.check_prerequisites(fake, config, Logger(log_file=None, stream=stream)) is False
+    assert "No testable sites" in stream.getvalue()
+
+
+def test_from_env_reads_sites(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("SITES", "https://a,https://b")
+    assert Config.from_env().sites_env == "https://a,https://b"

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -1,4 +1,10 @@
-"""Consecutive-failure counters (in-memory, reset-on-pass, no persistence)."""
+"""Consecutive-failure counters (in-memory, reset-on-pass, no persistence).
+
+Why: these counters are the whole of the monitor's per-site / per-dependent
+memory (ADR-0006 / Tenet 8 — re-act rather than remember). The behavior that
+matters is that failures count *consecutively* and a reset truly zeroes, since
+that's what turns "N failures in a row" into a remediation trigger.
+"""
 
 from __future__ import annotations
 
@@ -6,6 +12,8 @@ from gluetun_monitor.state import Counter
 
 
 def test_fail_increments_consecutively() -> None:
+    """fail() returns a monotonically increasing count for the same key — this is
+    what the threshold checks compare against."""
     c = Counter()
     assert c.fail("x") == 1
     assert c.fail("x") == 2
@@ -14,6 +22,8 @@ def test_fail_increments_consecutively() -> None:
 
 
 def test_reset_zeroes_one_key() -> None:
+    """reset() clears only its own key — a passing site/dependent must not reset
+    another's accumulated failures."""
     c = Counter()
     c.fail("x")
     c.fail("y")
@@ -23,10 +33,13 @@ def test_reset_zeroes_one_key() -> None:
 
 
 def test_get_unknown_key_is_zero() -> None:
+    """An unseen key reads as 0, so first-failure logic doesn't need to pre-seed."""
     assert Counter().get("never-seen") == 0
 
 
 def test_reset_all() -> None:
+    """reset_all() zeroes every key — used after a successful gluetun recovery to
+    give the whole stack a clean slate."""
     c = Counter()
     c.fail("a")
     c.fail("b")

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -1,0 +1,35 @@
+"""Consecutive-failure counters (in-memory, reset-on-pass, no persistence)."""
+
+from __future__ import annotations
+
+from gluetun_monitor.state import Counter
+
+
+def test_fail_increments_consecutively() -> None:
+    c = Counter()
+    assert c.fail("x") == 1
+    assert c.fail("x") == 2
+    assert c.fail("x") == 3
+    assert c.get("x") == 3
+
+
+def test_reset_zeroes_one_key() -> None:
+    c = Counter()
+    c.fail("x")
+    c.fail("y")
+    c.reset("x")
+    assert c.get("x") == 0
+    assert c.get("y") == 1
+
+
+def test_get_unknown_key_is_zero() -> None:
+    assert Counter().get("never-seen") == 0
+
+
+def test_reset_all() -> None:
+    c = Counter()
+    c.fail("a")
+    c.fail("b")
+    c.reset_all()
+    assert c.get("a") == 0
+    assert c.get("b") == 0

--- a/tests/test_stats_corrupt.py
+++ b/tests/test_stats_corrupt.py
@@ -1,0 +1,54 @@
+"""A corrupt stats sidecar degrades to "start fresh", never crashes startup.
+
+Why (Tenet 1): the stats file is best-effort telemetry, not load-bearing state.
+A malformed file — truncated, wrong top-level type, or a wrong-typed "sites"/
+"monitor" value — must never take the monitor down. SiteStatsStore is built in
+Monitor.__init__ before the loop, so a crash here would be a boot loop.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from gluetun_monitor.site_stats import SiteStatsStore
+
+GARBAGE = [
+    "not json at all {{{",          # invalid JSON -> ValueError
+    "[1, 2, 3]",                    # top level is a list -> .get() AttributeError
+    '"just a string"',             # top level is a string
+    "12345",                        # top level is a number
+    '{"sites": [1, 2, 3]}',        # sites is a list -> .items() AttributeError
+    '{"sites": {"x": "notadict"}}',  # a site value is a string -> .get() AttributeError
+    '{"sites": {"x": 5}}',          # a site value is a number
+    '{"monitor": [1, 2]}',         # monitor is a list
+    '{"recent_restarts": "nope"}',  # wrong type for recent_restarts
+    "",                              # empty file
+]
+
+
+@pytest.mark.parametrize("payload", GARBAGE)
+def test_corrupt_stats_file_starts_fresh(tmp_path: Path, payload: str) -> None:
+    p = tmp_path / "site-stats.json"
+    p.write_text(payload, encoding="utf-8")
+    store = SiteStatsStore(str(p))  # must not raise
+    assert store.sites == {}
+    assert store.recent_restarts == []
+    assert store.monitor.total_loops == 0
+
+
+def test_valid_stats_file_still_loads(tmp_path: Path) -> None:
+    """Sanity: the broadened except didn't swallow a genuinely good file."""
+    p = tmp_path / "site-stats.json"
+    p.write_text(json.dumps({
+        "sites": {"https://a.example": {"first_seen": 1.0, "total_polls": 7,
+                                        "total_failures": 2}},
+        "recent_restarts": [{"ts": 1.0, "site": "https://a.example"}],
+        "monitor": {"total_loops": 5},
+    }), encoding="utf-8")
+    store = SiteStatsStore(str(p))
+    assert store.sites["https://a.example"].total_polls == 7
+    assert store.recent_restarts == [{"ts": 1.0, "site": "https://a.example"}]
+    assert store.monitor.total_loops == 5

--- a/tests/test_timeout_tunables.py
+++ b/tests/test_timeout_tunables.py
@@ -1,0 +1,79 @@
+"""TIMEOUT + WGET_TRIES are standardized across every probe method.
+
+Why: an operator setting TIMEOUT=10 expects it to reach the wget inside the
+dependent containers and the gluetun site tests and the post-restart DNS probe —
+one knob, everywhere. WGET_TRIES likewise. These tests assert the flags actually
+land on the exec'd commands.
+"""
+
+from __future__ import annotations
+
+import io
+
+from gluetun_monitor.config import Config
+from gluetun_monitor.connectivity import probe_site
+from gluetun_monitor.dns_check import validate_dns
+from gluetun_monitor.docker_client import ExecResult
+from gluetun_monitor.logging_setup import Logger
+from gluetun_monitor.recovery import wait_for_dns
+
+from .fakes import FakeDockerClient
+
+GLUETUN_ID = "a" * 64
+
+
+def _capture() -> tuple[FakeDockerClient, list[list[str]]]:
+    fake = FakeDockerClient()
+    cmds: list[list[str]] = []
+
+    def handler(name: str, cmd: list[str]) -> ExecResult:
+        cmds.append(cmd)
+        return ExecResult(0, "  HTTP/1.1 200 OK\n")
+
+    fake.on_exec = handler
+    return fake, cmds
+
+
+def test_probe_site_applies_timeout_and_tries() -> None:
+    fake, cmds = _capture()
+    probe_site(fake, "dep", "https://x", timeout=10, tries=3)
+    assert "--timeout=10" in cmds[0]
+    assert "--tries=3" in cmds[0]
+
+
+def test_validate_dns_threads_timeout_and_tries_to_wget() -> None:
+    """The same TIMEOUT/WGET_TRIES reach the dependent-container wget."""
+    fake, cmds = _capture()
+    validate_dns(fake, "qbittorrent", "https://x", "x", timeout=15, tries=2)
+    wget_cmds = [c for c in cmds if c and c[0] == "wget"]
+    assert wget_cmds and "--timeout=15" in wget_cmds[0] and "--tries=2" in wget_cmds[0]
+
+
+def test_config_default_timeout_and_tries() -> None:
+    c = Config()
+    assert c.timeout == 10
+    assert c.wget_tries == 1
+
+
+def test_from_env_wget_tries(monkeypatch) -> None:
+    monkeypatch.setenv("WGET_TRIES", "4")
+    assert Config.from_env().wget_tries == 4
+
+
+def test_wait_for_dns_uses_standardized_timeout_not_hardcoded() -> None:
+    """The post-restart DNS probe uses request_timeout/tries (no hardcoded 5)."""
+    fake = FakeDockerClient()
+    fake.add_container("gluetun", id=GLUETUN_ID)
+    cmds: list[list[str]] = []
+
+    def handler(name: str, cmd: list[str]) -> ExecResult:
+        cmds.append(cmd)
+        return ExecResult(0, "")  # nslookup + wget both succeed -> returns fast
+
+    fake.on_exec = handler
+    logger = Logger(log_file=None, stream=io.StringIO())
+    assert wait_for_dns(fake, "gluetun", 30, logger, request_timeout=10, tries=2,
+                        sleep=lambda _s: None) is True
+    wget_cmds = [c for c in cmds if c and c[0] == "wget"]
+    assert wget_cmds and "--timeout=10" in wget_cmds[0] and "--tries=2" in wget_cmds[0]
+    assert all("--timeout=5" not in c for c in wget_cmds)  # no hardcoded 5

--- a/tests/test_viability_jitter.py
+++ b/tests/test_viability_jitter.py
@@ -1,0 +1,92 @@
+"""DEPENDENT_VIABILITY opt-out (A3) and MAX_JITTER_MS opt-in jitter (A4).
+
+Why: ADR-0006 promised both knobs. DEPENDENT_VIABILITY lets an operator drop the
+L7 (DNS/connectivity) probe and rely on the L3 interface/strand check alone;
+MAX_JITTER_MS exists for load-spreading but defaults to 0 so the simple path (the
+concurrency cap) is the default. These tests pin those behaviors.
+"""
+
+from __future__ import annotations
+
+import io
+import random
+
+from gluetun_monitor.config import Config
+from gluetun_monitor.docker_client import ExecResult
+from gluetun_monitor.logging_setup import Logger
+from gluetun_monitor.monitor import Monitor
+
+from .fakes import FakeDockerClient
+
+GLUETUN_ID = "a" * 64
+
+
+def _mon(fake: FakeDockerClient, sleep=lambda _s: None, **cfg: object) -> Monitor:
+    cfg.setdefault("config_file", "/dev/null")
+    cfg.setdefault("gluetun_container", "gluetun")
+    logger = Logger(log_file=None, level="DEBUG", stream=io.StringIO())
+    return Monitor(fake, Config(**cfg), logger, rng=random.Random(0), sleep=sleep)
+
+
+def test_viability_disabled_skips_l7_fetch_but_keeps_interface_check() -> None:
+    """With DEPENDENT_VIABILITY off, a live dependent is judged healthy on the
+    interface check alone — no wget/URL fetch is issued (L3 only, no L7)."""
+    fake = FakeDockerClient()
+    fake.add_container("gluetun", id=GLUETUN_ID)
+    fake.add_container("dep", network_mode=f"container:{GLUETUN_ID}")
+    wget_calls: list[list[str]] = []
+
+    def handler(name: str, cmd: list[str]) -> ExecResult:
+        if cmd[:2] == ["ls", "/sys/class/net"]:
+            return ExecResult(0, "eth0\nlo\n")  # LIVE
+        wget_calls.append(cmd)
+        return ExecResult(4, "")  # would FAIL if a viability probe were issued
+
+    fake.on_exec = handler
+    mon = _mon(fake, dependent_viability=False)
+    probe = mon._probe_dependent("dep", GLUETUN_ID, ["https://x"], [])
+    assert probe.viability_ok is None
+    assert "disabled" in probe.reason
+    assert wget_calls == []  # the L7 probe was skipped
+
+
+def test_viability_enabled_by_default_does_fetch() -> None:
+    """Default behavior is unchanged: the L7 probe runs."""
+    fake = FakeDockerClient()
+    fake.add_container("gluetun", id=GLUETUN_ID)
+    fake.add_container("dep", network_mode=f"container:{GLUETUN_ID}")
+    fake.on_exec = lambda name, cmd: ExecResult(0, "eth0\nlo\n" if cmd[0] == "ls" else "")
+    probe = _mon(fake)._probe_dependent("dep", GLUETUN_ID, ["https://x"], [])
+    assert probe.viability_ok is True
+
+
+def test_no_jitter_by_default() -> None:
+    """MAX_JITTER_MS defaults to 0 → no jitter sleep is taken."""
+    fake = FakeDockerClient()
+    fake.add_container("dep", network_mode=f"container:{GLUETUN_ID}")
+    fake.on_exec = lambda name, cmd: ExecResult(0, "eth0\nlo\n" if cmd[0] == "ls" else "")
+    slept: list[float] = []
+    mon = _mon(fake, sleep=lambda s: slept.append(s))
+    mon._probe_dependent("dep", GLUETUN_ID, ["https://x"], [])
+    assert slept == []
+
+
+def test_jitter_sleeps_within_window_when_enabled() -> None:
+    """With MAX_JITTER_MS set, a per-dispatch jitter in [0, window] seconds is
+    taken before probing — present but opt-in."""
+    fake = FakeDockerClient()
+    fake.add_container("dep", network_mode=f"container:{GLUETUN_ID}")
+    fake.on_exec = lambda name, cmd: ExecResult(0, "eth0\nlo\n" if cmd[0] == "ls" else "")
+    slept: list[float] = []
+    mon = _mon(fake, max_jitter_ms=100, sleep=lambda s: slept.append(s))
+    mon._probe_dependent("dep", GLUETUN_ID, ["https://x"], [])
+    assert len(slept) == 1
+    assert 0.0 <= slept[0] <= 0.1  # 100 ms window
+
+
+def test_env_reads_new_knobs(monkeypatch) -> None:
+    monkeypatch.setenv("DEPENDENT_VIABILITY", "0")
+    monkeypatch.setenv("MAX_JITTER_MS", "250")
+    c = Config.from_env()
+    assert c.dependent_viability is False
+    assert c.max_jitter_ms == 250

--- a/tests/test_viability_samples.py
+++ b/tests/test_viability_samples.py
@@ -1,0 +1,117 @@
+"""DEPENDENT_VIABILITY_SAMPLES — how many sites each dependent tests per loop.
+
+Why: default 1 (one shuffled site — optimal, since dependents share gluetun's
+netns so only DNS differs); N samples N distinct sites; -1 samples all. Viable if
+ANY sampled site resolves; not-viable only if ALL sampled resolvable sites fail
+DNS. The dial is for completeness; this pins the count + the combine semantics.
+"""
+
+from __future__ import annotations
+
+import io
+import random
+
+from gluetun_monitor.config import Config
+from gluetun_monitor.docker_client import ExecResult
+from gluetun_monitor.logging_setup import Logger
+from gluetun_monitor.monitor import Monitor
+from gluetun_monitor.site_stats import SiteStatsStore
+
+from .fakes import FakeDockerClient
+
+GLUETUN_ID = "a" * 64
+POOL = ["https://a.example", "https://b.example", "https://c.example", "https://d.example"]
+
+
+def _mon(fake: FakeDockerClient, **cfg: object) -> Monitor:
+    cfg.setdefault("config_file", "/dev/null")
+    cfg.setdefault("gluetun_container", "gluetun")
+    logger = Logger(log_file=None, level="DEBUG", stream=io.StringIO())
+    return Monitor(fake, Config(**cfg), logger, rng=random.Random(0),
+                   sleep=lambda _s: None, stats=SiteStatsStore(None))
+
+
+def _count_wget(fake: FakeDockerClient) -> list[int]:
+    """Track how many wget (viability) execs happen per probe call."""
+    calls: list[str] = []
+
+    def handler(name: str, cmd: list[str]) -> ExecResult:
+        if cmd[:2] == ["ls", "/sys/class/net"]:
+            return ExecResult(0, "eth0\nlo\n")  # LIVE
+        if cmd and cmd[0] == "wget":
+            calls.append(cmd[-1])
+        return ExecResult(0, "  HTTP/1.1 200 OK\n")
+
+    fake.on_exec = handler
+    return calls
+
+
+def test_default_samples_one_site() -> None:
+    fake = FakeDockerClient()
+    fake.add_container("dep", network_mode=f"container:{GLUETUN_ID}")
+    calls = _count_wget(fake)
+    mon = _mon(fake)  # default samples=1
+    mon._probe_dependent("dep", GLUETUN_ID, POOL, [])
+    assert len(calls) == 1
+
+
+def test_n_samples_n_distinct_sites() -> None:
+    fake = FakeDockerClient()
+    fake.add_container("dep", network_mode=f"container:{GLUETUN_ID}")
+    calls = _count_wget(fake)
+    mon = _mon(fake, dependent_viability_samples=3)
+    mon._probe_dependent("dep", GLUETUN_ID, POOL, [])
+    assert len(calls) == 3
+    assert len(set(calls)) == 3  # distinct
+
+
+def test_minus_one_samples_all() -> None:
+    fake = FakeDockerClient()
+    fake.add_container("dep", network_mode=f"container:{GLUETUN_ID}")
+    calls = _count_wget(fake)
+    mon = _mon(fake, dependent_viability_samples=-1)
+    mon._probe_dependent("dep", GLUETUN_ID, POOL, [])
+    assert len(calls) == len(POOL)
+
+
+def test_samples_capped_at_pool_size() -> None:
+    fake = FakeDockerClient()
+    fake.add_container("dep", network_mode=f"container:{GLUETUN_ID}")
+    calls = _count_wget(fake)
+    mon = _mon(fake, dependent_viability_samples=99)  # more than pool
+    mon._probe_dependent("dep", GLUETUN_ID, POOL, [])
+    assert len(calls) == len(POOL)
+
+
+def test_viable_if_any_sample_resolves() -> None:
+    """Sample 3; one resolves, two DNS-fail -> still viable (DNS works)."""
+    fake = FakeDockerClient()
+    fake.add_container("dep", network_mode=f"container:{GLUETUN_ID}")
+    ok_host = "a.example"
+
+    def handler(name: str, cmd: list[str]) -> ExecResult:
+        if cmd[:2] == ["ls", "/sys/class/net"]:
+            return ExecResult(0, "eth0\nlo\n")
+        if ok_host in cmd[-1]:
+            return ExecResult(0, "  HTTP/1.1 200 OK\n")
+        return ExecResult(1, "wget: bad address\n")  # DNS fail
+
+    fake.on_exec = handler
+    mon = _mon(fake, dependent_viability_samples=-1)  # test all -> a.example resolves
+    probe = mon._probe_dependent("dep", GLUETUN_ID, POOL, [])
+    assert probe.viability_ok is True
+
+
+def test_not_viable_only_if_all_samples_fail_dns() -> None:
+    fake = FakeDockerClient()
+    fake.add_container("dep", network_mode=f"container:{GLUETUN_ID}")
+
+    def handler(name: str, cmd: list[str]) -> ExecResult:
+        if cmd[:2] == ["ls", "/sys/class/net"]:
+            return ExecResult(0, "eth0\nlo\n")
+        return ExecResult(1, "wget: bad address\n")  # all DNS-fail
+
+    fake.on_exec = handler
+    mon = _mon(fake, dependent_viability_samples=-1)
+    probe = mon._probe_dependent("dep", GLUETUN_ID, POOL, [])
+    assert probe.viability_ok is False

--- a/tests/test_viability_semantic.py
+++ b/tests/test_viability_semantic.py
@@ -1,0 +1,114 @@
+"""Dependent viability fails ONLY on DNS resolution failure (the shared-netns model).
+
+Why: dependents share gluetun's network namespace, so their L3/L4 egress is
+gluetun's — already proven by the root test, and a strand is caught upstream by
+the interface check. The one fault a per-dependent probe uniquely detects is the
+container's own DNS (ADR-0006). So a 404/403, a flaky-site connection refusal, or
+a TLS hiccup must NOT count as a viability failure (no spurious dependent
+restarts); only "couldn't resolve the name" does. These tests pin that at the
+_probe_dependent level.
+"""
+
+from __future__ import annotations
+
+import io
+import random
+
+from gluetun_monitor.config import Config
+from gluetun_monitor.docker_client import ExecResult
+from gluetun_monitor.logging_setup import Logger
+from gluetun_monitor.monitor import Monitor
+
+from .fakes import FakeDockerClient
+
+GLUETUN_ID = "a" * 64
+
+
+def _mon(fake: FakeDockerClient) -> Monitor:
+    cfg = Config(config_file="/dev/null", gluetun_container="gluetun")
+    logger = Logger(log_file=None, level="DEBUG", stream=io.StringIO())
+    return Monitor(fake, cfg, logger, rng=random.Random(0), sleep=lambda _s: None)
+
+
+def _live_dep_returning(probe_output: str, probe_exit: int) -> FakeDockerClient:
+    fake = FakeDockerClient()
+    fake.add_container("dep", network_mode=f"container:{GLUETUN_ID}")
+
+    def handler(name: str, cmd: list[str]) -> ExecResult:
+        if cmd[:2] == ["ls", "/sys/class/net"]:
+            return ExecResult(0, "eth0\nlo\n")  # LIVE
+        return ExecResult(probe_exit, probe_output)
+
+    fake.on_exec = handler
+    return fake
+
+
+def test_busybox_404_is_viable() -> None:
+    """busybox 404 (exit 1, but site responded) → viable (DNS resolved)."""
+    fake = _live_dep_returning("  HTTP/1.1 404 Not Found\n", 1)
+    probe = _mon(fake)._probe_dependent("dep", GLUETUN_ID, ["https://x"], [])
+    assert probe.viability_ok is True
+
+
+def test_connection_refused_is_viable() -> None:
+    """A flaky site refusing the connection (DNS resolved) → viable; it's the
+    remote's problem, not the dependent's (shared netns)."""
+    fake = _live_dep_returning("wget: can't connect: Connection refused\n", 1)
+    probe = _mon(fake)._probe_dependent("dep", GLUETUN_ID, ["https://x"], [])
+    assert probe.viability_ok is True
+
+
+def test_dns_failure_is_not_viable() -> None:
+    """A real resolver failure → NOT viable (this is the fault we exist to catch)."""
+    fake = _live_dep_returning("wget: bad address 'x'\n", 1)
+    probe = _mon(fake)._probe_dependent("dep", GLUETUN_ID, ["https://x"], [])
+    assert probe.viability_ok is False
+
+
+def test_only_dns_failures_accumulate_to_remediation(tmp_path) -> None:
+    """End to end: a dependent that only ever gets 404s never trips remediation,
+    while one with persistent DNS failures reaches the threshold and is acted on."""
+    conf = tmp_path / "sites.conf"
+    conf.write_text("https://www.google.com\n")
+
+    # Case 1: dependent always gets a 404 — never remediated.
+    fake = FakeDockerClient()
+    fake.add_container("gluetun", id=GLUETUN_ID)
+    fake.add_container("dep", network_mode=f"container:{GLUETUN_ID}")
+
+    def http404(name: str, cmd: list[str]) -> ExecResult:
+        if cmd[:2] == ["ls", "/sys/class/net"]:
+            return ExecResult(0, "eth0\nlo\n")
+        if name == "gluetun":
+            return ExecResult(0, "  HTTP/1.1 200 OK\n")
+        return ExecResult(1, "  HTTP/1.1 404 Not Found\n")  # busybox 404
+
+    fake.on_exec = http404
+    cfg = Config(config_file=str(conf), gluetun_container="gluetun", dependent_container_failures=2)
+    mon = Monitor(fake, cfg, Logger(log_file=None, stream=io.StringIO()),
+                  rng=random.Random(0), sleep=lambda _s: None)
+    mon.run_once()
+    mon.run_once()
+    mon.run_once()
+    assert fake.restarted == []  # 404s never count
+    assert mon.dependent_failures.get("dep") == 0
+
+    # Case 2: dependent's DNS is broken — reaches threshold and is remediated.
+    fake2 = FakeDockerClient()
+    fake2.add_container("gluetun", id=GLUETUN_ID)
+    fake2.add_container("dep", network_mode=f"container:{GLUETUN_ID}")
+
+    def dnsfail(name: str, cmd: list[str]) -> ExecResult:
+        if cmd[:2] == ["ls", "/sys/class/net"]:
+            return ExecResult(0, "eth0\nlo\n")
+        if name == "gluetun":
+            return ExecResult(0, "  HTTP/1.1 200 OK\n")
+        return ExecResult(1, "wget: bad address 'site'\n")  # DNS failure
+
+    fake2.on_exec = dnsfail
+    mon2 = Monitor(fake2, cfg, Logger(log_file=None, stream=io.StringIO()),
+                   rng=random.Random(0), sleep=lambda _s: None)
+    mon2.run_once()
+    assert fake2.restarted == []  # 1/2
+    mon2.run_once()
+    assert fake2.restarted == ["dep"]  # 2/2 -> remediated


### PR DESCRIPTION
Reimplements gluetun-monitor as a Python package (docker-py) and adds the
dependent-aware health design for **issue #20**. Backward compatible: existing
env / `sites.conf` / compose work unchanged.

## Why
The #20 design (per-dependent state machine, restart-vs-recreate decision, and a
default-on non-destructive recreate that does container JSON surgery) is complex
and destructive-adjacent — hard to test in bash. Python + the docker-py SDK makes
the whole thing unit-testable. The connectivity test itself is unchanged
(`wget --spider` inside gluetun's netns, same exit-code map). See
[ADR-0007](docs/adr/0007-reimplement-in-python.md).

## What it fixes (#20)
The monitor no longer reports healthy while dependents (`network_mode:
service:gluetun`) are stranded loopback-only after gluetun is restarted/recreated.
Each loop it interface-checks every dependent and runs a per-dependent
connectivity+DNS viability probe (one shuffled resolvable name per dependent),
then remediates:
- **same gluetun id** → `docker restart` the dependent
- **gluetun recreated (id moved)** → **non-destructive recreate** — all mounts
  (named, bind, **anonymous** volumes) carried forward by source, old container
  removed *without* `-v`; disabled/denied → reported **FAILED**, not papered over.

## No-regressions gate
A characterization/differential suite executes the **actual legacy
`gluetun-monitor.sh` functions** and asserts the Python port matches them
(`trim`, `decode_wget_exit_code`, env defaults). The bash script stays in-tree as
that oracle and as the `:1` rollback anchor.

## Quality
- 151 tests passing, `ruff` clean, `mypy --strict` clean, ~85% coverage
- All Docker access behind one seam (`DockerClient` Protocol over docker-py);
  tests inject a fake — no daemon needed, including for the recreate path
- Image base → `python:3.13-slim` (docker-py talks the API directly; no docker
  CLI in the image). Socket-proxy permissions unchanged (recreate rides on `POST`)
- Verified: image builds; smoke-tested against the live daemon (Docker 29.1.3)
- CI adds a Python job (ruff/mypy/pytest); keeps shellcheck + bats for the legacy script

## New env vars
`DEPENDENT_CONTAINER_FAILURES` (= `FAIL_THRESHOLD`), `MAX_PARALLEL_CHECKS` (6),
`AUTO_RECREATE` (on), `DNS_WAIT_TIMEOUT` (30), `LOG_LEVEL` (INFO).

## Rollout (ROC)
Ships `:2` / `:latest` / `2.0.0`; `:1` stays pullable. Rollback = repin `:1`.

Closes #20.