### PR TITLE
CI: pin dev toolchain + scoped Dependabot auto-merge (#23)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,8 +24,10 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
-      - name: Install package + dev tooling
-        run: pip install -e '.[dev]'
+      - name: Install package + pinned dev tooling
+        # requirements-dev.txt holds the exact dev-tool versions (Dependabot-tracked,
+        # auto-merged on green); the package itself comes from the local checkout.
+        run: pip install -e . -r requirements-dev.txt
 
       - name: Ruff (lint)
         run: ruff check gluetun_monitor tests

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,49 @@
+name: Dependabot auto-merge
+
+# Auto-approve + enable auto-merge for LOW-RISK Dependabot PRs only.
+#
+# "Auto-merge" still waits for every required status check (the 3.13/3.14 test
+# matrix, shellcheck, bats, build, integration) to go green — so a bump that
+# breaks anything fails its own CI and stays open for a human. This workflow only
+# widens *which already-green PRs* merge without a manual click; it never bypasses
+# the gate. (Requires repo "Allow auto-merge" + branch protection with required
+# checks — see issue #23 / CONTRIBUTING.)
+#
+# In scope (fast-tracked, patch + minor):
+#   • dev tooling — ruff / mypy / pytest / pytest-cov (pip, direct:development)
+#   • github-actions
+# Held for human review (never auto-merged):
+#   • any MAJOR bump
+#   • the runtime `docker` lib (pip, direct:production) — FakeDockerClient mocks
+#     it, so green CI ≠ runtime-safe until the real-daemon test (#24) lands
+#   • the Docker base image (python:3.x-slim) — a 3.x→3.y jump needs a CI-matrix
+#     change + manual validation (cf. #32), so it always gets eyes
+
+on: pull_request
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]'
+    steps:
+      - name: Fetch Dependabot metadata
+        id: meta
+        uses: dependabot/fetch-metadata@v2
+
+      - name: Approve + enable auto-merge (squash) for in-scope updates
+        if: >
+          (steps.meta.outputs.update-type == 'version-update:semver-patch' ||
+           steps.meta.outputs.update-type == 'version-update:semver-minor') &&
+          ((steps.meta.outputs.package-ecosystem == 'pip' &&
+            steps.meta.outputs.dependency-type == 'direct:development') ||
+           steps.meta.outputs.package-ecosystem == 'github_actions')
+        run: |
+          gh pr review --approve "$PR_URL"
+          gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### CI / tooling
+- Pinned dev toolchain in `requirements-dev.txt` (ruff/mypy/pytest/pytest-cov),
+  installed by CI for reproducible runs and tracked per-release by Dependabot (#23).
+- Scoped Dependabot auto-merge: low-risk bumps (dev tooling + github-actions,
+  patch/minor only) auto-merge **after** the full matrix passes; majors, the
+  runtime `docker` lib, and Docker base-image bumps still require human review (#23).
+
 ## [2.0.1] - 2026-06-04
 
 ### Changed

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -82,6 +82,25 @@ CI runs exactly these (plus a Docker build, an integration smoke test, and
 
 See [DEVELOPMENT.md](DEVELOPMENT.md) for architecture and deeper internals.
 
+## Dependency updates
+
+Dependabot opens PRs for the Python deps, GitHub Actions, and the Docker base
+image. The dev toolchain is pinned in `requirements-dev.txt` (CI's source of
+truth); the loose `[dev]` extras in `pyproject.toml` are for local installs.
+
+Low-risk bumps **auto-merge after the full required-check matrix passes** —
+nothing merges on red. Auto-merge is limited to dev tooling (ruff/mypy/pytest/
+pytest-cov) and GitHub Actions, patch/minor only. These always get a human:
+
+- any **major** version bump;
+- the runtime **`docker`** library — it's mocked by `FakeDockerClient`, so green
+  CI doesn't prove runtime safety until the real-daemon test (#24) lands;
+- the **Docker base image** (`python:3.x-slim`) — a feature-version jump needs a
+  CI-matrix change (cf. #32).
+
+`main` is branch-protected to require those checks; repo admins can still push
+docs directly.
+
 ## Reporting issues & feature requests
 
 Use the issue templates. Include sanitized logs and your environment (Docker

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,11 @@
+# Pinned dev toolchain — the source of truth for CI.
+#
+# Exact pins (not ranges) so CI is reproducible and Dependabot opens one PR per
+# tool release, which dependabot-auto-merge.yml fast-tracks on patch/minor once
+# the full matrix is green. The loose ranges in pyproject's [project.optional-
+# dependencies].dev stay for local "just give me something recent" installs;
+# this file is what CI installs.
+ruff==0.15.15
+mypy==2.1.0
+pytest==9.0.3
+pytest-cov==7.1.0


### PR DESCRIPTION
Closes #23 (code half — repo settings tracked in the issue until applied).

## What
- **`requirements-dev.txt`** — exact pins for ruff/mypy/pytest/pytest-cov. CI's
  source of truth: reproducible runs, and Dependabot opens one PR per release.
  The loose `[dev]` extras in `pyproject.toml` stay for local installs.
- **CI install** switched from `pip install -e '.[dev]'` to
  `pip install -e . -r requirements-dev.txt`.
- **`dependabot-auto-merge.yml`** — approves + enables auto-merge (squash) for
  low-risk bumps **only**.

## Auto-merge scope (deliberately narrow)
Auto-merge still **waits for every required check** (3.13/3.14 matrix, shellcheck,
bats, build, integration). It only removes the manual click on already-green,
low-risk PRs — it never bypasses the gate.

| Update | Auto-merge? |
|---|---|
| dev tooling (ruff/mypy/pytest/pytest-cov), patch/minor | ✅ |
| github-actions, patch/minor | ✅ |
| any **major** | ❌ human |
| runtime `docker` lib (pip direct:production) | ❌ human — mocked by FakeDockerClient until #24 |
| Docker base image (`python:3.x-slim`) | ❌ human — needs a matrix change (cf. #32) |

A breaking bump (e.g. a ruff minor that adds a lint rule we trip) fails its own CI
and stays open — auto-merge never completes.

## Repo settings still required (separate, admin)
For `--auto` to actually wait rather than no-op, the repo needs **Allow auto-merge**
on, plus **branch protection** on `main` requiring the matrixed checks. Applied
out-of-band; left tracked on #23 until done. (Configured to keep direct
docs-to-`main` pushes working — required checks gate PR merges, not admin pushes.)