### PR TITLE
CI: promote docker-py into Dependabot auto-merge (#24)

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -16,11 +16,12 @@ name: Dependabot auto-merge
 #
 # In scope (fast-tracked, patch + minor):
 #   • dev tooling — ruff / mypy / pytest / pytest-cov (pip, direct:development)
+#   • the runtime `docker` lib (pip, direct:production) — promoted once the
+#     real-daemon integration job (#24, a required check) made a docker-py
+#     regression turn CI red; green now means runtime-safe
 #   • github-actions
 # Held for human review (never auto-merged):
 #   • any MAJOR bump
-#   • the runtime `docker` lib (pip, direct:production) — FakeDockerClient mocks
-#     it, so green CI ≠ runtime-safe until the real-daemon test (#24) lands
 #   • the Docker base image (python:3.x-slim) — a 3.x→3.y jump needs a CI-matrix
 #     change + manual validation (cf. #32), so it always gets eyes
 
@@ -44,7 +45,8 @@ jobs:
           (steps.meta.outputs.update-type == 'version-update:semver-patch' ||
            steps.meta.outputs.update-type == 'version-update:semver-minor') &&
           ((steps.meta.outputs.package-ecosystem == 'pip' &&
-            steps.meta.outputs.dependency-type == 'direct:development') ||
+            (steps.meta.outputs.dependency-type == 'direct:development' ||
+             steps.meta.outputs.dependency-type == 'direct:production')) ||
            steps.meta.outputs.package-ecosystem == 'github_actions')
         run: gh pr merge --auto --squash "$PR_URL"
         env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (exec/inspect/restart + the non-destructive recreate, asserting a dependent's
   volume data survives) against a live `dockerd`, so a docker-py regression turns CI
   red. The unit job now deselects the `integration` marker.
+- Promoted the runtime `docker` lib into Dependabot auto-merge (patch/minor), now
+  that the real-daemon job (a required check) gates it. Pinned `docker==7.1.0` in
+  `pyproject.toml` so the image build is reproducible and Dependabot tracks it
+  per-release; majors (8.x) still require a human.
 
 ### Dependencies
 - Bump `ruff` 0.15.15 → 0.15.16 (auto-merged).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -89,12 +89,13 @@ image. The dev toolchain is pinned in `requirements-dev.txt` (CI's source of
 truth); the loose `[dev]` extras in `pyproject.toml` are for local installs.
 
 Low-risk bumps **auto-merge after the full required-check matrix passes** —
-nothing merges on red. Auto-merge is limited to dev tooling (ruff/mypy/pytest/
-pytest-cov) and GitHub Actions, patch/minor only. These always get a human:
+nothing merges on red. Auto-merge covers (patch/minor only): dev tooling
+(ruff/mypy/pytest/pytest-cov), GitHub Actions, and the runtime **`docker`**
+library — the last is safe to auto-merge because the real-daemon integration job
+(#24, a required check) turns CI red on a docker-py regression. These always get a
+human:
 
 - any **major** version bump;
-- the runtime **`docker`** library — it's mocked by `FakeDockerClient`, so green
-  CI doesn't prove runtime safety until the real-daemon test (#24) lands;
 - the **Docker base image** (`python:3.x-slim`) — a feature-version jump needs a
   CI-matrix change (cf. #32).
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,11 @@ requires-python = ">=3.13"
 authors = [{ name = "Charles Marshall" }]
 keywords = ["gluetun", "vpn", "docker", "monitoring", "healthcheck"]
 dependencies = [
-    "docker>=7.0,<8",
+    # Exact pin (not a range): the image installs straight from here, so pinning
+    # makes builds reproducible AND gives Dependabot a per-release target. docker-py
+    # bumps are gated by the real-daemon integration job (#24) and auto-merged on
+    # green (patch/minor); a major (8.x) still gets a human.
+    "docker==7.1.0",
 ]
 
 [project.urls]


### PR DESCRIPTION
Follow-up to #40 (#24): now that the real-daemon integration job catches docker-py regressions, promote the runtime `docker` lib from human-review into auto-merge.

## Changes
- **Auto-merge scope** widened to pip `direct:production` (patch/minor) — i.e. the `docker` lib — alongside dev tooling and github-actions.
- **`docker==7.1.0` pin** in `pyproject.toml` (was `>=7,<8`). Dependabot never opens within-range PRs, so the range made the promotion symbolic; the image installs straight from `pyproject`, so an exact pin makes builds reproducible *and* gives Dependabot a per-release target. `7.1.0` is what the range already resolved to — **no behavior change**.
- **`Integration (real daemon, pytest)` is now a required check** on `main`, so auto-merge waits on it (a docker-py bump that breaks the real paths can't merge).
- CONTRIBUTING + CHANGELOG updated.

## Still human-only
- any **major** bump (incl. docker 8.x);
- the Docker **base image** (`python:3.x-slim`).

## Net effect
A docker-py patch/minor now flows: Dependabot PR → matrix + real-daemon job run against the new docker-py → green → auto-merge; red → held.