### PR TITLE
Feature: opt-in Apprise notification layer (#22)

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -16,9 +16,10 @@ name: Dependabot auto-merge
 #
 # In scope (fast-tracked, patch + minor):
 #   • dev tooling — ruff / mypy / pytest / pytest-cov (pip, direct:development)
-#   • the runtime `docker` lib (pip, direct:production) — promoted once the
-#     real-daemon integration job (#24, a required check) made a docker-py
-#     regression turn CI red; green now means runtime-safe
+#   • the runtime prod libs (pip, direct:production): `docker` and `apprise` —
+#     each is exercised for real by a required check (docker by the real-daemon
+#     job #24; apprise by the localhost-sink test #22), so a regression turns CI
+#     red and green means runtime-safe
 #   • github-actions
 # Held for human review (never auto-merged):
 #   • any MAJOR bump

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Opt-in notification layer (#22, ADR-0010).** Set `APPRISE_URLS` to push
+  significant events out-of-band via [Apprise](https://github.com/caronc/apprise)
+  (ntfy/Discord/Telegram/email/webhook/… — 100+ backends): gluetun restart, recovery
+  failure / restart-ineffective, dependent remediation success/failure, the
+  flaky-site advisory, and refusal to start. Filtered by `NOTIFY_MIN_LEVEL`
+  (default WARN), throttled per event by `NOTIFY_THROTTLE` (default 1h), and bounded
+  off the loop by `NOTIFY_TIMEOUT` (default 10s). Unset = disabled (drop-in, no
+  behavior change). `gluetun-monitor --notify-test` verifies your configuration.
+
 ### CI / tooling
 - Pinned dev toolchain in `requirements-dev.txt` (ruff/mypy/pytest/pytest-cov),
   installed by CI for reproducible runs and tracked per-release by Dependabot (#23).
@@ -24,6 +34,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   that the real-daemon job (a required check) gates it. Pinned `docker==7.1.0` in
   `pyproject.toml` so the image build is reproducible and Dependabot tracks it
   per-release; majors (8.x) still require a human.
+- `apprise` ships pinned (`==1.11.0`) and validated by a real-library localhost-sink
+  test (a required check), so it joins `docker` as an auto-merge-eligible prod dep
+  (patch/minor); majors still require a human (#22).
 
 ### Dependencies
 - Bump `ruff` 0.15.15 → 0.15.16 (auto-merged).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -90,10 +90,11 @@ truth); the loose `[dev]` extras in `pyproject.toml` are for local installs.
 
 Low-risk bumps **auto-merge after the full required-check matrix passes** —
 nothing merges on red. Auto-merge covers (patch/minor only): dev tooling
-(ruff/mypy/pytest/pytest-cov), GitHub Actions, and the runtime **`docker`**
-library — the last is safe to auto-merge because the real-daemon integration job
-(#24, a required check) turns CI red on a docker-py regression. These always get a
-human:
+(ruff/mypy/pytest/pytest-cov), GitHub Actions, and the runtime libraries
+**`docker`** and **`apprise`** — those last two are safe to auto-merge because each
+is exercised for real by a required check (docker by the real-daemon integration
+job #24, apprise by the localhost-sink test #22), so a regression turns CI red.
+These always get a human:
 
 - any **major** version bump;
 - the **Docker base image** (`python:3.x-slim`) — a feature-version jump needs a

--- a/README.md
+++ b/README.md
@@ -193,6 +193,10 @@ docker compose up -d
 | `LOG_BACKUP_COUNT` | `5` | How many rotated log backups to keep (≈60 MB total at defaults) |
 | `LOG_FILE` | `/logs/gluetun-monitor.log` | Path to the log file inside the `/logs` mount. Logs always go to stdout (`docker logs`) too; if this path isn't writable the monitor degrades to stdout-only rather than failing |
 | `TZ` | `UTC` | Timezone for log timestamps |
+| `APPRISE_URLS` | *(unset → off)* | Comma-separated [Apprise](https://github.com/caronc/apprise) URLs to push events to (ntfy/Discord/Telegram/email/webhook/…). Unset = notifications disabled. See [Notifications](#notifications) |
+| `NOTIFY_MIN_LEVEL` | `WARN` | Minimum severity to push: `INFO`, `WARN`, or `ERROR`. See [Notifications](#notifications) |
+| `NOTIFY_THROTTLE` | `3600` | Per-event throttle (seconds): at most one notification per event key per window; `0` disables throttling. See [Notifications](#notifications) |
+| `NOTIFY_TIMEOUT` | `10` | Max seconds to wait for a notification send before carrying on (sends run off the loop, so a slow backend can't stall the watchdog). See [Notifications](#notifications) |
 
 ### Configuration is validated — sane defaults, but bad config is fatal
 
@@ -540,6 +544,48 @@ successful poll for the site's whole life, so you get a lifetime baseline rather
 than just "recently." `--json` includes both windows (`latency_ms` and
 `lifetime_latency_ms`). Exact avg/min/max are kept either way; only the percentiles
 are approximate.
+
+## Notifications
+
+By default the monitor is **log-only**. Set `APPRISE_URLS` to also push significant
+events out-of-band via [Apprise](https://github.com/caronc/apprise) — one library,
+100+ backends (ntfy, Discord, Telegram, Slack, email, Pushover, Gotify, generic
+webhook, …), all configured by URL. Unset = disabled, so this is fully opt-in.
+
+```yaml
+    environment:
+      # One or more comma-separated Apprise URLs. Examples:
+      - APPRISE_URLS=ntfy://ntfy.example.com/gluetun
+      # - APPRISE_URLS=ntfy://host/topic,discord://webhook_id/webhook_token
+      - NOTIFY_MIN_LEVEL=WARN   # INFO | WARN | ERROR (default WARN)
+```
+
+**What gets pushed** (each at the noted severity; below `NOTIFY_MIN_LEVEL` is
+suppressed):
+
+| Event | Level |
+|-------|-------|
+| gluetun restart triggered | WARN |
+| gluetun **recovery failed** / still failing after restart (can't come up) | ERROR |
+| dependent remediated (restart/recreate) | WARN |
+| dependent **remediation failed** | ERROR |
+| **flaky-site advisory** (one site keeps causing restarts) | WARN |
+| refused to start (bad config / Docker unreachable / gluetun missing) | ERROR |
+
+Notifications are **best-effort and never affect monitoring** (Tenet 7): a send is
+filtered by `NOTIFY_MIN_LEVEL`, throttled per event by `NOTIFY_THROTTLE` (so a
+persistent fault notifies once, not every loop), run off the loop bounded by
+`NOTIFY_TIMEOUT`, and any failure is swallowed (logged at `DEBUG`). Apprise URLs
+carry tokens and are never logged.
+
+Verify your setup without waiting for a real event:
+
+```bash
+docker exec gluetun-monitor gluetun-monitor --notify-test
+```
+
+See [ADR-0010](docs/adr/0010-notification-layer.md) for the design and the full
+[Apprise URL list](https://github.com/caronc/apprise/wiki) for backends.
 
 ## Docker Compose Example
 

--- a/docker-compose.yml.example
+++ b/docker-compose.yml.example
@@ -88,6 +88,15 @@ services:
       # - ADVISORY_WINDOW=86400      # seconds (24h)
       # - ADVISORY_MIN_RESTARTS=5
       # - ADVISORY_DOMINANCE=0.5     # one site causing >=50% of recent restarts -> flag it
+      # --- Notifications (opt-in; unset = log-only, no outbound traffic) ---
+      # Comma-separated Apprise URLs to push significant events (restart, recovery
+      # failure, dependent remediation, flaky-site advisory, refusal to start).
+      # 100+ backends; see https://github.com/caronc/apprise/wiki
+      # - APPRISE_URLS=ntfy://ntfy.example.com/gluetun,discord://webhook_id/webhook_token
+      # - NOTIFY_MIN_LEVEL=WARN      # INFO | WARN | ERROR (minimum severity to push)
+      # - NOTIFY_THROTTLE=3600       # seconds; at most one push per event key per window (0=off)
+      # - NOTIFY_TIMEOUT=10          # seconds to wait for a send before carrying on (off the loop)
+      # Verify with:  docker exec gluetun-monitor gluetun-monitor --notify-test
       # Recreate a dependent stranded by a gluetun recreate (id changed); 0 disables
       # - AUTO_RECREATE=1
       # Seconds to wait for gluetun DNS to stabilize after a restart

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -2,25 +2,17 @@
 
 Future work not yet scheduled. Items here are candidates, not commitments.
 
-## Notification layer
-A pluggable way to **announce** monitor events to the outside world — fired from
-the **FAILED state** (ADR-0006) and optionally on recovery/endpoint-change.
+## Notification layer — ✅ shipped (ADR-0010)
+Implemented as an opt-in [Apprise](https://github.com/caronc/apprise) layer:
+`APPRISE_URLS` unset = disabled (drop-in); set = significant events
+(gluetun restart, recovery failure, dependent remediation, the flaky-site advisory,
+refusal to start) are pushed to any of 100+ backends, filtered by `NOTIFY_MIN_LEVEL`
+and throttled per event. Best-effort (Tenet 7) and `--notify-test` to verify a URL.
+See ADR-0010 and the README "Notifications" section.
 
-- Decouple *what happened* (the monitor's state machine) from *how it's announced*.
-- **Leverage a standard, maintained Python library rather than hand-rolling
-  senders.** [Apprise](https://github.com/caronc/apprise) is the strong default:
-  one well-supported dependency covers 100+ targets (ntfy, Slack, Discord,
-  Telegram, email, generic webhook, …) behind a single URL-string API — a natural
-  fit for "opt-in URL(s) via env." Hand-written senders per service are exactly
-  the bespoke surface we'd avoid (cf. ADR-0007: use the SDK, don't reinvent).
-- Triggers to consider: entering FAILED, recovering from FAILED, gluetun endpoint
-  change, dependent recreated.
-- Config: opt-in URL(s) via env; quiet by default (no surprise outbound traffic).
-- Why backlog: it's a separate, sizeable feature surface; the **FAILED state** in
-  ADR-0006 is the natural trigger point and is the only prerequisite. Until it
-  lands, FAILED surfaces only as a **loud ERROR log** — there is no separate
-  machine-readable health surface (no HTTP endpoint, no container `HEALTHCHECK`);
-  exposing one could be a follow-up to this item.
+Possible follow-ups: a machine-readable health surface (HTTP endpoint / container
+`HEALTHCHECK`) distinct from the outbound notifications; more event types behind
+the same contract.
 
 ## Portable injected viability probe
 Today the per-dependent viability probe execs the dependent's **own** `wget`,

--- a/docs/adr/0010-notification-layer.md
+++ b/docs/adr/0010-notification-layer.md
@@ -1,0 +1,68 @@
+# ADR-0010: Opt-in external notification layer via Apprise
+
+- **Status:** Accepted
+- **Date:** 2026-06-05
+- **Relates to:** ADR-0008 (flaky-site advisory — its log line is now also pushable),
+  Tenet 7 (best-effort, non-blocking), Tenet 8 (safe, additive defaults)
+
+## Context
+Every "alert" and the flaky-site "advisory" were **log lines only**. Significant,
+infrequent events — gluetun restarted, a restart that did **not** bring gluetun back
+(stuck/can't-come-up), a dependent remediated or failed, a site that keeps causing
+restarts, a refusal to start on bad config — are exactly the things an operator
+wants pushed out-of-band, not discovered later by grepping a log.
+
+This matters more now that the dependency pipeline auto-merges and we are weighing
+auto-release (the deferred #26): set-and-forget shipping is only defensible if a
+human is told when something goes wrong. The notification channel is that safety
+net, so it lands first.
+
+## Decision
+Add an **opt-in** notification layer built on
+[Apprise](https://github.com/caronc/apprise) (one dependency, 100+ backends —
+ntfy/Discord/Telegram/email/Pushover/Gotify/webhook/… — all configured by URL).
+
+- **Drop-in:** `APPRISE_URLS` unset → a `NullNotifier` (no-op). Zero behavior change;
+  the monitor stays a log-only tool unless you opt in. (Tenet 8.)
+- **The seam mirrors ADR-0007's Docker seam:** a `Notifier` Protocol with
+  `NullNotifier` (disabled), `AppriseNotifier` (real, apprise imported lazily), and
+  a `FakeNotifier` in tests. The monitor fires `NotifyEvent`s; it never imports
+  apprise directly.
+- **Event contract** (the stable surface): `gluetun-restart` (WARN),
+  `gluetun-recovery-failed` / `gluetun-restart-ineffective` (ERROR),
+  `dependent-remediated:<name>` (WARN) / `dependent-failed:<name>` (ERROR),
+  `advisory:<site>` (WARN), `refused-*` (ERROR). Filtered by `NOTIFY_MIN_LEVEL`
+  (default WARN) and throttled per event key by `NOTIFY_THROTTLE` (default 1h) so a
+  persistent fault notifies once, not every loop — mirroring the in-log dedup.
+- **Best-effort, non-blocking (Tenet 7):** every send is wrapped, level-filtered,
+  throttled, and on any failure swallowed + logged at DEBUG. A notification problem
+  can only ever degrade notifications — it can never touch the monitoring loop or
+  restart/remediation behavior. Apprise URLs carry tokens and are never logged.
+  Apprise's `notify()` is synchronous, so sends run on a daemon thread bounded by
+  `NOTIFY_TIMEOUT` (default 10s): a slow or hung backend can't stall the watchdog.
+- **Following Apprise's idioms:** one reused `Apprise()` instance (not per-send),
+  branded with an `AppriseAsset` (`gluetun-monitor`), `add()` return values checked,
+  the official `notify_type` values used, and apprise's own logger quieted so a
+  DEBUG run stays clean.
+- **`--notify-test`** sends a one-off test notification so an operator can verify
+  their URL without waiting for a real event.
+
+## Consequences
+- Apprise becomes a second pinned runtime dependency. To keep it from being an
+  unvalidated auto-merge (the trap docker-py had under `FakeDockerClient`), CI
+  exercises the **real** library end to end against a localhost HTTP sink — if an
+  apprise update broke the parse/dispatch path we use, CI goes red. That test runs
+  in the normal (required) test job, so it gates auto-merge. With it, apprise
+  patch/minor are safe to auto-merge on the same principle as docker-py: *a
+  dependency may auto-merge once CI genuinely exercises it.* Majors still get a human.
+- The advisory/alert log lines are unchanged; this is purely an **additional**
+  outward channel (ADR-0008's "advise a human" made external). It does **not** change
+  any restart/remediation decision.
+
+## Alternatives considered
+- **A specific backend (ntfy/Discord) directly.** Rejected: locks users to one
+  service; Apprise is one dependency for all of them, by URL.
+- **Optional extra (`pip install …[notify]`).** Rejected: the primary artifact is a
+  Docker image, and "set `APPRISE_URLS` and it works" requires apprise in the image.
+- **A webhook-only callout we write ourselves.** Rejected: re-implements a fraction
+  of Apprise (retries, 100+ schemas) for no gain.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -38,3 +38,4 @@ Format: [`_template.md`](_template.md). Status ∈ Proposed | Accepted | Superse
 | [0007](0007-reimplement-in-python.md) | Reimplement the monitor in Python (v2.0.0) — docker-py seam, characterization + differential no-regressions gate | Accepted |
 | [0008](0008-persistent-site-stats-and-advisory.md) | Persistent per-site stats + a flaky-site advisory (keep restart-first; record + advise, don't auto-quarantine) | Accepted |
 | [0009](0009-all-time-latency-histogram.md) | All-time latency percentiles via a bounded DDSketch-style histogram (lifetime view alongside the recent ring) | Accepted |
+| [0010](0010-notification-layer.md) | Opt-in external notification layer via Apprise (drop-in when unset; best-effort; real-library CI test gates auto-merge) | Accepted |

--- a/gluetun_monitor/cli.py
+++ b/gluetun_monitor/cli.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import argparse
 import signal
 import sys
 from types import FrameType
@@ -11,6 +12,7 @@ from .dependents import parse_csv_names
 from .docker_client import DockerClient, DockerPyClient
 from .logging_setup import Logger, install_bash_format_on_root
 from .monitor import Monitor
+from .notify import Notifier, NotifyEvent, build_notifier
 from .sites import load_sites_report
 
 
@@ -122,11 +124,38 @@ def _announce_banner(config: Config, logger: Logger) -> None:
         )
 
 
-def main() -> int:
+def _parse_args(argv: list[str] | None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        prog="gluetun-monitor",
+        description="Dependent-aware connectivity monitor and self-healer for gluetun VPN stacks",
+    )
+    parser.add_argument(
+        "--notify-test",
+        action="store_true",
+        help="send a test notification to APPRISE_URLS and exit (verifies your config)",
+    )
+    return parser.parse_args(argv)
+
+
+def _run_notify_test(config: Config, notifier: Notifier, logger: Logger) -> int:
+    """Send a one-off test notification and report the outcome."""
+    if not config.apprise_urls:
+        logger.error("APPRISE_URLS is not set — there is nothing to test")
+        return 1
+    logger.info(f"Sending a test notification to {len(config.apprise_urls)} configured URL(s)...")
+    if notifier.test():
+        logger.info("Test notification sent successfully")
+        return 0
+    logger.error("Test notification failed to send — check the Apprise URL/scheme (DEBUG logs)")
+    return 1
+
+
+def main(argv: list[str] | None = None) -> int:
     """Build config + logger + Docker client, check prerequisites, run the loop.
 
     Returns a process exit code: 0 on clean shutdown, 1 if startup fails.
     """
+    args = _parse_args(argv)
     config = Config.from_env()
     logger = Logger(
         log_file=config.log_file,
@@ -135,6 +164,13 @@ def main() -> int:
         backup_count=config.log_backup_count,
     )
     install_bash_format_on_root()  # make stray docker-py/urllib3 logs match our format
+    # Opt-in notifications (#22). Built early so the "refused to start" paths below
+    # can alert too; NullNotifier (no-op) unless APPRISE_URLS is configured.
+    notifier = build_notifier(config, logger)
+
+    if args.notify_test:
+        return _run_notify_test(config, notifier, logger)
+
     _install_signal_handlers(logger)
     _announce_banner(config, logger)
 
@@ -142,18 +178,30 @@ def main() -> int:
         for err in config.errors:
             logger.error(err)
         logger.error("Refusing to start due to invalid configuration")
+        notifier.notify(NotifyEvent(
+            "ERROR", "gluetun-monitor refused to start",
+            "Invalid configuration: " + "; ".join(config.errors), key="refused-config",
+        ))
         return 1
 
     try:
         client: DockerClient = DockerPyClient(timeout=max(config.timeout * 2, 60))
     except Exception as exc:
         logger.error(f"Failed to initialize Docker client: {exc}")
+        notifier.notify(NotifyEvent(
+            "ERROR", "gluetun-monitor refused to start",
+            f"Failed to initialize the Docker client: {exc}", key="refused-docker",
+        ))
         return 1
 
     if not check_prerequisites(client, config, logger):
+        notifier.notify(NotifyEvent(
+            "ERROR", "gluetun-monitor refused to start",
+            "Prerequisite check failed — see the logs for the specific cause.", key="refused-prereq",
+        ))
         return 1
 
-    monitor = Monitor(client, config, logger)
+    monitor = Monitor(client, config, logger, notifier=notifier)
     monitor.announce()
     monitor.run()
     return 0

--- a/gluetun_monitor/config.py
+++ b/gluetun_monitor/config.py
@@ -153,6 +153,18 @@ class Config:
     advisory_min_restarts: int = 5
     advisory_dominance: float = 0.5
 
+    # --- Opt-in notification layer (issue #22, ADR-0010) ---
+    # Comma-separated Apprise URLs (ntfy/Discord/Telegram/email/webhook/…).
+    # Unset/empty = notifications disabled = today's log-only behavior (drop-in).
+    apprise_urls: tuple[str, ...] = ()
+    # Minimum severity to push (INFO/WARN/ERROR); default WARN.
+    notify_min_level: str = "WARN"
+    # Per-event-key throttle in seconds (one send per key per window); 0 = no throttle.
+    notify_throttle: int = 3600
+    # Max seconds to wait for a notification send before carrying on (it runs off the
+    # monitoring loop, so a slow/hung backend can't stall the watchdog). Tenet 7.
+    notify_timeout: int = 10
+
     # Fatal config errors (malformed env values), collected during from_env and
     # surfaced by the CLI once the logger exists — the CLI then refuses to start.
     # Not an env var.
@@ -182,6 +194,12 @@ class Config:
         if log_level not in _VALID_LOG_LEVELS:
             errors.append(
                 f"Invalid LOG_LEVEL={log_level!r}: expected one of {sorted(_VALID_LOG_LEVELS)}"
+            )
+        notify_min_level = os.environ.get("NOTIFY_MIN_LEVEL", "WARN").upper()
+        if notify_min_level not in _VALID_LOG_LEVELS:
+            errors.append(
+                f"Invalid NOTIFY_MIN_LEVEL={notify_min_level!r}: "
+                f"expected one of {sorted(_VALID_LOG_LEVELS)}"
             )
         return cls(
             config_file=os.environ.get("CONFIG_FILE", "/config/sites.conf"),
@@ -217,5 +235,11 @@ class Config:
             advisory_min_restarts=_env_int("ADVISORY_MIN_RESTARTS", 5, errors, minimum=1),
             advisory_dominance=_env_float("ADVISORY_DOMINANCE", 0.5, errors,
                                           minimum=0.0, maximum=1.0),
+            apprise_urls=tuple(
+                u.strip() for u in os.environ.get("APPRISE_URLS", "").split(",") if u.strip()
+            ),
+            notify_min_level=notify_min_level,
+            notify_throttle=_env_int("NOTIFY_THROTTLE", 3600, errors, minimum=0),
+            notify_timeout=_env_int("NOTIFY_TIMEOUT", 10, errors, minimum=1),
             errors=tuple(errors),
         )

--- a/gluetun_monitor/monitor.py
+++ b/gluetun_monitor/monitor.py
@@ -29,6 +29,7 @@ from .dependents import (
 )
 from .dns_check import DnsResult, DnsStatus, validate_dns
 from .endpoint import get_endpoint_info
+from .notify import Notifier, NotifyEvent, NullNotifier
 from .recovery import remediate_dependent, restart_gluetun
 from .site_stats import SiteStatsStore, format_window
 from .sites import hostname_of, ip_pool, is_ip_literal, load_sites, resolvable_pool
@@ -80,10 +81,14 @@ class Monitor:
         rng: random.Random | None = None,
         sleep: Sleep = time.sleep,
         stats: SiteStatsStore | None = None,
+        notifier: Notifier | None = None,
     ) -> None:
         self.client = client
         self.config = config
         self.log = logger
+        # Opt-in external notifications (#22). Default = NullNotifier (no-op), so
+        # nothing changes unless APPRISE_URLS is configured and a notifier injected.
+        self.notifier = notifier if notifier is not None else NullNotifier()
         self._rng = rng if rng is not None else random.Random()
         # _probe_dependent runs across a ThreadPoolExecutor (_fan_out), and a
         # random.Random instance is not thread-safe — concurrent sample()/uniform()
@@ -109,6 +114,10 @@ class Monitor:
         self._warned_orphans: set[str] = set()
         # Dedup for "can't validate DNS (no usable tool)" — re-armed if it later validates.
         self._warned_dns_unvalidated: set[str] = set()
+
+    def _notify(self, level: str, title: str, body: str, key: str) -> None:
+        """Push one event to the (opt-in) notifier. Best-effort; never raises."""
+        self.notifier.notify(NotifyEvent(level=level, title=title, body=body, key=key))
 
     # ----- gluetun root test (nodes 2-3) -----
 
@@ -442,6 +451,20 @@ class Monitor:
                 self.client, dep, gluetun_id, self.config, self.log, sleep=self._sleep
             ):
                 self.dependent_failures.reset(dep)
+                self._notify(
+                    "WARN",
+                    f"dependent remediated: {dep}",
+                    f"{dep} was remediated ({reason}) and verified healthy.",
+                    key=f"dependent-remediated:{dep}",
+                )
+            else:
+                self._notify(
+                    "ERROR",
+                    f"dependent remediation FAILED: {dep}",
+                    f"{dep} is still unhealthy after remediation ({reason}) — "
+                    f"manual intervention may be required.",
+                    key=f"dependent-failed:{dep}",
+                )
 
     # ----- one full loop iteration (node 1 -> 22, minus the sleep) -----
 
@@ -501,8 +524,22 @@ class Monitor:
             self.run_dependent_phase(gluetun.id, sites)
             return
         self.stats.record_gluetun_restart()  # monitor-wide count of actual restarts
+        self._notify(
+            "WARN",
+            f"gluetun restarting ({self.config.gluetun_container})",
+            f"Connectivity failed for: {', '.join(breached)} — restarting "
+            f"{self.config.gluetun_container} and re-verifying.",
+            key="gluetun-restart",
+        )
         if not restart_gluetun(self.client, self.config, self.log, sleep=self._sleep):
             self.log.error("Recovery failed - manual intervention may be required")
+            self._notify(
+                "ERROR",
+                f"gluetun recovery FAILED ({self.config.gluetun_container})",
+                f"{self.config.gluetun_container} did not come back healthy after a restart — "
+                f"manual intervention may be required.",
+                key="gluetun-recovery-failed",
+            )
             return
 
         # Re-verify without recording (so the loop counts one poll per site, not two).
@@ -513,6 +550,13 @@ class Monitor:
             self.stats.record_restart_outcome(site, cleared=site not in still)
         if reverify_breached:
             self.log.warn("Connectivity still failing after restart; leaving dependents untouched")
+            self._notify(
+                "ERROR",
+                f"gluetun still failing after restart ({self.config.gluetun_container})",
+                f"Connectivity still failing after restarting {self.config.gluetun_container}: "
+                f"{', '.join(reverify_breached)} — manual intervention may be required.",
+                key="gluetun-restart-ineffective",
+            )
             self.site_failures.reset_all()
             return
 
@@ -542,6 +586,14 @@ class Monitor:
             f"{adv.total_restarts} gluetun restarts over the last "
             f"{format_window(adv.window_seconds)} — it may be flaky; consider "
             f"reviewing or removing it from sites.conf"
+        )
+        self._notify(
+            "WARN",
+            f"flaky site: {adv.site}",
+            f"{adv.site} caused {adv.site_restarts} of the last {adv.total_restarts} "
+            f"gluetun restarts over {format_window(adv.window_seconds)} — it may be flaky; "
+            f"consider reviewing or removing it from sites.conf.",
+            key=f"advisory:{adv.site}",
         )
 
     def _save_stats(self) -> None:

--- a/gluetun_monitor/notify.py
+++ b/gluetun_monitor/notify.py
@@ -1,0 +1,216 @@
+"""Opt-in external notification layer (issue #22, ADR-0010).
+
+By default (``APPRISE_URLS`` unset) this is a :class:`NullNotifier`: zero behavior
+change — the monitor stays a log-only tool. When configured, significant and
+infrequent events — gluetun restart, recovery failure, dependent remediation, the
+flaky-site advisory, and refusal to start — are pushed out-of-band via
+`Apprise <https://github.com/caronc/apprise>`_ (100+ backends, configured by URL).
+
+Tenet 7 (best-effort, non-blocking): a notification failure must **never** affect
+monitoring. Every send is wrapped and swallowed (logged at DEBUG), filtered by a
+minimum severity, and throttled per event key so a persistent fault can't spam.
+Apprise URLs carry secrets, so they are never logged.
+
+The library is exercised for real in CI (a localhost webhook sink), which is what
+lets Dependabot auto-merge apprise patch/minor — the same bar docker-py clears via
+the real-daemon test (#24).
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+from collections.abc import Callable
+from dataclasses import dataclass
+from time import monotonic
+from typing import TYPE_CHECKING, Any, Protocol
+
+if TYPE_CHECKING:
+    from .config import Config
+    from .logging_setup import Logger
+
+# Severity aligned with stdlib logging so NOTIFY_MIN_LEVEL reuses the log names.
+_LEVEL_BY_NAME: dict[str, int] = {
+    "DEBUG": logging.DEBUG,
+    "INFO": logging.INFO,
+    "WARN": logging.WARNING,
+    "WARNING": logging.WARNING,
+    "ERROR": logging.ERROR,
+}
+
+# Our level names → Apprise notify-type strings (apprise's NotifyType is str-based,
+# so the value is accepted directly; the real-apprise CI test confirms this).
+_APPRISE_TYPE_BY_LEVEL = {"INFO": "info", "WARN": "warning", "WARNING": "warning", "ERROR": "failure"}
+
+
+def level_value(name: str) -> int:
+    """Map a level name (INFO/WARN/ERROR) to its numeric severity (default WARN)."""
+    return _LEVEL_BY_NAME.get(name.upper(), logging.WARNING)
+
+
+@dataclass(frozen=True, slots=True)
+class NotifyEvent:
+    """One notifiable occurrence.
+
+    ``key`` is the throttle/dedup key: at most one send per key per throttle window
+    (mirrors the in-log dedup so a persistent fault notifies once, not every loop).
+    """
+
+    level: str  # "INFO" | "WARN" | "ERROR"
+    title: str
+    body: str
+    key: str
+
+
+class Notifier(Protocol):
+    """Sink for :class:`NotifyEvent`. Implementations must never raise."""
+
+    def notify(self, event: NotifyEvent) -> None:
+        """Best-effort send of one event."""
+        ...
+
+    def test(self) -> bool:
+        """Send a test notification; return True if it was delivered."""
+        ...
+
+
+class NullNotifier:
+    """The default when ``APPRISE_URLS`` is unset — notifications disabled."""
+
+    def notify(self, event: NotifyEvent) -> None:
+        """No-op."""
+        return
+
+    def test(self) -> bool:
+        """Nothing configured to test."""
+        return False
+
+
+class AppriseNotifier:
+    """:class:`Notifier` over Apprise: min-level filter + per-key throttle, fully
+    swallowed.
+
+    ``apprise_factory`` is injectable so the wrapper logic (filter/throttle/swallow)
+    is unit-testable with no library and no network; production passes ``None`` and
+    the real ``apprise`` is imported lazily (only when notifications are enabled).
+    """
+
+    def __init__(
+        self,
+        urls: tuple[str, ...],
+        *,
+        min_level: str,
+        throttle_seconds: int,
+        logger: Logger,
+        timeout_seconds: int = 10,
+        now: Callable[[], float] = monotonic,
+        apprise_factory: Callable[[tuple[str, ...]], Any] | None = None,
+    ) -> None:
+        self._min = level_value(min_level)
+        self._throttle = throttle_seconds
+        self._timeout = timeout_seconds
+        self._log = logger
+        self._now = now
+        self._last_sent: dict[str, float] = {}
+        self._apprise = self._build(urls, apprise_factory)
+
+    def _build(self, urls: tuple[str, ...], factory: Callable[[tuple[str, ...]], Any] | None) -> Any:
+        if factory is not None:
+            return factory(urls)
+        try:
+            import apprise  # lazy: imported only when notifications are actually enabled
+        except Exception as exc:  # pragma: no cover - apprise is a declared dependency
+            self._log.error(f"apprise import failed; notifications disabled: {exc}")
+            return None
+        # Quiet apprise's own logger: at LOG_LEVEL=DEBUG it is chatty and may echo
+        # URL detail (it masks credentials, but we don't want host/path either).
+        logging.getLogger("apprise").setLevel(logging.WARNING)
+        # Brand the notifications so an operator knows what is alerting them.
+        asset = apprise.AppriseAsset(
+            app_id="gluetun-monitor",
+            app_desc="gluetun-monitor",
+            app_url="https://github.com/csmarshall/gluetun-monitor",
+        )
+        ap = apprise.Apprise(asset=asset)
+        for url in urls:
+            # Never log the URL itself — it carries tokens.
+            if not ap.add(url):
+                self._log.warn("An APPRISE_URLS entry was rejected by apprise (check its scheme)")
+        return ap
+
+    def notify(self, event: NotifyEvent) -> None:
+        """Send ``event`` if it clears the min level and isn't throttled. Never raises."""
+        try:
+            if self._apprise is None:
+                return
+            if level_value(event.level) < self._min:
+                return
+            if self._throttled(event.key):
+                self._log.debug(f"notify throttled: {event.key}")
+                return
+            ntype = _APPRISE_TYPE_BY_LEVEL.get(event.level.upper(), "warning")
+            if self._dispatch(lambda: self._apprise.notify(
+                title=event.title, body=event.body, notify_type=ntype
+            )):
+                self._last_sent[event.key] = self._now()
+            else:
+                self._log.debug(f"notify send reported no success: {event.key}")
+        except Exception as exc:  # Tenet 7: a notify failure never touches the loop
+            self._log.debug(f"notify error (swallowed): {exc}")
+
+    def test(self) -> bool:
+        """Send a test notification (bypasses level/throttle); True if delivered."""
+        if self._apprise is None:
+            return False
+        return self._dispatch(lambda: self._apprise.notify(
+            title="gluetun-monitor test notification",
+            body="If you can read this, gluetun-monitor notifications are working.",
+            notify_type="info",
+        ))
+
+    def _dispatch(self, send: Callable[[], Any]) -> bool:
+        """Run ``send`` on a daemon thread and wait at most ``timeout_seconds``.
+
+        Apprise's ``notify`` is synchronous, so calling it inline would let a slow
+        or hung endpoint add latency to the monitoring loop. Bounding it keeps the
+        send **off the hot path with a timeout** (Tenet 7 / #22): if it overruns we
+        stop waiting and carry on — the daemon thread is harmless and any error in
+        it is swallowed.
+        """
+        result: list[bool] = []
+
+        def run() -> None:
+            try:
+                result.append(bool(send()))
+            except Exception as exc:
+                self._log.debug(f"notify error (swallowed): {exc}")
+                result.append(False)
+
+        worker = threading.Thread(target=run, daemon=True)
+        worker.start()
+        worker.join(self._timeout)
+        if worker.is_alive():
+            self._log.debug(f"notify exceeded {self._timeout}s; not blocking the loop")
+            return False
+        return result[0] if result else False
+
+    def _throttled(self, key: str) -> bool:
+        if self._throttle <= 0:
+            return False
+        last = self._last_sent.get(key)
+        return last is not None and (self._now() - last) < self._throttle
+
+
+def build_notifier(config: Config, logger: Logger) -> Notifier:
+    """A :class:`NullNotifier` when ``APPRISE_URLS`` is unset; an
+    :class:`AppriseNotifier` otherwise.
+    """
+    if not config.apprise_urls:
+        return NullNotifier()
+    return AppriseNotifier(
+        config.apprise_urls,
+        min_level=config.notify_min_level,
+        throttle_seconds=config.notify_throttle,
+        timeout_seconds=config.notify_timeout,
+        logger=logger,
+    )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,11 +12,13 @@ requires-python = ">=3.13"
 authors = [{ name = "Charles Marshall" }]
 keywords = ["gluetun", "vpn", "docker", "monitoring", "healthcheck"]
 dependencies = [
-    # Exact pin (not a range): the image installs straight from here, so pinning
-    # makes builds reproducible AND gives Dependabot a per-release target. docker-py
-    # bumps are gated by the real-daemon integration job (#24) and auto-merged on
-    # green (patch/minor); a major (8.x) still gets a human.
+    # Exact pins (not ranges): the image installs straight from here, so pinning
+    # makes builds reproducible AND gives Dependabot a per-release target. Both prod
+    # deps are exercised for real in CI (docker by the real-daemon job #24, apprise
+    # by the localhost-sink test #22), so patch/minor auto-merge on green; majors
+    # still get a human.
     "docker==7.1.0",
+    "apprise==1.11.0",
 ]
 
 [project.urls]

--- a/tests/fakes.py
+++ b/tests/fakes.py
@@ -11,8 +11,27 @@ from collections.abc import Callable
 from typing import Any
 
 from gluetun_monitor.docker_client import ContainerInfo, ExecResult
+from gluetun_monitor.notify import NotifyEvent
 
 ExecHandler = Callable[[str, list[str]], ExecResult]
+
+
+class FakeNotifier:
+    """Records every NotifyEvent so tests can assert what was pushed (no network)."""
+
+    def __init__(self) -> None:
+        self.events: list[NotifyEvent] = []
+        self.test_result = True
+
+    def notify(self, event: NotifyEvent) -> None:
+        self.events.append(event)
+
+    def test(self) -> bool:
+        return self.test_result
+
+    def event_keys(self) -> list[str]:
+        """The dedup keys of recorded events, in order — handy for assertions."""
+        return [e.key for e in self.events]
 
 
 def make_inspect(

--- a/tests/test_entrypoint.py
+++ b/tests/test_entrypoint.py
@@ -1,4 +1,4 @@
-"""cli.main() wiring, signal handling, and the Monitor.run() loop."""
+"""cli.main([]) wiring, signal handling, and the Monitor.run() loop."""
 
 from __future__ import annotations
 
@@ -86,7 +86,7 @@ def test_announce_logs_connection_and_endpoint() -> None:
     assert "[ENDPOINT]" in out
 
 
-# ----- cli.main() -----
+# ----- cli.main([]) -----
 
 
 def _prep_env(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
@@ -105,7 +105,7 @@ def test_main_success(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     ran: list[int] = []
     monkeypatch.setattr(cli.Monitor, "announce", lambda self: None)
     monkeypatch.setattr(cli.Monitor, "run", lambda self: ran.append(1))
-    assert cli.main() == 0
+    assert cli.main([]) == 0
     assert ran == [1]
 
 
@@ -118,7 +118,7 @@ def test_main_client_init_failure_returns_1(
         raise RuntimeError("no docker")
 
     monkeypatch.setattr(cli, "DockerPyClient", boom)
-    assert cli.main() == 1
+    assert cli.main([]) == 1
 
 
 def test_main_prereq_failure_returns_1(
@@ -127,7 +127,7 @@ def test_main_prereq_failure_returns_1(
     _prep_env(monkeypatch, tmp_path)
     fake = FakeDockerClient()  # no gluetun container -> prereq fails
     monkeypatch.setattr(cli, "DockerPyClient", lambda **_kw: fake)
-    assert cli.main() == 1
+    assert cli.main([]) == 1
 
 
 def test_signal_handler_exits_cleanly() -> None:

--- a/tests/test_monitor.py
+++ b/tests/test_monitor.py
@@ -19,8 +19,9 @@ from gluetun_monitor.config import Config
 from gluetun_monitor.docker_client import ExecResult
 from gluetun_monitor.logging_setup import Logger
 from gluetun_monitor.monitor import Monitor
+from gluetun_monitor.site_stats import SiteStatsStore
 
-from .fakes import FakeDockerClient
+from .fakes import FakeDockerClient, FakeNotifier
 
 GLUETUN_ID = "a" * 64
 OLD_ID = "b" * 64
@@ -34,10 +35,14 @@ def sites_file(tmp_path: Path) -> str:
     return str(conf)
 
 
-def _monitor(fake: FakeDockerClient, sites_file: str, **cfg_overrides) -> Monitor:
+def _monitor(
+    fake: FakeDockerClient, sites_file: str, *, notifier: FakeNotifier | None = None, **cfg_overrides
+) -> Monitor:
     cfg = Config(config_file=sites_file, gluetun_container="gluetun", **cfg_overrides)
     logger = Logger(log_file=None, level="DEBUG", stream=io.StringIO())
-    return Monitor(fake, cfg, logger, rng=random.Random(0), sleep=lambda _s: None)
+    return Monitor(
+        fake, cfg, logger, rng=random.Random(0), sleep=lambda _s: None, notifier=notifier
+    )
 
 
 def test_gluetun_not_running_does_nothing(sites_file: str) -> None:
@@ -179,6 +184,67 @@ def test_viability_failure_accumulates_to_threshold(sites_file: str) -> None:
 
     mon.run_once()  # fail 2/2 — remediate
     assert fake.restarted == ["dep"]
+
+
+def test_notifies_on_restart_and_persisting_failure(sites_file: str) -> None:
+    """The two operator-facing signals (#22): a restart was triggered, and it did
+    NOT clear the failure (gluetun can't come up)."""
+    fake = FakeDockerClient()
+    fake.add_container("gluetun", id=GLUETUN_ID)
+
+    def handler(name: str, cmd: list[str]) -> ExecResult:
+        if cmd[:2] == ["ls", "/sys/class/net"]:
+            return ExecResult(0, "eth0\nlo\n")
+        return ExecResult(4, "")  # every site probe keeps failing, even after restart
+
+    fake.on_exec = handler
+    fn = FakeNotifier()
+    _monitor(fake, sites_file, notifier=fn, fail_threshold=1).run_once()
+
+    assert "gluetun-restart" in fn.event_keys()
+    assert "gluetun-restart-ineffective" in fn.event_keys()
+    ineffective = next(e for e in fn.events if e.key == "gluetun-restart-ineffective")
+    assert ineffective.level == "ERROR"
+
+
+def test_notifies_on_recovery_failed(sites_file: str) -> None:
+    """When the gluetun restart itself fails, the operator gets an ERROR alert."""
+    fake = FakeDockerClient()
+    fake.add_container("gluetun", id=GLUETUN_ID)
+
+    def handler(name: str, cmd: list[str]) -> ExecResult:
+        if cmd[:2] == ["ls", "/sys/class/net"]:
+            return ExecResult(0, "eth0\nlo\n")
+        return ExecResult(4, "")
+
+    fake.on_exec = handler
+
+    def boom(_name: str) -> None:
+        raise RuntimeError("restart failed")
+
+    fake.restart = boom  # type: ignore[method-assign]
+    fn = FakeNotifier()
+    _monitor(fake, sites_file, notifier=fn, fail_threshold=1).run_once()
+
+    assert "gluetun-recovery-failed" in fn.event_keys()
+    assert next(e for e in fn.events if e.key == "gluetun-recovery-failed").level == "ERROR"
+
+
+def test_notifies_flaky_site_advisory(sites_file: str) -> None:
+    """The flaky-site advisory (restarting on a site too often) pushes a WARN."""
+    fake = FakeDockerClient()
+    fake.add_container("gluetun", id=GLUETUN_ID)
+    fn = FakeNotifier()
+    stats = SiteStatsStore(None)
+    for _ in range(6):
+        stats.record_restart("flaky.example")
+    mon = _monitor(fake, sites_file, notifier=fn)
+    mon.stats = stats
+    mon._emit_advisory()
+
+    adv = next(e for e in fn.events if e.key.startswith("advisory:"))
+    assert adv.level == "WARN"
+    assert "flaky.example" in adv.title
 
 
 def test_gluetun_failure_triggers_restart_then_reverify(sites_file: str) -> None:

--- a/tests/test_notify.py
+++ b/tests/test_notify.py
@@ -1,0 +1,160 @@
+"""The opt-in notification layer (#22, ADR-0010).
+
+The wrapper logic — min-level filter, per-key throttle, and the Tenet-7 swallow —
+is tested with a fake Apprise object (no library calls, no network). The real
+library is exercised separately in ``test_notify_apprise_real.py`` (the bar that
+lets apprise auto-merge). The monitor wiring (which events fire) is asserted with
+``FakeNotifier`` against ``FakeDockerClient``.
+"""
+
+from __future__ import annotations
+
+import io
+from typing import Any
+
+from gluetun_monitor.config import Config
+from gluetun_monitor.logging_setup import Logger
+from gluetun_monitor.notify import (
+    AppriseNotifier,
+    NotifyEvent,
+    NullNotifier,
+    build_notifier,
+    level_value,
+)
+
+
+def _log() -> Logger:
+    return Logger(log_file=None, level="DEBUG", stream=io.StringIO())
+
+
+class _FakeApprise:
+    """Stand-in for apprise.Apprise — records sends; can fail on demand."""
+
+    def __init__(self) -> None:
+        self.sent: list[tuple[str, str, str]] = []
+        self.raise_on_notify = False
+        self.return_value = True
+
+    def notify(self, *, title: str, body: str, notify_type: str) -> bool:
+        if self.raise_on_notify:
+            raise RuntimeError("boom")
+        self.sent.append((title, body, notify_type))
+        return self.return_value
+
+
+class _Clock:
+    def __init__(self) -> None:
+        self.t = 1000.0
+
+    def __call__(self) -> float:
+        return self.t
+
+    def advance(self, dt: float) -> None:
+        self.t += dt
+
+
+def _notifier(fake: _FakeApprise, clock: _Clock, **kw: Any) -> AppriseNotifier:
+    kw.setdefault("min_level", "WARN")
+    kw.setdefault("throttle_seconds", 100)
+    return AppriseNotifier(
+        ("memory://",), logger=_log(), now=clock, apprise_factory=lambda _urls: fake, **kw
+    )
+
+
+def test_level_value_maps_names() -> None:
+    assert level_value("INFO") < level_value("WARN") < level_value("ERROR")
+    assert level_value("warning") == level_value("WARN")
+    assert level_value("bogus") == level_value("WARN")  # unknown → WARN default
+
+
+def test_null_notifier_is_noop() -> None:
+    n = NullNotifier()
+    n.notify(NotifyEvent("ERROR", "t", "b", "k"))  # must not raise
+    assert n.test() is False
+
+
+def test_min_level_filters_below_threshold() -> None:
+    fake, clock = _FakeApprise(), _Clock()
+    n = _notifier(fake, clock, min_level="WARN")
+    n.notify(NotifyEvent("INFO", "t", "b", "k1"))  # below WARN → dropped
+    assert fake.sent == []
+    n.notify(NotifyEvent("ERROR", "t", "b", "k2"))  # at/above → sent
+    assert len(fake.sent) == 1
+    assert fake.sent[0][2] == "failure"  # ERROR → apprise "failure"
+
+
+def test_throttle_dedups_same_key_until_window_passes() -> None:
+    fake, clock = _FakeApprise(), _Clock()
+    n = _notifier(fake, clock, throttle_seconds=100)
+    n.notify(NotifyEvent("WARN", "t", "b", "same"))
+    n.notify(NotifyEvent("WARN", "t", "b", "same"))  # within window → throttled
+    assert len(fake.sent) == 1
+    clock.advance(101)
+    n.notify(NotifyEvent("WARN", "t", "b", "same"))  # window passed → sent again
+    assert len(fake.sent) == 2
+
+
+def test_throttle_is_per_key() -> None:
+    fake, clock = _FakeApprise(), _Clock()
+    n = _notifier(fake, clock, throttle_seconds=100)
+    n.notify(NotifyEvent("WARN", "t", "b", "a"))
+    n.notify(NotifyEvent("WARN", "t", "b", "b"))  # different key → not throttled
+    assert len(fake.sent) == 2
+
+
+def test_throttle_zero_disables_throttling() -> None:
+    fake, clock = _FakeApprise(), _Clock()
+    n = _notifier(fake, clock, throttle_seconds=0)
+    for _ in range(3):
+        n.notify(NotifyEvent("WARN", "t", "b", "same"))
+    assert len(fake.sent) == 3
+
+
+def test_send_exception_is_swallowed() -> None:
+    fake, clock = _FakeApprise(), _Clock()
+    fake.raise_on_notify = True
+    n = _notifier(fake, clock)
+    n.notify(NotifyEvent("ERROR", "t", "b", "k"))  # must not raise (Tenet 7)
+    assert fake.sent == []
+
+
+def test_failed_send_is_not_recorded_so_it_retries() -> None:
+    fake, clock = _FakeApprise(), _Clock()
+    fake.return_value = False  # apprise reports no success
+    n = _notifier(fake, clock, throttle_seconds=100)
+    n.notify(NotifyEvent("WARN", "t", "b", "k"))
+    n.notify(NotifyEvent("WARN", "t", "b", "k"))  # not throttled (never recorded a success)
+    assert len(fake.sent) == 2
+
+
+def test_test_method_sends_and_reports() -> None:
+    fake, clock = _FakeApprise(), _Clock()
+    n = _notifier(fake, clock)
+    assert n.test() is True
+    assert fake.sent and fake.sent[0][2] == "info"
+
+
+def test_build_notifier_null_without_urls() -> None:
+    assert isinstance(build_notifier(Config(), _log()), NullNotifier)
+
+
+def test_build_notifier_apprise_with_urls() -> None:
+    cfg = Config(apprise_urls=("json://localhost",), notify_throttle=0)
+    assert isinstance(build_notifier(cfg, _log()), AppriseNotifier)
+
+
+def test_config_parses_notify_env(monkeypatch: Any) -> None:
+    monkeypatch.setenv("APPRISE_URLS", " ntfy://h/t , , discord://x ")
+    monkeypatch.setenv("NOTIFY_MIN_LEVEL", "error")
+    monkeypatch.setenv("NOTIFY_THROTTLE", "60")
+    cfg = Config.from_env()
+    assert cfg.apprise_urls == ("ntfy://h/t", "discord://x")  # trimmed, blanks dropped
+    assert cfg.notify_min_level == "ERROR"
+    assert cfg.notify_throttle == 60
+    assert cfg.errors == ()
+
+
+def test_config_rejects_bad_notify_min_level(monkeypatch: Any) -> None:
+    monkeypatch.setenv("NOTIFY_MIN_LEVEL", "LOUD")
+    cfg = Config.from_env()
+    assert any("NOTIFY_MIN_LEVEL" in e for e in cfg.errors)

--- a/tests/test_notify_apprise_real.py
+++ b/tests/test_notify_apprise_real.py
@@ -1,0 +1,94 @@
+"""Real-apprise validation (#22) — the bar that lets apprise auto-merge.
+
+Drives the REAL apprise library end to end against a localhost HTTP sink (no
+network egress, no secrets): if an apprise update broke the parse/dispatch path we
+depend on, this turns CI red. It needs no daemon, so it runs in the normal test job
+(a required check) and auto-merge waits on it — mirroring how the real-daemon test
+(#24) gates docker-py.
+"""
+
+from __future__ import annotations
+
+import io
+import threading
+from collections.abc import Iterator
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+import pytest
+
+from gluetun_monitor.logging_setup import Logger
+from gluetun_monitor.notify import AppriseNotifier, NotifyEvent
+
+pytest.importorskip("apprise")  # a declared dependency; importable in CI
+
+
+def _log(stream: io.StringIO) -> Logger:
+    return Logger(log_file=None, level="DEBUG", stream=stream)
+
+
+@pytest.fixture
+def sink() -> Iterator[tuple[int, list[bytes]]]:
+    """A throwaway localhost HTTP server; yields (port, received_bodies)."""
+    received: list[bytes] = []
+
+    class Handler(BaseHTTPRequestHandler):
+        def do_POST(self) -> None:
+            length = int(self.headers.get("Content-Length", 0))
+            received.append(self.rfile.read(length))
+            self.send_response(200)
+            self.end_headers()
+
+        def log_message(self, *_args: object) -> None:
+            pass  # keep test output quiet
+
+    server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+    port = server.server_address[1]
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield port, received
+    finally:
+        server.shutdown()
+        thread.join(timeout=5)
+
+
+def test_real_apprise_delivers_event_to_sink(sink: tuple[int, list[bytes]]) -> None:
+    port, received = sink
+    notifier = AppriseNotifier(
+        (f"json://127.0.0.1:{port}",),
+        min_level="INFO",
+        throttle_seconds=0,
+        logger=_log(io.StringIO()),
+    )
+    notifier.notify(NotifyEvent("ERROR", "title-XYZ", "body-ABC", "k"))
+
+    assert received, "real apprise did not POST to the localhost sink"
+    body = received[0]
+    assert b"title-XYZ" in body
+    assert b"body-ABC" in body
+
+
+def test_real_apprise_test_method_delivers(sink: tuple[int, list[bytes]]) -> None:
+    port, received = sink
+    notifier = AppriseNotifier(
+        (f"json://127.0.0.1:{port}",),
+        min_level="WARN",
+        throttle_seconds=0,
+        logger=_log(io.StringIO()),
+    )
+    assert notifier.test() is True
+    assert received
+
+
+def test_real_apprise_rejects_bad_scheme_and_warns() -> None:
+    stream = io.StringIO()
+    notifier = AppriseNotifier(
+        ("totally-not-a-scheme://nowhere",),
+        min_level="INFO",
+        throttle_seconds=0,
+        logger=_log(stream),
+    )
+    # No server got registered, so a send reports no success (swallowed); the
+    # rejection was warned at build time.
+    notifier.notify(NotifyEvent("ERROR", "t", "b", "k"))
+    assert "rejected by apprise" in stream.getvalue()

--- a/tests/test_prereq_strict.py
+++ b/tests/test_prereq_strict.py
@@ -96,4 +96,4 @@ def test_main_fatal_on_malformed_env(monkeypatch: pytest.MonkeyPatch, tmp_path: 
     monkeypatch.setenv("CHECK_INTERVAL", "abc")  # malformed -> Config.errors -> exit 1
     monkeypatch.setenv("LOG_FILE", str(tmp_path / "m.log"))
     monkeypatch.setenv("CONFIG_FILE", str(tmp_path / "sites.conf"))
-    assert cli.main() == 1  # returns before touching Docker
+    assert cli.main([]) == 1  # returns before touching Docker


### PR DESCRIPTION
Closes #22.

Adds an **opt-in** external notification channel so significant, infrequent events are pushed out-of-band — not just logged. This is also the safety net that makes auto-release (#26) defensible later: you'll hear about it when something breaks.

## What
- **`APPRISE_URLS` unset = disabled** (drop-in, zero behavior change). Set = events go to any of [Apprise](https://github.com/caronc/apprise)'s 100+ backends (ntfy/Discord/Telegram/email/webhook/…), by URL.
- **Seam** (mirrors the docker_client Protocol): `Notifier` + `NullNotifier` (default no-op) + `AppriseNotifier` (real, apprise lazy-imported) + `FakeNotifier` (tests).
- **Events** wired at the monitor's outcome points:

  | Event | Level |
  |---|---|
  | gluetun restart triggered | WARN |
  | gluetun recovery failed / still failing after restart | **ERROR** |
  | dependent remediated | WARN |
  | dependent remediation failed | **ERROR** |
  | flaky-site advisory | WARN |
  | refused to start | **ERROR** |

  (The two you asked for — *stuck/can't-come-up* and *restarting on a site too often* — are the ERROR recovery events and the advisory.)
- **Controls:** `NOTIFY_MIN_LEVEL` (default WARN), `NOTIFY_THROTTLE` (per-event, default 1h), `NOTIFY_TIMEOUT` (default 10s). `gluetun-monitor --notify-test` verifies a config.

## Best-effort (Tenet 7)
A notify failure never touches monitoring: filtered → throttled → run **off the loop on a bounded daemon thread** (apprise's `notify()` is synchronous, so a slow/hung backend can't stall the watchdog) → any error swallowed + DEBUG-logged. Apprise URLs carry tokens and are **never logged**.

## Apprise best practices followed
Single reused `Apprise()` instance, `AppriseAsset` branding (`gluetun-monitor`), `add()` returns checked, official `notify_type` values, apprise's own logger quieted.

## Dependency / auto-merge
`apprise==1.11.0` pinned as a prod dep. To avoid an *unvalidated* auto-merge (the trap docker-py had under `FakeDockerClient`), a **real-library test drives apprise end to end against a localhost HTTP sink** — it runs in the normal (required) test job, so apprise joins `docker` as auto-merge-eligible (patch/minor); majors still get a human. Same principle as #24: *a dependency may auto-merge once CI genuinely exercises it.*

## Tests
- Wrapper logic (filter/throttle/swallow/timeout) via a fake apprise — no network.
- Real apprise → localhost sink (delivery + `--notify-test` + bad-scheme rejection).
- Monitor wire-up via `FakeNotifier` (advisory, restart-ineffective, recovery-failed).
- Gate green locally: ruff + mypy + 97.8% coverage.

ADR-0010 documents the design; README has a Notifications section; ROADMAP marked shipped.