### PR TITLE
Test: real-daemon integration test exercising docker-py paths (#24)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,8 +50,30 @@ jobs:
 
       - name: Pytest (incl. differential vs. legacy bash)
         # Floor is set below the current ~99% so a real regression fails the build
-        # without flaking on trivial churn.
-        run: pytest --cov=gluetun_monitor --cov-report=term-missing --cov-fail-under=95
+        # without flaking on trivial churn. `not integration` excludes the
+        # real-daemon suite (it runs in its own job below).
+        run: pytest -m "not integration" --cov=gluetun_monitor --cov-report=term-missing --cov-fail-under=95
+
+  pytest-integration:
+    name: Integration (real daemon, pytest)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.13"
+
+      - name: Install package + pinned dev tooling
+        run: pip install -e . -r requirements-dev.txt
+
+      - name: Run real-daemon integration tests
+        # ubuntu-latest ships a running dockerd, so these drive the real
+        # DockerPyClient — exec/inspect/restart and the non-destructive recreate
+        # (incl. volume survival) against a live daemon (issue #24). This is the
+        # bar that must stay green before docker-py minors may be auto-merged.
+        run: pytest -m integration -p no:cacheprovider
 
   shellcheck:
     name: Shellcheck (legacy script)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `pip-audit` now upgrades build tooling (pip/setuptools/wheel) before scanning, so
   a fresh advisory against the runner's own bundled pip can't fail the build on
   something we don't ship; only our real dependency tree gates CI.
+- Real-daemon integration test + CI job (#24): drives the actual `DockerPyClient`
+  (exec/inspect/restart + the non-destructive recreate, asserting a dependent's
+  volume data survives) against a live `dockerd`, so a docker-py regression turns CI
+  red. The unit job now deselects the `integration` marker.
 
 ### Dependencies
 - Bump `ruff` 0.15.15 → 0.15.16 (auto-merged).

--- a/tests/test_real_daemon.py
+++ b/tests/test_real_daemon.py
@@ -1,0 +1,149 @@
+"""Real-daemon integration test (issue #24).
+
+The unit suite runs against ``FakeDockerClient`` — it proves our *logic*, not that
+docker-py still behaves the way we assume. This module drives the real
+``DockerPyClient`` against a live ``dockerd`` (as CI provides), exercising every
+docker-py path the monitor depends on: ``ping`` / ``list_running_ids`` / ``inspect``
+/ ``exec_run`` / ``logs`` / ``restart``, and the non-destructive recreate
+(``remove`` without volumes → ``create_from_config`` → ``start``).
+
+The marquee assertion is ADR-0005's data-preservation guarantee: a dependent's
+named volume — and the data in it — survives the recreate. A docker-py regression
+in any of these paths turns this red, which is the bar issue #24 sets before
+docker-py minors may be auto-merged.
+
+Marked ``integration``; the unit job deselects it (``-m "not integration"``). Run it
+against a daemon with ``pytest -m integration``. It self-skips if none is reachable.
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import Iterator
+from typing import Any
+
+import pytest
+
+from gluetun_monitor.docker_client import DockerPyClient
+from gluetun_monitor.logging_setup import Logger
+from gluetun_monitor.recreate import recreate_dependent
+
+# docker-py is a runtime dependency, so import (not skip) — but a missing daemon
+# skips at the fixture level below.
+docker = pytest.importorskip("docker")
+
+pytestmark = pytest.mark.integration
+
+# Tiny, ubiquitous image: busybox provides sh/cat for the exec + volume checks.
+IMAGE = "alpine:3"
+SENTINEL = "gluetun-monitor-survives-recreate"
+
+
+@pytest.fixture(scope="module")
+def client() -> DockerPyClient:
+    """A real ``DockerPyClient``, or skip the whole module if no daemon answers."""
+    try:
+        c = DockerPyClient(timeout=30)
+        if not c.ping():
+            pytest.skip("no reachable Docker daemon")
+    except Exception as exc:  # docker-py import/connect failure
+        pytest.skip(f"Docker unavailable: {exc}")
+    return c
+
+
+@pytest.fixture
+def world(client: DockerPyClient) -> Iterator[dict[str, Any]]:
+    """Bring up a gluetun-like netns owner + a dependent sharing it, with a named
+    volume holding nothing yet. Everything is torn down afterward (force-remove)."""
+    raw = docker.from_env()
+    suffix = uuid.uuid4().hex[:8]
+    gluetun = f"gm-it-gluetun-{suffix}"
+    gluetun2 = f"gm-it-gluetun2-{suffix}"
+    dep = f"gm-it-dep-{suffix}"
+    vol = f"gm-it-vol-{suffix}"
+
+    raw.images.pull(IMAGE)
+    raw.volumes.create(vol)
+    g1 = raw.containers.run(IMAGE, ["sleep", "3600"], detach=True, name=gluetun)
+    raw.containers.run(
+        IMAGE,
+        ["sleep", "3600"],
+        detach=True,
+        name=dep,
+        network_mode=f"container:{g1.id}",
+        volumes={vol: {"bind": "/data", "mode": "rw"}},
+    )
+    try:
+        yield {
+            "client": client,
+            "raw": raw,
+            "gluetun": gluetun,
+            "gluetun2": gluetun2,
+            "dep": dep,
+            "vol": vol,
+            "g1_id": g1.id,
+        }
+    finally:
+        for name in (dep, gluetun, gluetun2):
+            try:
+                raw.containers.get(name).remove(force=True)
+            except Exception:
+                pass
+        try:
+            raw.volumes.get(vol).remove(force=True)
+        except Exception:
+            pass
+
+
+def test_real_docker_paths_and_volume_survives_recreate(world: dict[str, Any]) -> None:
+    """End to end against a real daemon: probe → restart → recreate, asserting the
+    volume's data survives the (volumes=False) remove inside the recreate."""
+    client: DockerPyClient = world["client"]
+    raw = world["raw"]
+    dep = world["dep"]
+    g1_id = world["g1_id"]
+
+    # ping / list_running_ids
+    assert client.ping() is True
+    assert g1_id in client.list_running_ids()
+
+    # inspect: the dependent shares gluetun's netns
+    info = client.inspect(dep)
+    assert info is not None
+    assert info.running
+    assert info.network_mode == f"container:{g1_id}"
+    original_dep_id = info.id
+
+    # exec_run: write then read a sentinel into the named volume
+    write = client.exec_run(dep, ["sh", "-c", f"echo {SENTINEL} > /data/sentinel"])
+    assert write.exit_code == 0, write.output
+    read = client.exec_run(dep, ["cat", "/data/sentinel"])
+    assert read.exit_code == 0
+    assert SENTINEL in read.output
+
+    # logs: smoke — decodes to text without error
+    assert isinstance(client.logs(world["gluetun"]), str)
+
+    # restart preserves identity (same container id) and never touches the volume
+    client.restart(dep)
+    after_restart = client.inspect(dep)
+    assert after_restart is not None
+    assert after_restart.id == original_dep_id
+    assert SENTINEL in client.exec_run(dep, ["cat", "/data/sentinel"]).output
+
+    # --- simulate a gluetun recreate: a NEW netns owner with a new id ---
+    g2 = raw.containers.run(IMAGE, ["sleep", "3600"], detach=True, name=world["gluetun2"])
+
+    assert recreate_dependent(client, dep, g2.id, Logger(level="DEBUG")) is True
+
+    # the dependent is back, re-homed onto the new gluetun, and is a NEW container
+    rehomed = client.inspect(dep)
+    assert rehomed is not None
+    assert rehomed.running
+    assert rehomed.network_mode == f"container:{g2.id}"
+    assert rehomed.id != original_dep_id
+
+    # THE GUARANTEE (ADR-0005): the volume and its data survived remove+recreate.
+    survived = client.exec_run(dep, ["cat", "/data/sentinel"])
+    assert survived.exit_code == 0
+    assert SENTINEL in survived.output


### PR DESCRIPTION
Closes #24.

## What
A real-daemon integration test that drives the **actual `DockerPyClient`** — not `FakeDockerClient` — against a live `dockerd`, so a docker-py regression in the paths we depend on turns CI red.

`tests/test_real_daemon.py` (marked `integration`):
1. Brings up a gluetun-like netns owner + a dependent sharing its namespace, with a **named volume**.
2. Exercises every docker-py path the monitor uses: `ping`, `list_running_ids`, `inspect`, `exec_run` (write+read), `logs`, `restart` (asserts identity preserved).
3. Simulates a gluetun recreate (new netns owner, new id) and runs the **non-destructive recreate** (`remove` without volumes → `create_from_config` → `start`).
4. **Marquee assertion (ADR-0005):** the dependent's volume data survives the recreate.

## CI
- New job **"Integration (real daemon, pytest)"** runs `pytest -m integration` against the runner's live dockerd.
- Unit job now deselects it (`-m "not integration"`); the test self-skips when no daemon is reachable, so local `pytest` stays daemon-free.

## Why it matters
This is the confidence bar #24 sets: today docker-py is **excluded from auto-merge** because `FakeDockerClient` mocks it (green CI ≠ runtime-safe). Once this job reliably catches a docker-py regression, promoting docker-py (pip `direct:production`, patch/minor) into auto-merge becomes safe.

**Follow-up (intentionally not in this PR):** after this job has proven green a couple of times, add it to branch-protection required checks and widen the auto-merge scope to include docker-py. Earn confidence first.