### PR TITLE
Security: sanitize control chars from parsed endpoint log fields (#30)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+- Strip control characters from the country/city parsed out of gluetun's endpoint
+  logs before logging them (#30). That geo string comes from a third-party
+  IP-getter, so control chars / ANSI escapes in a malicious response could
+  otherwise reach the log file (cosmetic terminal-injection); Unicode place names
+  are preserved.
+
 ### Docs
 - Clarified the `sites.conf` live-reload contract (#33): "re-read every loop"
   reloads reliably only for **in-place** edits; with a single-file bind mount, an

--- a/gluetun_monitor/endpoint.py
+++ b/gluetun_monitor/endpoint.py
@@ -34,6 +34,16 @@ class EndpointInfo:
         )
 
 
+def _clean(value: str) -> str:
+    """Strip control characters from a value parsed out of (externally-influenced)
+    gluetun log text. The country/city come from a geo string a third-party
+    IP-getter service returns, so a malicious response could embed control chars /
+    ANSI escapes that would otherwise land in our log file (cosmetic log-spoofing).
+    Printable text — including Unicode like ``Zürich`` — is kept; controls dropped.
+    """
+    return "".join(ch for ch in value if ch.isprintable())
+
+
 def _last_match(pattern: re.Pattern[str], lines: list[str]) -> str | None:
     """The capture group of the last line matching ``pattern``, or None."""
     for line in reversed(lines):
@@ -65,7 +75,7 @@ def parse_endpoint(logs: str) -> EndpointInfo:
         if loc_match:
             # Drop the trailing " - source: ..." annotation, then split fields.
             location = loc_match.group(1).split(" - source:")[0]
-            fields = [f.strip() for f in location.split(",")]
+            fields = [_clean(f.strip()) for f in location.split(",")]
             if fields and fields[0]:
                 country = fields[0]
             if len(fields) > 1 and fields[1]:

--- a/tests/test_endpoint.py
+++ b/tests/test_endpoint.py
@@ -42,6 +42,23 @@ def test_parse_apostrophe_location_issue_17() -> None:
     assert info.city == "Provence-Alpes-Cote-d'Azur"
 
 
+def test_parse_strips_control_chars_from_location() -> None:
+    """The geo string comes from a third-party IP-getter, so control chars (CR,
+    tab, ESC, bell …) must be stripped before they reach the log — neutralizing
+    terminal-control injection — while legitimate Unicode (Zürich) is preserved.
+    (Any leftover *printable* bytes are harmless without the control char.)"""
+    # Use non-line-break controls (tab, ESC, bell): \r\n etc. are consumed by
+    # splitlines() before parsing, so they can't reach the field anyway.
+    line = (
+        "INFO [ip getter] Public IP address is 5.6.7.8 "
+        "(Switzer\tland, Z\x1b\x07ürich - source: x)"
+    )
+    info = parse_endpoint(line)
+    assert info.country == "Switzerland"  # tab stripped
+    assert info.city == "Zürich"          # ESC + bell stripped, Unicode kept
+    assert all(ch.isprintable() for ch in info.country + info.city)
+
+
 def test_parse_takes_last_ip_getter_line() -> None:
     """Logs accumulate; we report the *most recent* endpoint, not a stale one."""
     older = "INFO [ip getter] Public IP address is 1.1.1.1 (A, B, C - source: x)"


### PR DESCRIPTION
Strips non-printable chars from the country/city parsed out of gluetun's endpoint logs (a third-party geo string) before they're logged — neutralizing cosmetic terminal-injection. Unicode place names preserved; `public_ip`/`wg_server` are regex-numeric so already clean. Test covers tab/ESC/bell (the controls that survive `splitlines()`). Closes #30.