### PR TITLE
Notification tiers + per-loop rollup + edge-triggered lifecycle (#22)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,14 +8,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- **Opt-in notification layer (#22, ADR-0010).** Set `APPRISE_URLS` to push
-  significant events out-of-band via [Apprise](https://github.com/caronc/apprise)
-  (ntfy/Discord/Telegram/email/webhook/… — 100+ backends): gluetun restart, recovery
-  failure / restart-ineffective, dependent remediation success/failure, the
-  flaky-site advisory, and refusal to start. Filtered by `NOTIFY_MIN_LEVEL`
-  (default WARN), throttled per event by `NOTIFY_THROTTLE` (default 1h), and bounded
-  off the loop by `NOTIFY_TIMEOUT` (default 10s). Unset = disabled (drop-in, no
-  behavior change). `gluetun-monitor --notify-test` verifies your configuration.
+- **Opt-in notification layer (#22, ADR-0010/0011/0012).** Set `APPRISE_URLS` to push
+  events out-of-band via [Apprise](https://github.com/caronc/apprise) (100+ backends:
+  ntfy/Discord/Telegram/email/webhook/…). Unset = disabled (drop-in, no behavior
+  change). `gluetun-monitor --notify-test` verifies your config.
+  - **One dial, `NOTIFY_LEVEL`** (default `attention`), cumulative and keyed on
+    actionability: `attention` (only when you must act — failed recovery/remediation,
+    refused start, flaky-site advisory) → `recovery` (self-healed incidents) →
+    `activity` (non-fault changes) → `all` (firehose).
+  - **Per-loop rollup:** a cycle's events are grouped into one digest, colored by the
+    most-urgent tier — no storms from a fast restarter.
+  - **Edge-triggered lifecycle:** an ongoing problem announces once, reminds every
+    `NOTIFY_REPEAT_INTERVAL` loops (default `0` = once), and emits a resolve when it
+    clears (or clears silently if its subject was removed). State persists to
+    `NOTIFY_STATE_FILE` across monitor restarts.
+  - Best-effort (Tenet 7): sent off the loop bounded by `NOTIFY_TIMEOUT`, failures
+    swallowed; URLs never logged; startup logs exactly what you signed up for.
 
 ### CI / tooling
 - Pinned dev toolchain in `requirements-dev.txt` (ruff/mypy/pytest/pytest-cov),

--- a/README.md
+++ b/README.md
@@ -194,8 +194,9 @@ docker compose up -d
 | `LOG_FILE` | `/logs/gluetun-monitor.log` | Path to the log file inside the `/logs` mount. Logs always go to stdout (`docker logs`) too; if this path isn't writable the monitor degrades to stdout-only rather than failing |
 | `TZ` | `UTC` | Timezone for log timestamps |
 | `APPRISE_URLS` | *(unset → off)* | Comma-separated [Apprise](https://github.com/caronc/apprise) URLs to push events to (ntfy/Discord/Telegram/email/webhook/…). Unset = notifications disabled. See [Notifications](#notifications) |
-| `NOTIFY_MIN_LEVEL` | `WARN` | Minimum severity to push: `INFO`, `WARN`, or `ERROR`. See [Notifications](#notifications) |
-| `NOTIFY_THROTTLE` | `3600` | Per-event throttle (seconds): at most one notification per event key per window; `0` disables throttling. See [Notifications](#notifications) |
+| `NOTIFY_LEVEL` | `attention` | Cumulative scope dial: `attention` (only when you must act) → `recovery` (self-healed incidents) → `activity` (non-fault changes) → `all` (firehose). See [Notifications](#notifications) |
+| `NOTIFY_REPEAT_INTERVAL` | `0` | Re-notify cadence for an *ongoing* problem, in **loops**. `0` = announce once, then silent until it resolves; `N` = remind every `N` loops. Alerts are edge-triggered. See [Notifications](#notifications) |
+| `NOTIFY_STATE_FILE` | `/logs/notify-state.json` | Where the active-alert lifecycle persists (so a monitor restart doesn't re-spam or miss a resolve). Best-effort. See [Notifications](#notifications) |
 | `NOTIFY_TIMEOUT` | `10` | Max seconds to wait for a notification send before carrying on (sends run off the loop, so a slow backend can't stall the watchdog). See [Notifications](#notifications) |
 
 ### Configuration is validated — sane defaults, but bad config is fatal
@@ -547,36 +548,54 @@ are approximate.
 
 ## Notifications
 
-By default the monitor is **log-only**. Set `APPRISE_URLS` to also push significant
-events out-of-band via [Apprise](https://github.com/caronc/apprise) — one library,
-100+ backends (ntfy, Discord, Telegram, Slack, email, Pushover, Gotify, generic
-webhook, …), all configured by URL. Unset = disabled, so this is fully opt-in.
+By default the monitor is **log-only**. Set `APPRISE_URLS` to also push events
+out-of-band via [Apprise](https://github.com/caronc/apprise) — one library, 100+
+backends (ntfy, Discord, Telegram, Slack, email, Pushover, Gotify, generic webhook,
+…), all configured by URL. Unset = disabled, so this is fully opt-in.
 
 ```yaml
     environment:
-      # One or more comma-separated Apprise URLs. Examples:
+      # One or more comma-separated Apprise URLs:
       - APPRISE_URLS=ntfy://ntfy.example.com/gluetun
       # - APPRISE_URLS=ntfy://host/topic,discord://webhook_id/webhook_token
-      - NOTIFY_MIN_LEVEL=WARN   # INFO | WARN | ERROR (default WARN)
+      - NOTIFY_LEVEL=attention   # attention | recovery | activity | all (default attention)
 ```
 
-**What gets pushed** (each at the noted severity; below `NOTIFY_MIN_LEVEL` is
-suppressed):
+### One dial: `NOTIFY_LEVEL`
 
-| Event | Level |
-|-------|-------|
-| gluetun restart triggered | WARN |
-| gluetun **recovery failed** / still failing after restart (can't come up) | ERROR |
-| dependent remediated (restart/recreate) | WARN |
-| dependent **remediation failed** | ERROR |
-| **flaky-site advisory** (one site keeps causing restarts) | WARN |
-| refused to start (bad config / Docker unreachable / gluetun missing) | ERROR |
+The scope is a single cumulative dial keyed on **who has to act**, not on how scary a
+line looks. Each level adds its own row to everything above it (ADR-0011):
 
-Notifications are **best-effort and never affect monitoring** (Tenet 7): a send is
-filtered by `NOTIFY_MIN_LEVEL`, throttled per event by `NOTIFY_THROTTLE` (so a
-persistent fault notifies once, not every loop), run off the loop bounded by
-`NOTIFY_TIMEOUT`, and any failure is swallowed (logged at `DEBUG`). Apprise URLs
-carry tokens and are never logged.
+| `NOTIFY_LEVEL` | You get | Events |
+|---|---|---|
+| **`attention`** *(default)* | only when **you** must act/decide | recovery/remediation failed, refused to start, **flaky-site advisory** |
+| `recovery` | + self-healed incidents | gluetun recovered, dependent remediated |
+| `activity` | + non-fault changes | `sites.conf` reloaded |
+| `all` | + the firehose | per-loop checks, restart play-by-play |
+
+So enabling notifications gets you **`attention` only** — the monitor stays silent
+through every self-heal and pings you when it's actually stuck. Raise the dial to
+hear more.
+
+### No notification storms
+
+Alerts are **edge-triggered**: an ongoing problem is announced **once, when it
+starts** — not every 30-second loop it persists. `NOTIFY_REPEAT_INTERVAL` (in
+**loops**, default `0`) controls reminders: `0` = announce once then stay silent
+until it resolves; `N` = remind every `N` loops. When a problem **clears** you get a
+resolve note (so you hear it's back); when its subject is **removed** (site dropped,
+dependent excluded) it clears silently. This state persists to `NOTIFY_STATE_FILE`,
+so restarting the monitor neither re-spams still-broken problems nor misses a
+resolve (ADR-0012).
+
+### Grouped, best-effort
+
+A loop's surviving events are **rolled up into one digest** (so one cycle = at most
+one notification), colored by the most-urgent tier present. Sending is best-effort
+and **never affects monitoring** (Tenet 7): run off the loop bounded by
+`NOTIFY_TIMEOUT`, any failure swallowed (logged at `DEBUG`). Apprise URLs carry
+tokens and are **never logged** — and at startup the log states exactly what you
+signed up for, including what stays silent.
 
 Verify your setup without waiting for a real event:
 
@@ -584,8 +603,9 @@ Verify your setup without waiting for a real event:
 docker exec gluetun-monitor gluetun-monitor --notify-test
 ```
 
-See [ADR-0010](docs/adr/0010-notification-layer.md) for the design and the full
-[Apprise URL list](https://github.com/caronc/apprise/wiki) for backends.
+See [ADR-0011](docs/adr/0011-notification-tiers-and-rollup.md) (the dial + rollup) and
+[ADR-0012](docs/adr/0012-alert-lifecycle.md) (the lifecycle) for the design, and the
+full [Apprise URL list](https://github.com/caronc/apprise/wiki) for backends.
 
 ## Docker Compose Example
 

--- a/docker-compose.yml.example
+++ b/docker-compose.yml.example
@@ -93,8 +93,9 @@ services:
       # failure, dependent remediation, flaky-site advisory, refusal to start).
       # 100+ backends; see https://github.com/caronc/apprise/wiki
       # - APPRISE_URLS=ntfy://ntfy.example.com/gluetun,discord://webhook_id/webhook_token
-      # - NOTIFY_MIN_LEVEL=WARN      # INFO | WARN | ERROR (minimum severity to push)
-      # - NOTIFY_THROTTLE=3600       # seconds; at most one push per event key per window (0=off)
+      # - NOTIFY_LEVEL=attention     # attention | recovery | activity | all (cumulative dial)
+      # - NOTIFY_REPEAT_INTERVAL=0   # loops; 0 = announce an ongoing problem once, then silent
+      # - NOTIFY_STATE_FILE=/logs/notify-state.json  # active-alert lifecycle persistence
       # - NOTIFY_TIMEOUT=10          # seconds to wait for a send before carrying on (off the loop)
       # Verify with:  docker exec gluetun-monitor gluetun-monitor --notify-test
       # Recreate a dependent stranded by a gluetun recreate (id changed); 0 disables

--- a/docs/adr/0010-notification-layer.md
+++ b/docs/adr/0010-notification-layer.md
@@ -28,15 +28,15 @@ ntfy/Discord/Telegram/email/Pushover/Gotify/webhook/… — all configured by UR
   `NullNotifier` (disabled), `AppriseNotifier` (real, apprise imported lazily), and
   a `FakeNotifier` in tests. The monitor fires `NotifyEvent`s; it never imports
   apprise directly.
-- **Event contract** (the stable surface): `gluetun-restart` (WARN),
-  `gluetun-recovery-failed` / `gluetun-restart-ineffective` (ERROR),
-  `dependent-remediated:<name>` (WARN) / `dependent-failed:<name>` (ERROR),
-  `advisory:<site>` (WARN), `refused-*` (ERROR). Filtered by `NOTIFY_MIN_LEVEL`
-  (default WARN) and throttled per event key by `NOTIFY_THROTTLE` (default 1h) so a
-  persistent fault notifies once, not every loop — mirroring the in-log dedup.
-- **Best-effort, non-blocking (Tenet 7):** every send is wrapped, level-filtered,
-  throttled, and on any failure swallowed + logged at DEBUG. A notification problem
-  can only ever degrade notifications — it can never touch the monitoring loop or
+- **Event contract** — the events surfaced (gluetun restart/recovery, dependent
+  remediation, the flaky-site advisory, refusal to start). How they're *classified*
+  (the `NOTIFY_LEVEL` tier dial), *grouped* (per-loop rollup), and *re-notified*
+  (edge-trigger / repeat / resolve) is decided in **ADR-0011** and **ADR-0012** —
+  this ADR's original severity-floor (`NOTIFY_MIN_LEVEL`) and per-event throttle were
+  superseded there before release.
+- **Best-effort, non-blocking (Tenet 7):** every send is wrapped, tier-filtered,
+  and on any failure swallowed + logged at DEBUG. A notification problem can only
+  ever degrade notifications — it can never touch the monitoring loop or
   restart/remediation behavior. Apprise URLs carry tokens and are never logged.
   Apprise's `notify()` is synchronous, so sends run on a daemon thread bounded by
   `NOTIFY_TIMEOUT` (default 10s): a slow or hung backend can't stall the watchdog.

--- a/docs/adr/0011-notification-tiers-and-rollup.md
+++ b/docs/adr/0011-notification-tiers-and-rollup.md
@@ -1,0 +1,132 @@
+# ADR-0011: Notification tiers (actionability dial) + per-loop rollup digest
+
+- **Status:** Accepted
+- **Date:** 2026-06-05
+- **Relates to:** ADR-0010 (the Apprise notification layer this configures),
+  ADR-0012 (the edge-triggered alert lifecycle that feeds this dial),
+  Tenet 7 (best-effort, non-blocking)
+
+## Context
+ADR-0010 added the notification channel; this decides **what** is sent and **how
+it's grouped**. The first cut used a single severity floor (`NOTIFY_MIN_LEVEL`,
+default WARN) — borrowed reflexively from log levels. That filters by *how bad a
+line looks*, which is the wrong axis for an alert channel: a watchdog's whole job
+is to self-heal, so the default signal an operator wants is *"I couldn't fix it —
+your turn,"* not a play-by-play of every restart it handled on its own.
+
+It also sent one notification per event. Because our "operations" are just
+container restarts — sub-second to a few seconds — a single monitoring loop can
+emit a **burst** of events almost simultaneously (gluetun recovered + three
+dependents remediated + an advisory). Unlike systems whose failures trickle in over
+minutes, ours cluster *within a loop*, so per-event sending is a notification storm.
+
+## Prior art
+- **Veritas Cluster Server** (the closest analog — HA failover notifications): four
+  severities (`Information → Warning → Error → SevereError`) with a **cumulative
+  floor** — you pick a level and get that and higher; default Warning. The level
+  name encodes actionability (`SevereError` = data/service loss). ([VCS event
+  notification, Linux](https://sort.veritas.com/public/documents/vie/7.0/linux/productguides/html/vcs_admin/ch13s01.htm),
+  [Cluster Server 7.4.1 Admin Guide, Linux](https://www.veritas.com/content/support/en_US/doc/79561893-79561899-0/v30708461-79561899))
+- **Google SRE** ("My Philosophy on Alerting"): route by actionability — **page /
+  ticket / log**; a page must be urgent, real, and *actionable*.
+- **Nagios** flap detection: track recent state changes, and on flapping **suppress
+  the per-event storm in favor of one signal** — i.e. group, don't spam.
+
+## Decision
+**1. One dial — `NOTIFY_LEVEL` — keyed on actionability, cumulative, default
+`attention`.** Four rungs (off = `APPRISE_URLS` unset):
+
+| `NOTIFY_LEVEL` | Adds | Meaning | SRE | VCS |
+|---|---|---|---|---|
+| `attention` *(default)* | needs you | "do/decide something" — recovery failed, remediation failed, refused to start, **flaky-site advisory** | Page/Ticket | Error/SevereError |
+| `recovery` | self-healed incidents | "broke — I fixed it" — gluetun restarted & recovered, dependent remediated & recovered | Ticket | Warning |
+| `activity` | non-fault changes | "changed, no fault" — endpoint/IP changed, `sites.conf` reloaded | — | Information |
+| `all` | firehose | per-loop checks / play-by-play | Log | Debug |
+
+The flaky-site advisory lives in `attention` even though it summarizes recoveries:
+it's the one self-healing-class event that asks a human to *decide* something
+(review/remove a site), and as an edge-triggered rollup it gives the quiet floor the
+*actionable summary* without the individual-restart stream.
+
+**2. Rollup is the substrate, not a toggle.** Every notification is a single,
+self-contained summary of a completed operation ("X failed → did Y → outcome");
+the start/progress/end play-by-play exists only at `all`. The notifier's job is:
+**collect a loop's events → filter by `NOTIFY_LEVEL` → emit one rollup.** Within a
+loop, multiple surviving events are grouped into **one digest** notification
+(colored by the worst tier present); a single event is sent as itself; the
+one-shot CLI paths (`--notify-test`, refused-to-start) are a batch of one. There is
+deliberately **no** separate "digest on/off" knob — grouping is how it works.
+
+Severity (for the Apprise color/icon) is derived from the tier: `attention`→failure,
+`recovery`→success, `activity`/`all`→info.
+
+## How it works (diagrams)
+
+**The dial — what each `NOTIFY_LEVEL` surfaces** (each level adds its own row to
+everything above it):
+
+```mermaid
+flowchart TD
+    OFF[APPRISE_URLS unset — log-only, no alerts]
+    OFF -->|enable: set APPRISE_URLS| ACT
+    ACT[NOTIFY_LEVEL = attention  default] --> ACTe[Needs you: recovery/remediation failed, refused to start, flaky-site advisory]
+    ACT --> REC
+    REC[recovery] --> RECe[Self-healed incidents: gluetun recovered, dependent remediated]
+    REC --> ACTV
+    ACTV[activity] --> ACTVe[Non-fault changes: sites.conf reloaded, endpoint/IP changed]
+    ACTV --> ALL
+    ALL[all] --> ALLe[Firehose: per-loop checks, restart play-by-play]
+```
+
+**How an event earns its tier** — a self-heal is `recovery` (FYI) unless it crosses
+a threshold, which promotes it to `attention`:
+
+```mermaid
+flowchart TD
+    E[A monitor event] --> Q1{Needed fixing?}
+    Q1 -->|no, just changed| ACTV[activity]
+    Q1 -->|yes| Q2{Fix succeeded?}
+    Q2 -->|no| AC1[attention: you must intervene]
+    Q2 -->|yes| Q3{Crossed a threshold? flapping / too-hard}
+    Q3 -->|no| REC[recovery: FYI, self-healed]
+    Q3 -->|yes| AC2[attention: advisory, it keeps needing fixing]
+```
+
+v1 wires the site-flapping threshold (`ADVISORY_WINDOW`/`ADVISORY_MIN_RESTARTS`/
+`ADVISORY_DOMINANCE`). A dependent-flapping advisory and effort-based escalation
+(retries/backoff — ties into #27) plug into the same "crossed a threshold?" gate
+later, with no contract change.
+
+**The pipeline** — why grouping is intrinsic (the rollup substrate):
+
+```mermaid
+flowchart LR
+    EV[problems + point events this loop] --> LC{lifecycle: new / repeat / resolve?}
+    LC -->|suppressed| X[dropped]
+    LC -->|emit| TF{tier within NOTIFY_LEVEL?}
+    TF -->|no| X
+    TF -->|yes| RU[rolled up: one digest per loop]
+    RU --> S[Apprise send: off-thread, time-bounded]
+```
+
+The "lifecycle" step (edge-trigger, repeat, resolve, persistence) is ADR-0012.
+
+## Consequences
+- One conceptual knob (`NOTIFY_LEVEL`) plus operational tunables
+  (`NOTIFY_REPEAT_INTERVAL` re-notify cadence in loops, `NOTIFY_TIMEOUT` send bound).
+  No severity/scope/digest sprawl.
+- Quiet-by-default-when-enabled: turning alerts on gets you only `attention` — exactly
+  "tell me when interaction is required," with deeper levels opt-in.
+- Per-loop grouping makes the channel usable for a fast-acting restarter where many
+  systems would storm — a genuine fit for this tool's event cadence.
+- `activity`/`all` are seeded but intentionally sparse in v1; new events slot into a
+  tier later with no contract change.
+
+## Alternatives considered
+- **Severity floor (`NOTIFY_MIN_LEVEL`).** The shipped-but-unreleased first cut.
+  Rejected: filters by appearance, not actionability; defaults to chatty.
+- **Two dials (level + digest on/off).** Rejected as needless customization —
+  rollup is strictly better here, so it's the default behavior, not a choice.
+- **Per-event sends with downstream grouping (Alertmanager-style).** Rejected for
+  v1: pushes the storm onto the user's backend; the loop is the natural batch
+  boundary and we own it. A cross-loop digest could be a later refinement.

--- a/docs/adr/0012-alert-lifecycle.md
+++ b/docs/adr/0012-alert-lifecycle.md
@@ -1,0 +1,78 @@
+# ADR-0012: Edge-triggered alert lifecycle + persisted state
+
+- **Status:** Accepted
+- **Date:** 2026-06-05
+- **Relates to:** ADR-0011 (the tier dial this feeds), ADR-0010 (the Apprise layer),
+  ADR-0008 (the per-site stats sidecar this mirrors), Tenet 7
+
+## Context
+ADR-0011 decided *what* tier each event is and *how* a loop's events are grouped.
+This decides *when* an ongoing problem is (re-)announced — the part that keeps the
+channel from becoming noise.
+
+A naive notifier sends on every loop a problem is true. But a watchdog re-checks
+every `CHECK_INTERVAL`, so a fault that lasts an hour would fire ~120 times. The
+operator's ask was explicit: **announce a problem once; don't send an unbounded
+stream until I attend to it.** That is edge-triggering — alert on the *transition
+into* a bad state, not its persistence — exactly what Nagios does when it detects
+flapping and suppresses the per-event storm (ADR-0011, prior art).
+
+Two consequences fall out:
+
+1. To announce *once*, the notifier must **remember** which problems are already
+   firing — and that memory must **survive a restart** of the monitor (updates,
+   reboots — and it restarts containers, so restarts happen). Otherwise a restart
+   re-announces everything still broken, or misses a resolve that happened while it
+   was down.
+2. If we announce a start, we should announce the **end** — but a problem can end
+   two ways, and they are not the same message.
+
+## Decision
+A small state machine, `AlertState`, owns the lifecycle. Each loop the monitor
+**reports** the problems currently true and **forgets** subjects it no longer
+manages; at loop end the machine emits the transitions.
+
+```mermaid
+stateDiagram-v2
+    [*] --> Inactive
+    Inactive --> Active: reported (new) — announce
+    Active --> Active: still true & repeat due — remind
+    Active --> Inactive: cleared, subject still live — resolve note
+    Active --> Inactive: subject forgotten — silent clear
+```
+
+- **Edge-triggered:** a problem announces once, when it goes Inactive→Active.
+- **Re-notify cadence — `NOTIFY_REPEAT_INTERVAL`, measured in loops** (the system is
+  loop-driven, so loops are more meaningful than seconds). Default **0 = announce
+  once, then silent until it resolves**; `N>0` reminds every `N` loops while it
+  persists.
+- **Two endings, two messages** (the load-bearing distinction):
+  - **cleared** — the condition went away and the subject still exists → a **resolve**
+    note at the *same tier as the alert* (so an `attention` alert's closure reaches
+    the quiet floor — you hear it broke *and* that it's back).
+  - **removed** — the subject is gone (site dropped from `sites.conf`, dependent
+    excluded/removed) → **silent clear**. A "recovered" there would be a lie.
+- **Persisted** to a JSON sidecar (`NOTIFY_STATE_FILE`, mirroring ADR-0008's stats
+  sidecar) — the active set *and* the loop counter. On startup it loads and
+  reconciles on the first loop: still-broken problems are already Active so they
+  don't re-announce; a problem that cleared while down resolves; best-effort, and a
+  corrupt sidecar degrades to empty rather than crashing the watchdog.
+
+The notifier (ADR-0011) stays a dumb sink — filter by tier, group, send. All
+edge/repeat/resolve logic is here, which keeps both pieces simple and testable.
+
+## Consequences
+- A fault that lasts forever is **one** notification (+ optional reminders), then a
+  resolve — bounded regardless of duration. This is the alert-fatigue fix.
+- A second small sidecar under the logs mount. Best-effort; never gates the loop.
+- "Attended to" is approximated by "resolved" (the condition cleared). A true
+  **ack/silence** ("mute this, I'm on it") needs a control surface (CLI/file/HTTP)
+  and is deliberately left as a follow-up.
+
+## Alternatives considered
+- **Level-triggered (notify every loop it's true) + a time throttle.** Rejected:
+  the throttle only *thins* the stream; edge-triggering removes it. A throttle also
+  can't tell "still broken" from "broke again."
+- **In-memory only (no sidecar).** Rejected: a monitor restart would re-announce
+  every active problem and lose pending resolves — common, since the monitor is
+  itself a container that gets updated/restarted.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -39,3 +39,5 @@ Format: [`_template.md`](_template.md). Status ∈ Proposed | Accepted | Superse
 | [0008](0008-persistent-site-stats-and-advisory.md) | Persistent per-site stats + a flaky-site advisory (keep restart-first; record + advise, don't auto-quarantine) | Accepted |
 | [0009](0009-all-time-latency-histogram.md) | All-time latency percentiles via a bounded DDSketch-style histogram (lifetime view alongside the recent ring) | Accepted |
 | [0010](0010-notification-layer.md) | Opt-in external notification layer via Apprise (drop-in when unset; best-effort; real-library CI test gates auto-merge) | Accepted |
+| [0011](0011-notification-tiers-and-rollup.md) | Notification tiers (`NOTIFY_LEVEL` actionability dial) + per-loop rollup digest | Accepted |
+| [0012](0012-alert-lifecycle.md) | Edge-triggered alert lifecycle (announce once, repeat in loops, resolve vs silent-remove) + persisted state | Accepted |

--- a/gluetun_monitor/alert_state.py
+++ b/gluetun_monitor/alert_state.py
@@ -1,0 +1,159 @@
+"""Active-alert lifecycle with best-effort persistence (ADR-0012).
+
+The notification layer (ADR-0010/0011) is **edge-triggered**: an ongoing problem is
+announced when it *starts*, not every loop it persists. This component owns that
+state machine so the notifier itself stays a dumb sink.
+
+Each loop the monitor reports the problems currently true via :meth:`report`, and the
+subjects it has stopped managing via :meth:`forget`. At loop end :meth:`events` yields:
+
+* a **new** alert for each problem that just appeared,
+* a **reminder** for an ongoing problem every ``repeat_interval`` loops (0 = never —
+  announce once, then stay silent until it resolves),
+* a **resolve** (same tier as the alert) for a problem that **cleared** — its subject
+  still exists, so "it's back" is true, and
+* **silent removal** for a problem whose subject was *forgotten* (site removed from
+  config, dependent excluded/gone) — a "recovered" there would be a lie.
+
+State persists to a JSON sidecar, and the loop counter persists with it, so a restart
+of the monitor neither re-spams still-broken problems nor misses a resolve that
+happened while it was down.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from .notify import NotifyEvent
+
+if TYPE_CHECKING:
+    from .logging_setup import Logger
+
+
+@dataclass
+class _Active:
+    """One currently-firing problem alert."""
+
+    tier: str
+    title: str
+    body: str
+    since_loop: int
+    last_notified_loop: int
+
+
+class AlertState:
+    """Edge-triggered active-alert lifecycle for the notification layer."""
+
+    def __init__(self, path: str | None, *, logger: Logger, repeat_interval: int) -> None:
+        self._path = path
+        self._log = logger
+        self._repeat = repeat_interval
+        self._loop = 0
+        self._active: dict[str, _Active] = {}
+        self._reported: dict[str, tuple[str, str, str]] = {}  # this loop: key -> (tier,title,body)
+        self._forgotten: set[str] = set()  # this loop: subjects no longer monitored
+        self._load()
+
+    # ----- per-loop input from the monitor -----
+
+    def begin_loop(self) -> None:
+        """Open a loop: advance the (persistent) counter, clear this loop's inputs."""
+        self._loop += 1
+        self._reported = {}
+        self._forgotten = set()
+
+    def report(self, key: str, tier: str, title: str, body: str) -> None:
+        """Declare that problem ``key`` is currently true this loop."""
+        self._reported[key] = (tier, title, body)
+
+    def forget(self, key: str) -> None:
+        """Declare that ``key``'s subject is no longer monitored (silent clear)."""
+        self._forgotten.add(key)
+
+    # ----- per-loop output -----
+
+    def events(self) -> list[NotifyEvent]:
+        """Diff this loop's reported problems against the persisted active set."""
+        out: list[NotifyEvent] = []
+
+        for key, (tier, title, body) in self._reported.items():
+            active = self._active.get(key)
+            if active is None:
+                self._active[key] = _Active(tier, title, body, self._loop, self._loop)
+                self._log.debug(f"notify: {key} new ({tier})")
+                out.append(NotifyEvent(tier=tier, title=title, body=body, key=key))
+                continue
+            # Refresh the latest summary in case the numbers moved.
+            active.tier, active.title, active.body = tier, title, body
+            if self._repeat > 0 and (self._loop - active.last_notified_loop) >= self._repeat:
+                active.last_notified_loop = self._loop
+                active_for = self._loop - active.since_loop
+                self._log.debug(f"notify: {key} reminder (active {active_for} loops)")
+                out.append(NotifyEvent(
+                    tier=tier, title=f"still active: {title}", body=body, key=key,
+                ))
+            else:
+                self._log.debug(f"notify: {key} still active, suppressed (repeat={self._repeat})")
+
+        for key in list(self._active):
+            if key in self._reported:
+                continue
+            active = self._active.pop(key)
+            if key in self._forgotten:
+                self._log.debug(f"notify: {key} subject removed — silent clear")
+                continue
+            active_for = self._loop - active.since_loop
+            self._log.debug(f"notify: {key} resolved after {active_for} loops")
+            out.append(NotifyEvent(
+                tier=active.tier,
+                title=f"resolved: {active.title}",
+                body=f"{active.title} has cleared (was active {active_for} loop(s)).",
+                key=f"resolve:{key}",
+            ))
+        return out
+
+    def active_count(self) -> int:
+        """How many problems are currently firing (for the startup/heartbeat log)."""
+        return len(self._active)
+
+    # ----- persistence (best-effort, like the stats sidecar) -----
+
+    def _load(self) -> None:
+        if not self._path:
+            return
+        try:
+            with Path(self._path).open(encoding="utf-8") as fh:
+                raw = json.load(fh)
+            self._loop = int(raw.get("loop", 0))
+            for key, rec in (raw.get("active") or {}).items():
+                self._active[key] = _Active(
+                    tier=str(rec["tier"]),
+                    title=str(rec["title"]),
+                    body=str(rec["body"]),
+                    since_loop=int(rec["since_loop"]),
+                    last_notified_loop=int(rec["last_notified_loop"]),
+                )
+        except (OSError, ValueError, KeyError, TypeError):
+            # Corrupt/missing sidecar: start clean rather than crash the watchdog.
+            self._loop = 0
+            self._active = {}
+
+    def save(self) -> None:
+        """Persist the active set + loop counter atomically. Best-effort."""
+        if not self._path:
+            return
+        payload = {
+            "loop": self._loop,
+            "active": {key: asdict(a) for key, a in self._active.items()},
+        }
+        try:
+            Path(self._path).parent.mkdir(parents=True, exist_ok=True)
+            tmp = Path(f"{self._path}.tmp")
+            with tmp.open("w", encoding="utf-8") as fh:
+                json.dump(payload, fh, indent=2, sort_keys=True)
+            tmp.replace(self._path)
+        except OSError as exc:
+            self._log.debug(f"notify: could not persist alert state: {exc}")

--- a/gluetun_monitor/cli.py
+++ b/gluetun_monitor/cli.py
@@ -124,6 +124,40 @@ def _announce_banner(config: Config, logger: Logger) -> None:
         )
 
 
+_NOTIFY_LEVEL_BLURB = {
+    "attention": "Pinged only when your attention is needed (failed recovery/remediation, "
+    "refused start, flaky-site advisory). Self-heals, changes, and the firehose stay silent.",
+    "recovery": "Also pinged on self-healed incidents (gluetun/dependent recovered).",
+    "activity": "Also pinged on non-fault changes (sites reloaded, endpoint changed).",
+    "all": "Pinged on everything, including per-loop checks (the firehose).",
+}
+
+
+def _log_notify_summary(config: Config, logger: Logger) -> None:
+    """Tell the operator exactly what they signed up for — including what stays silent."""
+    if not config.apprise_urls:
+        logger.info("Notifications: disabled (log-only). Set APPRISE_URLS to enable (see README).")
+        return
+    # Schemes only — the full URLs carry tokens and must never be logged.
+    schemes = sorted({u.split("://", 1)[0] for u in config.apprise_urls if "://" in u})
+    logger.info(
+        f"Notifications: ENABLED — {len(config.apprise_urls)} target(s) "
+        f"[{', '.join(schemes)}], level={config.notify_level}"
+    )
+    logger.info(f"  {_NOTIFY_LEVEL_BLURB.get(config.notify_level, '')}")
+    if config.notify_repeat_interval == 0:
+        logger.info(
+            "  Ongoing problems: announced once, then silent until they resolve "
+            "(NOTIFY_REPEAT_INTERVAL=0)."
+        )
+    else:
+        logger.info(
+            f"  Ongoing problems: reminded every {config.notify_repeat_interval} loop(s) "
+            "while unresolved (NOTIFY_REPEAT_INTERVAL)."
+        )
+    logger.info("  Resolve notices: on — you'll hear when a problem clears.")
+
+
 def _parse_args(argv: list[str] | None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(
         prog="gluetun-monitor",
@@ -173,13 +207,14 @@ def main(argv: list[str] | None = None) -> int:
 
     _install_signal_handlers(logger)
     _announce_banner(config, logger)
+    _log_notify_summary(config, logger)
 
     if config.errors:  # malformed env values — fatal; don't run with unparseable params
         for err in config.errors:
             logger.error(err)
         logger.error("Refusing to start due to invalid configuration")
         notifier.notify(NotifyEvent(
-            "ERROR", "gluetun-monitor refused to start",
+            "attention", "gluetun-monitor refused to start",
             "Invalid configuration: " + "; ".join(config.errors), key="refused-config",
         ))
         return 1
@@ -189,14 +224,14 @@ def main(argv: list[str] | None = None) -> int:
     except Exception as exc:
         logger.error(f"Failed to initialize Docker client: {exc}")
         notifier.notify(NotifyEvent(
-            "ERROR", "gluetun-monitor refused to start",
+            "attention", "gluetun-monitor refused to start",
             f"Failed to initialize the Docker client: {exc}", key="refused-docker",
         ))
         return 1
 
     if not check_prerequisites(client, config, logger):
         notifier.notify(NotifyEvent(
-            "ERROR", "gluetun-monitor refused to start",
+            "attention", "gluetun-monitor refused to start",
             "Prerequisite check failed — see the logs for the specific cause.", key="refused-prereq",
         ))
         return 1

--- a/gluetun_monitor/config.py
+++ b/gluetun_monitor/config.py
@@ -13,6 +13,9 @@ from dataclasses import dataclass
 _TRUE_VALUES = {"1", "true", "yes", "on"}
 _FALSE_VALUES = {"0", "false", "no", "off"}
 _VALID_LOG_LEVELS = {"DEBUG", "INFO", "WARN", "WARNING", "ERROR"}
+# Notification tiers (ADR-0011), cumulative from the quiet floor: action ⊂ recovery
+# ⊂ activity ⊂ all.
+_VALID_NOTIFY_LEVELS = {"attention", "recovery", "activity", "all"}
 
 
 def _env_int(
@@ -157,10 +160,19 @@ class Config:
     # Comma-separated Apprise URLs (ntfy/Discord/Telegram/email/webhook/…).
     # Unset/empty = notifications disabled = today's log-only behavior (drop-in).
     apprise_urls: tuple[str, ...] = ()
-    # Minimum severity to push (INFO/WARN/ERROR); default WARN.
-    notify_min_level: str = "WARN"
-    # Per-event-key throttle in seconds (one send per key per window); 0 = no throttle.
-    notify_throttle: int = 3600
+    # Notification scope (ADR-0011), cumulative: attention (default — only when the
+    # operator's attention is needed) ⊂ recovery (self-healed incidents) ⊂ activity
+    # (non-fault changes) ⊂ all (firehose). The one notification "dial"; rollup/digest
+    # is intrinsic, not a knob.
+    notify_level: str = "attention"
+    # Re-notify cadence for an ONGOING problem, measured in monitor loops (ADR-0012).
+    # 0 = announce once when it starts, then silence until it resolves; N>0 = remind
+    # every N loops while it persists. Alerts are edge-triggered, so a fault that lasts
+    # an hour is one notification, not one per loop.
+    notify_repeat_interval: int = 0
+    # Where the active-alert lifecycle state persists (ADR-0012), so a restart of the
+    # monitor neither re-spams still-broken problems nor misses a resolve. Best-effort.
+    notify_state_file: str = "/logs/notify-state.json"
     # Max seconds to wait for a notification send before carrying on (it runs off the
     # monitoring loop, so a slow/hung backend can't stall the watchdog). Tenet 7.
     notify_timeout: int = 10
@@ -195,11 +207,11 @@ class Config:
             errors.append(
                 f"Invalid LOG_LEVEL={log_level!r}: expected one of {sorted(_VALID_LOG_LEVELS)}"
             )
-        notify_min_level = os.environ.get("NOTIFY_MIN_LEVEL", "WARN").upper()
-        if notify_min_level not in _VALID_LOG_LEVELS:
+        notify_level = os.environ.get("NOTIFY_LEVEL", "attention").lower()
+        if notify_level not in _VALID_NOTIFY_LEVELS:
             errors.append(
-                f"Invalid NOTIFY_MIN_LEVEL={notify_min_level!r}: "
-                f"expected one of {sorted(_VALID_LOG_LEVELS)}"
+                f"Invalid NOTIFY_LEVEL={notify_level!r}: "
+                f"expected one of {sorted(_VALID_NOTIFY_LEVELS)}"
             )
         return cls(
             config_file=os.environ.get("CONFIG_FILE", "/config/sites.conf"),
@@ -238,8 +250,9 @@ class Config:
             apprise_urls=tuple(
                 u.strip() for u in os.environ.get("APPRISE_URLS", "").split(",") if u.strip()
             ),
-            notify_min_level=notify_min_level,
-            notify_throttle=_env_int("NOTIFY_THROTTLE", 3600, errors, minimum=0),
+            notify_level=notify_level,
+            notify_repeat_interval=_env_int("NOTIFY_REPEAT_INTERVAL", 0, errors, minimum=0),
+            notify_state_file=os.environ.get("NOTIFY_STATE_FILE", "/logs/notify-state.json"),
             notify_timeout=_env_int("NOTIFY_TIMEOUT", 10, errors, minimum=1),
             errors=tuple(errors),
         )

--- a/gluetun_monitor/monitor.py
+++ b/gluetun_monitor/monitor.py
@@ -17,6 +17,7 @@ from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
+from .alert_state import AlertState
 from .connectivity import probe_site
 from .dependents import (
     classify_interfaces,
@@ -89,6 +90,17 @@ class Monitor:
         # Opt-in external notifications (#22). Default = NullNotifier (no-op), so
         # nothing changes unless APPRISE_URLS is configured and a notifier injected.
         self.notifier = notifier if notifier is not None else NullNotifier()
+        # Events buffered during one loop; flushed as a single rollup per cycle
+        # (ADR-0011 — grouping is intrinsic, since our fast restarts can fire a
+        # burst of events within one loop).
+        self._pending: list[NotifyEvent] = []
+        # Edge-triggered active-alert lifecycle (ADR-0012). Persisted only when
+        # notifications are actually enabled (no stray sidecar for a log-only run).
+        self.alerts = AlertState(
+            config.notify_state_file if config.apprise_urls else None,
+            logger=logger,
+            repeat_interval=config.notify_repeat_interval,
+        )
         self._rng = rng if rng is not None else random.Random()
         # _probe_dependent runs across a ThreadPoolExecutor (_fan_out), and a
         # random.Random instance is not thread-safe — concurrent sample()/uniform()
@@ -108,6 +120,9 @@ class Monitor:
         # longer matches it — but we remember it from before the recreate and
         # keep checking it (ADR-0004: track across cycles). Pruned to existing.
         self._known_dependents: set[str] = set()
+        # The set managed last loop — to silently clear an alert when a dependent
+        # leaves (excluded or gone), rather than emit a false "resolved" (ADR-0012).
+        self._managed_dependents: set[str] = set()
         # Dedup so a missing explicitly-listed dependent warns once, not per loop.
         self._warned_missing: set[str] = set()
         # Dedup for the dangling-orphan warning (see _warn_dangling_orphans).
@@ -115,9 +130,26 @@ class Monitor:
         # Dedup for "can't validate DNS (no usable tool)" — re-armed if it later validates.
         self._warned_dns_unvalidated: set[str] = set()
 
-    def _notify(self, level: str, title: str, body: str, key: str) -> None:
-        """Push one event to the (opt-in) notifier. Best-effort; never raises."""
-        self.notifier.notify(NotifyEvent(level=level, title=title, body=body, key=key))
+    def _notify(self, tier: str, title: str, body: str, key: str) -> None:
+        """Buffer a one-shot point event for this loop's rollup (ADR-0011)."""
+        self._pending.append(NotifyEvent(tier=tier, title=title, body=body, key=key))
+
+    def _problem(self, key: str, tier: str, title: str, body: str) -> None:
+        """Report an ONGOING problem this loop; the lifecycle (ADR-0012) edge-triggers
+        the notification, repeats it per NOTIFY_REPEAT_INTERVAL, and resolves it.
+        """
+        self.alerts.report(key, tier, title, body)
+
+    def _forget(self, key: str) -> None:
+        """Drop a problem whose subject is no longer monitored (silent clear)."""
+        self.alerts.forget(key)
+
+    def _flush_notifications(self) -> None:
+        """Emit this loop's lifecycle events + point events as one rollup, then persist."""
+        events = self.alerts.events() + self._pending
+        self._pending = []
+        self.notifier.notify_batch(events)
+        self.alerts.save()
 
     # ----- gluetun root test (nodes 2-3) -----
 
@@ -150,10 +182,18 @@ class Monitor:
             if removed:
                 parts.append(f"removed {', '.join(removed)}")
             self.log.info(f"Sites changed: {'; '.join(parts)} (now {len(sites)})")
+            self._notify(
+                "activity",
+                "sites.conf changed",
+                f"Test sites changed: {'; '.join(parts)} (now {len(sites)}).",
+                key="sites-changed",
+            )
             # A removed site keeps no live failure counter — a later re-add starts
-            # clean rather than resuming near the threshold.
+            # clean rather than resuming near the threshold — and any active advisory
+            # for it is silently cleared (you removed it; "resolved" would be a lie).
             for site in removed:
                 self.site_failures.discard(site)
+                self._forget(f"advisory:{site}")
             self._last_sites = current
 
         results = self._fan_out(
@@ -365,6 +405,11 @@ class Monitor:
     def run_dependent_phase(self, gluetun_id: str, sites: list[str]) -> None:
         """Probe every dependent and remediate those that fail (nodes 6-19)."""
         dependents = self._resolve_dependents()
+        # A dependent that left the managed set (excluded or gone) gets its active
+        # alert silently cleared — a "resolved" would imply it recovered (ADR-0012).
+        for gone in self._managed_dependents - set(dependents):
+            self._forget(f"dependent-unhealthy:{gone}")
+        self._managed_dependents = set(dependents)
         if not dependents:
             return
 
@@ -452,23 +497,38 @@ class Monitor:
             ):
                 self.dependent_failures.reset(dep)
                 self._notify(
-                    "WARN",
-                    f"dependent remediated: {dep}",
+                    "recovery",
+                    f"dependent recovered: {dep}",
                     f"{dep} was remediated ({reason}) and verified healthy.",
                     key=f"dependent-remediated:{dep}",
                 )
             else:
-                self._notify(
-                    "ERROR",
-                    f"dependent remediation FAILED: {dep}",
+                # An ongoing problem → the lifecycle (edge-triggered, repeat, resolve),
+                # not a per-loop point event.
+                self._problem(
+                    f"dependent-unhealthy:{dep}",
+                    "attention",
+                    f"dependent unhealthy: {dep}",
                     f"{dep} is still unhealthy after remediation ({reason}) — "
                     f"manual intervention may be required.",
-                    key=f"dependent-failed:{dep}",
                 )
 
     # ----- one full loop iteration (node 1 -> 22, minus the sleep) -----
 
     def run_once(self) -> None:
+        """Execute one monitoring cycle, then flush this loop's notification rollup.
+
+        The flush is in ``finally`` so every early return (gluetun down, recovery
+        failed, …) still emits the cycle's single digest (ADR-0011).
+        """
+        self._pending = []
+        self.alerts.begin_loop()
+        try:
+            self._run_once_body()
+        finally:
+            self._flush_notifications()
+
+    def _run_once_body(self) -> None:
         """Execute one monitoring cycle (no inter-loop sleep)."""
         self.log.check("Start")
         self.stats.record_loop()  # monitor-wide: loop count + accumulated runtime
@@ -525,20 +585,19 @@ class Monitor:
             return
         self.stats.record_gluetun_restart()  # monitor-wide count of actual restarts
         self._notify(
-            "WARN",
-            f"gluetun restarting ({self.config.gluetun_container})",
-            f"Connectivity failed for: {', '.join(breached)} — restarting "
-            f"{self.config.gluetun_container} and re-verifying.",
+            "all",
+            f"gluetun restart triggered ({self.config.gluetun_container})",
+            f"Connectivity failed for: {', '.join(breached)} — restarting and re-verifying.",
             key="gluetun-restart",
         )
         if not restart_gluetun(self.client, self.config, self.log, sleep=self._sleep):
             self.log.error("Recovery failed - manual intervention may be required")
-            self._notify(
-                "ERROR",
-                f"gluetun recovery FAILED ({self.config.gluetun_container})",
-                f"{self.config.gluetun_container} did not come back healthy after a restart — "
-                f"manual intervention may be required.",
-                key="gluetun-recovery-failed",
+            self._problem(
+                "gluetun-unrecovered",
+                "attention",
+                f"gluetun cannot recover ({self.config.gluetun_container})",
+                f"Was failing on {', '.join(breached)}; restarted but it did not come back "
+                f"healthy — manual intervention may be required.",
             )
             return
 
@@ -550,17 +609,23 @@ class Monitor:
             self.stats.record_restart_outcome(site, cleared=site not in still)
         if reverify_breached:
             self.log.warn("Connectivity still failing after restart; leaving dependents untouched")
-            self._notify(
-                "ERROR",
-                f"gluetun still failing after restart ({self.config.gluetun_container})",
-                f"Connectivity still failing after restarting {self.config.gluetun_container}: "
+            self._problem(
+                "gluetun-unrecovered",
+                "attention",
+                f"gluetun cannot recover ({self.config.gluetun_container})",
+                f"Restarted {self.config.gluetun_container} but it's still failing: "
                 f"{', '.join(reverify_breached)} — manual intervention may be required.",
-                key="gluetun-restart-ineffective",
             )
             self.site_failures.reset_all()
             return
 
         self.log.info("Connectivity verified after restart")
+        self._notify(
+            "recovery",
+            f"gluetun recovered ({self.config.gluetun_container})",
+            f"Was failing on {', '.join(breached)}; restarted and connectivity is healthy again.",
+            key="gluetun-recovered",
+        )
         self.site_failures.reset_all()
         # Re-inspect: a restart keeps the same id, but be robust if it was recreated.
         gluetun = self.client.inspect(self.config.gluetun_container) or gluetun
@@ -568,7 +633,12 @@ class Monitor:
         self._save_stats()
 
     def _emit_advisory(self) -> None:
-        """Warn (deduped) when one site dominates recent gluetun restarts."""
+        """Surface a flaky-site advisory when one site dominates recent restarts.
+
+        Reported to the alert lifecycle every loop it holds (which edge-triggers the
+        notification + resolves it when it clears); the log line + stats count fire
+        once per episode (``_advised_site``).
+        """
         adv = self.stats.advisory(
             self.config.advisory_window,
             self.config.advisory_min_restarts,
@@ -577,8 +647,16 @@ class Monitor:
         if adv is None:
             self._advised_site = None
             return
+        self._problem(
+            f"advisory:{adv.site}",
+            "attention",
+            f"flaky site: {adv.site}",
+            f"{adv.site} caused {adv.site_restarts} of the last {adv.total_restarts} "
+            f"gluetun restarts over {format_window(adv.window_seconds)} — it may be flaky; "
+            f"consider reviewing or removing it from sites.conf.",
+        )
         if adv.site == self._advised_site:
-            return  # already warned about this site this episode
+            return  # log + stats once per episode (the notification is deduped by AlertState)
         self._advised_site = adv.site
         self.stats.record_advisory()
         self.log.warn(
@@ -586,14 +664,6 @@ class Monitor:
             f"{adv.total_restarts} gluetun restarts over the last "
             f"{format_window(adv.window_seconds)} — it may be flaky; consider "
             f"reviewing or removing it from sites.conf"
-        )
-        self._notify(
-            "WARN",
-            f"flaky site: {adv.site}",
-            f"{adv.site} caused {adv.site_restarts} of the last {adv.total_restarts} "
-            f"gluetun restarts over {format_window(adv.window_seconds)} — it may be flaky; "
-            f"consider reviewing or removing it from sites.conf.",
-            key=f"advisory:{adv.site}",
         )
 
     def _save_stats(self) -> None:

--- a/gluetun_monitor/notify.py
+++ b/gluetun_monitor/notify.py
@@ -1,19 +1,25 @@
-"""Opt-in external notification layer (issue #22, ADR-0010).
+"""Opt-in external notification layer (issue #22, ADR-0010 + ADR-0011).
 
 By default (``APPRISE_URLS`` unset) this is a :class:`NullNotifier`: zero behavior
-change — the monitor stays a log-only tool. When configured, significant and
-infrequent events — gluetun restart, recovery failure, dependent remediation, the
-flaky-site advisory, and refusal to start — are pushed out-of-band via
-`Apprise <https://github.com/caronc/apprise>`_ (100+ backends, configured by URL).
+change — the monitor stays a log-only tool. When configured, events are pushed
+out-of-band via `Apprise <https://github.com/caronc/apprise>`_ (100+ backends).
 
-Tenet 7 (best-effort, non-blocking): a notification failure must **never** affect
-monitoring. Every send is wrapped and swallowed (logged at DEBUG), filtered by a
-minimum severity, and throttled per event key so a persistent fault can't spam.
-Apprise URLs carry secrets, so they are never logged.
+Two design decisions live here (ADR-0011):
 
-The library is exercised for real in CI (a localhost webhook sink), which is what
-lets Dependabot auto-merge apprise patch/minor — the same bar docker-py clears via
-the real-daemon test (#24).
+* **One dial, keyed on actionability** — ``NOTIFY_LEVEL`` is a cumulative tier
+  floor, default ``action``: ``action`` (you must act) → ``recovery`` (self-healed
+  incidents) → ``activity`` (non-fault changes) → ``all`` (firehose).
+* **Rollup is the substrate** — the notifier collects a loop's events, filters by
+  the tier floor, and emits **one** digest notification (colored by the worst tier
+  present). A single event is sent as itself; the one-shot CLI paths are a batch of
+  one. Grouping is how it works, not a toggle.
+
+Re-notification of ongoing problems (edge-trigger, repeat, resolve) lives in
+:class:`~gluetun_monitor.alert_state.AlertState` (ADR-0012), upstream of here.
+
+Tenet 7 (best-effort, non-blocking): every send is filtered by tier, run off the
+loop on a bounded daemon thread (apprise's ``notify`` is synchronous), and on any
+failure swallowed + logged at DEBUG. Apprise URLs carry secrets and are never logged.
 """
 
 from __future__ import annotations
@@ -22,41 +28,35 @@ import logging
 import threading
 from collections.abc import Callable
 from dataclasses import dataclass
-from time import monotonic
 from typing import TYPE_CHECKING, Any, Protocol
 
 if TYPE_CHECKING:
     from .config import Config
     from .logging_setup import Logger
 
-# Severity aligned with stdlib logging so NOTIFY_MIN_LEVEL reuses the log names.
-_LEVEL_BY_NAME: dict[str, int] = {
-    "DEBUG": logging.DEBUG,
-    "INFO": logging.INFO,
-    "WARN": logging.WARNING,
-    "WARNING": logging.WARNING,
-    "ERROR": logging.ERROR,
-}
-
-# Our level names → Apprise notify-type strings (apprise's NotifyType is str-based,
-# so the value is accepted directly; the real-apprise CI test confirms this).
-_APPRISE_TYPE_BY_LEVEL = {"INFO": "info", "WARN": "warning", "WARNING": "warning", "ERROR": "failure"}
+# Actionability tiers, quietest floor → loudest. A cumulative NOTIFY_LEVEL of rank
+# R sends every event whose tier rank is <= R.
+TIERS = ("attention", "recovery", "activity", "all")
+_TIER_RANK = {name: i for i, name in enumerate(TIERS)}
+# Tier → Apprise notify-type (color/icon). Strings are accepted directly (apprise's
+# NotifyType is str-based; the real-apprise CI test confirms this).
+_TIER_NOTIFY_TYPE = {"attention": "failure", "recovery": "success", "activity": "info", "all": "info"}
 
 
-def level_value(name: str) -> int:
-    """Map a level name (INFO/WARN/ERROR) to its numeric severity (default WARN)."""
-    return _LEVEL_BY_NAME.get(name.upper(), logging.WARNING)
+def tier_rank(name: str) -> int:
+    """Rank of a tier name (0 = action … 3 = all); unknown → 0 (the loud floor)."""
+    return _TIER_RANK.get(name.lower(), 0)
 
 
 @dataclass(frozen=True, slots=True)
 class NotifyEvent:
     """One notifiable occurrence.
 
-    ``key`` is the throttle/dedup key: at most one send per key per throttle window
-    (mirrors the in-log dedup so a persistent fault notifies once, not every loop).
+    ``tier`` selects the actionability rung (see ``TIERS``). ``key`` is the stable
+    identity of the thing being reported (used by the lifecycle, ADR-0012).
     """
 
-    level: str  # "INFO" | "WARN" | "ERROR"
+    tier: str
     title: str
     body: str
     key: str
@@ -65,8 +65,12 @@ class NotifyEvent:
 class Notifier(Protocol):
     """Sink for :class:`NotifyEvent`. Implementations must never raise."""
 
+    def notify_batch(self, events: list[NotifyEvent]) -> None:
+        """Filter a loop's events by tier and emit one rollup."""
+        ...
+
     def notify(self, event: NotifyEvent) -> None:
-        """Best-effort send of one event."""
+        """Send a single event (a batch of one) — for one-shot paths."""
         ...
 
     def test(self) -> bool:
@@ -76,6 +80,10 @@ class Notifier(Protocol):
 
 class NullNotifier:
     """The default when ``APPRISE_URLS`` is unset — notifications disabled."""
+
+    def notify_batch(self, events: list[NotifyEvent]) -> None:
+        """No-op."""
+        return
 
     def notify(self, event: NotifyEvent) -> None:
         """No-op."""
@@ -87,31 +95,27 @@ class NullNotifier:
 
 
 class AppriseNotifier:
-    """:class:`Notifier` over Apprise: min-level filter + per-key throttle, fully
-    swallowed.
+    """:class:`Notifier` over Apprise: tier filter + per-loop rollup, fully swallowed.
 
-    ``apprise_factory`` is injectable so the wrapper logic (filter/throttle/swallow)
-    is unit-testable with no library and no network; production passes ``None`` and
-    the real ``apprise`` is imported lazily (only when notifications are enabled).
+    Re-notification of ongoing problems (edge-trigger, repeat, resolve) lives in
+    :class:`~gluetun_monitor.alert_state.AlertState`, so this stays a dumb sink:
+    filter by tier, group into one digest, send. ``apprise_factory`` is injectable so
+    the filter/rollup logic is unit-testable with no library and no network;
+    production passes ``None`` and the real ``apprise`` is imported lazily.
     """
 
     def __init__(
         self,
         urls: tuple[str, ...],
         *,
-        min_level: str,
-        throttle_seconds: int,
+        level: str,
         logger: Logger,
         timeout_seconds: int = 10,
-        now: Callable[[], float] = monotonic,
         apprise_factory: Callable[[tuple[str, ...]], Any] | None = None,
     ) -> None:
-        self._min = level_value(min_level)
-        self._throttle = throttle_seconds
+        self._level = tier_rank(level)
         self._timeout = timeout_seconds
         self._log = logger
-        self._now = now
-        self._last_sent: dict[str, float] = {}
         self._apprise = self._build(urls, apprise_factory)
 
     def _build(self, urls: tuple[str, ...], factory: Callable[[tuple[str, ...]], Any] | None) -> Any:
@@ -139,27 +143,30 @@ class AppriseNotifier:
         return ap
 
     def notify(self, event: NotifyEvent) -> None:
-        """Send ``event`` if it clears the min level and isn't throttled. Never raises."""
+        """Send a single event (a batch of one)."""
+        self.notify_batch([event])
+
+    def notify_batch(self, events: list[NotifyEvent]) -> None:
+        """Filter ``events`` by the tier floor, then emit one rollup. Never raises."""
         try:
-            if self._apprise is None:
+            if self._apprise is None or not events:
                 return
-            if level_value(event.level) < self._min:
+            survivors = [e for e in events if tier_rank(e.tier) <= self._level]
+            for e in events:
+                if tier_rank(e.tier) > self._level:
+                    self._log.debug(f"notify: {e.key} (tier={e.tier}) below level — not sent")
+            if not survivors:
                 return
-            if self._throttled(event.key):
-                self._log.debug(f"notify throttled: {event.key}")
-                return
-            ntype = _APPRISE_TYPE_BY_LEVEL.get(event.level.upper(), "warning")
-            if self._dispatch(lambda: self._apprise.notify(
-                title=event.title, body=event.body, notify_type=ntype
-            )):
-                self._last_sent[event.key] = self._now()
+            title, body, ntype = self._compose(survivors)
+            if self._dispatch(lambda: self._apprise.notify(title=title, body=body, notify_type=ntype)):
+                self._log.debug(f"notify: pushed {len(survivors)} event(s) as 1 digest")
             else:
-                self._log.debug(f"notify send reported no success: {event.key}")
+                self._log.debug("notify digest reported no success")
         except Exception as exc:  # Tenet 7: a notify failure never touches the loop
             self._log.debug(f"notify error (swallowed): {exc}")
 
     def test(self) -> bool:
-        """Send a test notification (bypasses level/throttle); True if delivered."""
+        """Send a test notification (bypasses the tier filter); True if delivered."""
         if self._apprise is None:
             return False
         return self._dispatch(lambda: self._apprise.notify(
@@ -167,6 +174,16 @@ class AppriseNotifier:
             body="If you can read this, gluetun-monitor notifications are working.",
             notify_type="info",
         ))
+
+    def _compose(self, events: list[NotifyEvent]) -> tuple[str, str, str]:
+        """Render survivors into one (title, body, notify_type). Worst tier wins the type."""
+        ordered = sorted(events, key=lambda e: tier_rank(e.tier))  # action first
+        ntype = _TIER_NOTIFY_TYPE.get(ordered[0].tier, "info")
+        if len(ordered) == 1:
+            return ordered[0].title, ordered[0].body, ntype
+        title = f"gluetun-monitor — {len(ordered)} events this cycle"
+        body = "\n".join(f"• [{e.tier}] {e.title}: {e.body}" for e in ordered)
+        return title, body, ntype
 
     def _dispatch(self, send: Callable[[], Any]) -> bool:
         """Run ``send`` on a daemon thread and wait at most ``timeout_seconds``.
@@ -194,12 +211,6 @@ class AppriseNotifier:
             return False
         return result[0] if result else False
 
-    def _throttled(self, key: str) -> bool:
-        if self._throttle <= 0:
-            return False
-        last = self._last_sent.get(key)
-        return last is not None and (self._now() - last) < self._throttle
-
 
 def build_notifier(config: Config, logger: Logger) -> Notifier:
     """A :class:`NullNotifier` when ``APPRISE_URLS`` is unset; an
@@ -209,8 +220,7 @@ def build_notifier(config: Config, logger: Logger) -> Notifier:
         return NullNotifier()
     return AppriseNotifier(
         config.apprise_urls,
-        min_level=config.notify_min_level,
-        throttle_seconds=config.notify_throttle,
+        level=config.notify_level,
         timeout_seconds=config.notify_timeout,
         logger=logger,
     )

--- a/tests/fakes.py
+++ b/tests/fakes.py
@@ -20,11 +20,16 @@ class FakeNotifier:
     """Records every NotifyEvent so tests can assert what was pushed (no network)."""
 
     def __init__(self) -> None:
-        self.events: list[NotifyEvent] = []
+        self.events: list[NotifyEvent] = []  # flattened across batches
+        self.batches: list[list[NotifyEvent]] = []  # one entry per flush (rollup)
         self.test_result = True
 
+    def notify_batch(self, events: list[NotifyEvent]) -> None:
+        self.events.extend(events)
+        self.batches.append(list(events))
+
     def notify(self, event: NotifyEvent) -> None:
-        self.events.append(event)
+        self.notify_batch([event])
 
     def test(self) -> bool:
         return self.test_result

--- a/tests/test_alert_state.py
+++ b/tests/test_alert_state.py
@@ -1,0 +1,113 @@
+"""The edge-triggered active-alert lifecycle (ADR-0012).
+
+Covers the four transitions an ongoing problem can make — new, reminder (per
+NOTIFY_REPEAT_INTERVAL loops), resolved (cleared, with subject still live), and
+silent-removed (forgotten) — plus persistence across a restart of the monitor.
+"""
+
+from __future__ import annotations
+
+import io
+from pathlib import Path
+
+from gluetun_monitor.alert_state import AlertState
+from gluetun_monitor.logging_setup import Logger
+
+
+def _log() -> Logger:
+    return Logger(log_file=None, level="DEBUG", stream=io.StringIO())
+
+
+def _state(path: str | None = None, *, repeat: int = 0) -> AlertState:
+    return AlertState(path, logger=_log(), repeat_interval=repeat)
+
+
+def test_new_problem_emits_once_then_silent_at_repeat_zero() -> None:
+    s = _state(repeat=0)
+    s.begin_loop()
+    s.report("k", "attention", "title", "body")
+    events = s.events()
+    assert len(events) == 1
+    assert events[0].key == "k" and events[0].tier == "attention"
+
+    s.begin_loop()
+    s.report("k", "attention", "title", "body")  # still active
+    assert s.events() == []  # repeat=0 → announce once, then silence
+
+
+def test_repeat_interval_reminds_every_n_loops() -> None:
+    s = _state(repeat=2)
+    s.begin_loop()
+    s.report("k", "attention", "t", "b")
+    assert len(s.events()) == 1  # loop 1: new
+    s.begin_loop()
+    s.report("k", "attention", "t", "b")
+    assert s.events() == []  # loop 2: 1 < 2 → suppressed
+    s.begin_loop()
+    s.report("k", "attention", "t", "b")
+    reminders = s.events()  # loop 3: 2 >= 2 → reminder
+    assert len(reminders) == 1
+    assert reminders[0].title.startswith("still active")
+
+
+def test_resolve_when_condition_clears() -> None:
+    s = _state()
+    s.begin_loop()
+    s.report("k", "attention", "The problem", "b")
+    s.events()
+    s.begin_loop()  # not reported this loop → it cleared
+    resolved = s.events()
+    assert len(resolved) == 1
+    assert resolved[0].key == "resolve:k"
+    assert resolved[0].tier == "attention"  # closure reaches the same floor as the alert
+    assert "resolved" in resolved[0].title.lower()
+
+
+def test_forgotten_subject_clears_silently() -> None:
+    s = _state()
+    s.begin_loop()
+    s.report("k", "attention", "P", "b")
+    s.events()
+    s.begin_loop()
+    s.forget("k")  # subject removed (site dropped / dependent excluded)
+    assert s.events() == []  # silent — no false "resolved"
+
+
+def test_active_count_reflects_firing_problems() -> None:
+    s = _state()
+    s.begin_loop()
+    s.report("a", "attention", "x", "y")
+    s.report("b", "attention", "x", "y")
+    s.events()
+    assert s.active_count() == 2
+
+
+def test_persistence_survives_a_restart(tmp_path: Path) -> None:
+    path = str(tmp_path / "notify-state.json")
+
+    s1 = AlertState(path, logger=_log(), repeat_interval=0)
+    s1.begin_loop()
+    s1.report("k", "attention", "P", "b")
+    assert len(s1.events()) == 1  # announced
+    s1.save()
+
+    # Restart: still broken → must NOT re-announce (the re-spam this prevents).
+    s2 = AlertState(path, logger=_log(), repeat_interval=0)
+    s2.begin_loop()
+    s2.report("k", "attention", "P", "b")
+    assert s2.events() == []
+    s2.save()
+
+    # Restart: now cleared → the resolve fires even though it healed while down.
+    s3 = AlertState(path, logger=_log(), repeat_interval=0)
+    s3.begin_loop()
+    resolved = s3.events()
+    assert len(resolved) == 1 and resolved[0].key == "resolve:k"
+
+
+def test_corrupt_sidecar_starts_clean(tmp_path: Path) -> None:
+    path = tmp_path / "notify-state.json"
+    path.write_text("{ not valid json")
+    s = AlertState(str(path), logger=_log(), repeat_interval=0)
+    s.begin_loop()
+    assert s.active_count() == 0  # degraded to empty, no crash

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import io
 from pathlib import Path
 
-from gluetun_monitor.cli import check_prerequisites
+from gluetun_monitor.cli import _log_notify_summary, check_prerequisites
 from gluetun_monitor.config import Config
 from gluetun_monitor.logging_setup import Logger
 
@@ -50,3 +50,23 @@ def test_prereqs_fail_gluetun_absent(tmp_path: Path) -> None:
     fake = FakeDockerClient()  # no gluetun container
     cfg = Config(config_file=_sites(tmp_path))
     assert check_prerequisites(fake, cfg, _logger()) is False
+
+
+def test_notify_summary_disabled() -> None:
+    stream = io.StringIO()
+    _log_notify_summary(Config(), Logger(log_file=None, level="INFO", stream=stream))
+    assert "disabled" in stream.getvalue()
+
+
+def test_notify_summary_enabled_masks_urls() -> None:
+    stream = io.StringIO()
+    cfg = Config(
+        apprise_urls=("ntfy://super-secret-token@host/topic",),
+        notify_level="attention",
+        notify_repeat_interval=0,
+    )
+    _log_notify_summary(cfg, Logger(log_file=None, level="INFO", stream=stream))
+    out = stream.getvalue()
+    assert "ENABLED" in out and "ntfy" in out  # scheme shown
+    assert "super-secret-token" not in out  # but never the URL/token
+    assert "announced once" in out  # repeat=0 behavior is stated

--- a/tests/test_monitor.py
+++ b/tests/test_monitor.py
@@ -201,10 +201,10 @@ def test_notifies_on_restart_and_persisting_failure(sites_file: str) -> None:
     fn = FakeNotifier()
     _monitor(fake, sites_file, notifier=fn, fail_threshold=1).run_once()
 
-    assert "gluetun-restart" in fn.event_keys()
-    assert "gluetun-restart-ineffective" in fn.event_keys()
-    ineffective = next(e for e in fn.events if e.key == "gluetun-restart-ineffective")
-    assert ineffective.level == "ERROR"
+    assert "gluetun-restart" in fn.event_keys()  # play-by-play (all tier)
+    assert "gluetun-unrecovered" in fn.event_keys()  # the ongoing problem (attention)
+    unrecovered = next(e for e in fn.events if e.key == "gluetun-unrecovered")
+    assert unrecovered.tier == "attention"
 
 
 def test_notifies_on_recovery_failed(sites_file: str) -> None:
@@ -226,12 +226,33 @@ def test_notifies_on_recovery_failed(sites_file: str) -> None:
     fn = FakeNotifier()
     _monitor(fake, sites_file, notifier=fn, fail_threshold=1).run_once()
 
-    assert "gluetun-recovery-failed" in fn.event_keys()
-    assert next(e for e in fn.events if e.key == "gluetun-recovery-failed").level == "ERROR"
+    assert "gluetun-unrecovered" in fn.event_keys()
+    assert next(e for e in fn.events if e.key == "gluetun-unrecovered").tier == "attention"
+
+
+def test_notifies_on_gluetun_recovery(sites_file: str) -> None:
+    """A gluetun restart that succeeds emits a `recovery`-tier rollup."""
+    fake = FakeDockerClient()
+    fake.add_container("gluetun", id=GLUETUN_ID)
+
+    def handler(name: str, cmd: list[str]) -> ExecResult:
+        if cmd[:2] == ["ls", "/sys/class/net"]:
+            return ExecResult(0, "eth0\nlo\n")
+        # gluetun's sites fail until it's restarted, then pass (recovers).
+        if name == "gluetun" and "gluetun" not in fake.restarted:
+            return ExecResult(4, "")
+        return ExecResult(0, "")
+
+    fake.on_exec = handler
+    fn = FakeNotifier()
+    _monitor(fake, sites_file, notifier=fn, fail_threshold=1).run_once()
+
+    recovered = next(e for e in fn.events if e.key == "gluetun-recovered")
+    assert recovered.tier == "recovery"
 
 
 def test_notifies_flaky_site_advisory(sites_file: str) -> None:
-    """The flaky-site advisory (restarting on a site too often) pushes a WARN."""
+    """The flaky-site advisory (restarting on a site too often) is an `attention` event."""
     fake = FakeDockerClient()
     fake.add_container("gluetun", id=GLUETUN_ID)
     fn = FakeNotifier()
@@ -240,11 +261,32 @@ def test_notifies_flaky_site_advisory(sites_file: str) -> None:
         stats.record_restart("flaky.example")
     mon = _monitor(fake, sites_file, notifier=fn)
     mon.stats = stats
-    mon._emit_advisory()
+    mon.alerts.begin_loop()
+    mon._emit_advisory()  # reports the problem to the lifecycle
+    mon._flush_notifications()  # which run_once normally drives
 
     adv = next(e for e in fn.events if e.key.startswith("advisory:"))
-    assert adv.level == "WARN"
+    assert adv.tier == "attention"
     assert "flaky.example" in adv.title
+
+
+def test_loop_rollup_is_one_batch(sites_file: str) -> None:
+    """All of a loop's events flush as a single rollup batch (ADR-0011)."""
+    fake = FakeDockerClient()
+    fake.add_container("gluetun", id=GLUETUN_ID)
+
+    def handler(name: str, cmd: list[str]) -> ExecResult:
+        if cmd[:2] == ["ls", "/sys/class/net"]:
+            return ExecResult(0, "eth0\nlo\n")
+        return ExecResult(4, "")
+
+    fake.on_exec = handler
+    fn = FakeNotifier()
+    _monitor(fake, sites_file, notifier=fn, fail_threshold=1).run_once()
+
+    # One flush for the loop, even though it emitted multiple events.
+    assert len(fn.batches) == 1
+    assert len(fn.batches[0]) >= 2  # restart (all) + unrecovered (attention) at least
 
 
 def test_gluetun_failure_triggers_restart_then_reverify(sites_file: str) -> None:

--- a/tests/test_notify.py
+++ b/tests/test_notify.py
@@ -1,10 +1,9 @@
-"""The opt-in notification layer (#22, ADR-0010).
+"""The notification sink (#22, ADR-0010 + ADR-0011).
 
-The wrapper logic — min-level filter, per-key throttle, and the Tenet-7 swallow —
-is tested with a fake Apprise object (no library calls, no network). The real
-library is exercised separately in ``test_notify_apprise_real.py`` (the bar that
-lets apprise auto-merge). The monitor wiring (which events fire) is asserted with
-``FakeNotifier`` against ``FakeDockerClient``.
+The tier filter, the per-loop rollup, and the Tenet-7 swallow are tested with a fake
+Apprise object (no library, no network). Re-notification of ongoing problems lives in
+``AlertState`` (see ``test_alert_state.py``). The real library is exercised in
+``test_notify_apprise_real.py``; the monitor wiring in ``test_monitor.py``.
 """
 
 from __future__ import annotations
@@ -19,7 +18,7 @@ from gluetun_monitor.notify import (
     NotifyEvent,
     NullNotifier,
     build_notifier,
-    level_value,
+    tier_rank,
 )
 
 
@@ -31,7 +30,7 @@ class _FakeApprise:
     """Stand-in for apprise.Apprise — records sends; can fail on demand."""
 
     def __init__(self) -> None:
-        self.sent: list[tuple[str, str, str]] = []
+        self.sent: list[tuple[str, str, str]] = []  # (title, body, notify_type)
         self.raise_on_notify = False
         self.return_value = True
 
@@ -42,94 +41,95 @@ class _FakeApprise:
         return self.return_value
 
 
-class _Clock:
-    def __init__(self) -> None:
-        self.t = 1000.0
-
-    def __call__(self) -> float:
-        return self.t
-
-    def advance(self, dt: float) -> None:
-        self.t += dt
+def _notifier(fake: _FakeApprise, **kw: Any) -> AppriseNotifier:
+    kw.setdefault("level", "attention")
+    return AppriseNotifier(("memory://",), logger=_log(), apprise_factory=lambda _urls: fake, **kw)
 
 
-def _notifier(fake: _FakeApprise, clock: _Clock, **kw: Any) -> AppriseNotifier:
-    kw.setdefault("min_level", "WARN")
-    kw.setdefault("throttle_seconds", 100)
-    return AppriseNotifier(
-        ("memory://",), logger=_log(), now=clock, apprise_factory=lambda _urls: fake, **kw
-    )
+def _ev(tier: str, key: str = "k") -> NotifyEvent:
+    return NotifyEvent(tier=tier, title=f"{tier}-title", body=f"{tier}-body", key=key)
 
 
-def test_level_value_maps_names() -> None:
-    assert level_value("INFO") < level_value("WARN") < level_value("ERROR")
-    assert level_value("warning") == level_value("WARN")
-    assert level_value("bogus") == level_value("WARN")  # unknown → WARN default
+def test_tier_rank_orders_quiet_floor_to_firehose() -> None:
+    assert tier_rank("attention") < tier_rank("recovery") < tier_rank("activity") < tier_rank("all")
+    assert tier_rank("ATTENTION") == tier_rank("attention")
+    assert tier_rank("bogus") == tier_rank("attention")  # unknown → loud floor
 
 
 def test_null_notifier_is_noop() -> None:
     n = NullNotifier()
-    n.notify(NotifyEvent("ERROR", "t", "b", "k"))  # must not raise
+    n.notify(_ev("attention"))
+    n.notify_batch([_ev("attention"), _ev("recovery")])
     assert n.test() is False
 
 
-def test_min_level_filters_below_threshold() -> None:
-    fake, clock = _FakeApprise(), _Clock()
-    n = _notifier(fake, clock, min_level="WARN")
-    n.notify(NotifyEvent("INFO", "t", "b", "k1"))  # below WARN → dropped
+def test_tier_floor_filters_deeper_tiers() -> None:
+    fake = _FakeApprise()
+    n = _notifier(fake, level="attention")
+    n.notify(_ev("recovery", "r"))  # deeper than attention → dropped
     assert fake.sent == []
-    n.notify(NotifyEvent("ERROR", "t", "b", "k2"))  # at/above → sent
+    n.notify(_ev("attention", "a"))  # at the floor → sent
     assert len(fake.sent) == 1
-    assert fake.sent[0][2] == "failure"  # ERROR → apprise "failure"
+    assert fake.sent[0][2] == "failure"  # attention → apprise "failure"
 
 
-def test_throttle_dedups_same_key_until_window_passes() -> None:
-    fake, clock = _FakeApprise(), _Clock()
-    n = _notifier(fake, clock, throttle_seconds=100)
-    n.notify(NotifyEvent("WARN", "t", "b", "same"))
-    n.notify(NotifyEvent("WARN", "t", "b", "same"))  # within window → throttled
+def test_higher_level_includes_lower_tiers() -> None:
+    fake = _FakeApprise()
+    n = _notifier(fake, level="activity")
+    n.notify(_ev("recovery", "r"))  # within activity floor
     assert len(fake.sent) == 1
-    clock.advance(101)
-    n.notify(NotifyEvent("WARN", "t", "b", "same"))  # window passed → sent again
-    assert len(fake.sent) == 2
+    assert fake.sent[0][2] == "success"  # recovery → apprise "success"
 
 
-def test_throttle_is_per_key() -> None:
-    fake, clock = _FakeApprise(), _Clock()
-    n = _notifier(fake, clock, throttle_seconds=100)
-    n.notify(NotifyEvent("WARN", "t", "b", "a"))
-    n.notify(NotifyEvent("WARN", "t", "b", "b"))  # different key → not throttled
-    assert len(fake.sent) == 2
+def test_rollup_groups_a_batch_into_one_send() -> None:
+    fake = _FakeApprise()
+    n = _notifier(fake, level="all")
+    n.notify_batch([_ev("attention", "a"), _ev("recovery", "r"), _ev("activity", "c")])
+    assert len(fake.sent) == 1  # one digest, not three
+    title, body, ntype = fake.sent[0]
+    assert "3 events" in title
+    assert "attention-body" in body and "recovery-body" in body and "activity-body" in body
+    assert ntype == "failure"  # worst tier present (attention) sets the color
 
 
-def test_throttle_zero_disables_throttling() -> None:
-    fake, clock = _FakeApprise(), _Clock()
-    n = _notifier(fake, clock, throttle_seconds=0)
-    for _ in range(3):
-        n.notify(NotifyEvent("WARN", "t", "b", "same"))
-    assert len(fake.sent) == 3
+def test_rollup_only_includes_surviving_tiers() -> None:
+    fake = _FakeApprise()
+    n = _notifier(fake, level="recovery")
+    # attention + recovery survive; activity is below the floor and is filtered out.
+    n.notify_batch([_ev("attention", "a"), _ev("recovery", "r"), _ev("activity", "c")])
+    title, body, _ = fake.sent[0]
+    assert "2 events" in title
+    assert "activity-body" not in body
+
+
+def test_single_survivor_sends_as_itself_not_a_digest() -> None:
+    fake = _FakeApprise()
+    n = _notifier(fake, level="recovery")
+    n.notify_batch([_ev("recovery", "r"), _ev("activity", "c")])  # only recovery survives
+    title, body, _ = fake.sent[0]
+    assert title == "recovery-title"  # not the "N events" digest framing
+    assert body == "recovery-body"
+
+
+def test_empty_or_all_filtered_batch_sends_nothing() -> None:
+    fake = _FakeApprise()
+    n = _notifier(fake, level="attention")
+    n.notify_batch([])  # nothing
+    n.notify_batch([_ev("all", "x"), _ev("activity", "y")])  # all below floor
+    assert fake.sent == []
 
 
 def test_send_exception_is_swallowed() -> None:
-    fake, clock = _FakeApprise(), _Clock()
+    fake = _FakeApprise()
     fake.raise_on_notify = True
-    n = _notifier(fake, clock)
-    n.notify(NotifyEvent("ERROR", "t", "b", "k"))  # must not raise (Tenet 7)
+    n = _notifier(fake)
+    n.notify(_ev("attention"))  # must not raise (Tenet 7)
     assert fake.sent == []
 
 
-def test_failed_send_is_not_recorded_so_it_retries() -> None:
-    fake, clock = _FakeApprise(), _Clock()
-    fake.return_value = False  # apprise reports no success
-    n = _notifier(fake, clock, throttle_seconds=100)
-    n.notify(NotifyEvent("WARN", "t", "b", "k"))
-    n.notify(NotifyEvent("WARN", "t", "b", "k"))  # not throttled (never recorded a success)
-    assert len(fake.sent) == 2
-
-
 def test_test_method_sends_and_reports() -> None:
-    fake, clock = _FakeApprise(), _Clock()
-    n = _notifier(fake, clock)
+    fake = _FakeApprise()
+    n = _notifier(fake)
     assert n.test() is True
     assert fake.sent and fake.sent[0][2] == "info"
 
@@ -139,22 +139,22 @@ def test_build_notifier_null_without_urls() -> None:
 
 
 def test_build_notifier_apprise_with_urls() -> None:
-    cfg = Config(apprise_urls=("json://localhost",), notify_throttle=0)
+    cfg = Config(apprise_urls=("json://localhost",))
     assert isinstance(build_notifier(cfg, _log()), AppriseNotifier)
 
 
 def test_config_parses_notify_env(monkeypatch: Any) -> None:
     monkeypatch.setenv("APPRISE_URLS", " ntfy://h/t , , discord://x ")
-    monkeypatch.setenv("NOTIFY_MIN_LEVEL", "error")
-    monkeypatch.setenv("NOTIFY_THROTTLE", "60")
+    monkeypatch.setenv("NOTIFY_LEVEL", "Recovery")
+    monkeypatch.setenv("NOTIFY_REPEAT_INTERVAL", "20")
     cfg = Config.from_env()
     assert cfg.apprise_urls == ("ntfy://h/t", "discord://x")  # trimmed, blanks dropped
-    assert cfg.notify_min_level == "ERROR"
-    assert cfg.notify_throttle == 60
+    assert cfg.notify_level == "recovery"
+    assert cfg.notify_repeat_interval == 20
     assert cfg.errors == ()
 
 
-def test_config_rejects_bad_notify_min_level(monkeypatch: Any) -> None:
-    monkeypatch.setenv("NOTIFY_MIN_LEVEL", "LOUD")
+def test_config_rejects_bad_notify_level(monkeypatch: Any) -> None:
+    monkeypatch.setenv("NOTIFY_LEVEL", "loud")
     cfg = Config.from_env()
-    assert any("NOTIFY_MIN_LEVEL" in e for e in cfg.errors)
+    assert any("NOTIFY_LEVEL" in e for e in cfg.errors)

--- a/tests/test_notify_apprise_real.py
+++ b/tests/test_notify_apprise_real.py
@@ -56,11 +56,10 @@ def test_real_apprise_delivers_event_to_sink(sink: tuple[int, list[bytes]]) -> N
     port, received = sink
     notifier = AppriseNotifier(
         (f"json://127.0.0.1:{port}",),
-        min_level="INFO",
-        throttle_seconds=0,
+        level="all",
         logger=_log(io.StringIO()),
     )
-    notifier.notify(NotifyEvent("ERROR", "title-XYZ", "body-ABC", "k"))
+    notifier.notify(NotifyEvent("attention", "title-XYZ", "body-ABC", "k"))
 
     assert received, "real apprise did not POST to the localhost sink"
     body = received[0]
@@ -72,8 +71,7 @@ def test_real_apprise_test_method_delivers(sink: tuple[int, list[bytes]]) -> Non
     port, received = sink
     notifier = AppriseNotifier(
         (f"json://127.0.0.1:{port}",),
-        min_level="WARN",
-        throttle_seconds=0,
+        level="all",
         logger=_log(io.StringIO()),
     )
     assert notifier.test() is True
@@ -84,11 +82,10 @@ def test_real_apprise_rejects_bad_scheme_and_warns() -> None:
     stream = io.StringIO()
     notifier = AppriseNotifier(
         ("totally-not-a-scheme://nowhere",),
-        min_level="INFO",
-        throttle_seconds=0,
+        level="all",
         logger=_log(stream),
     )
     # No server got registered, so a send reports no success (swallowed); the
     # rejection was warned at build time.
-    notifier.notify(NotifyEvent("ERROR", "t", "b", "k"))
+    notifier.notify(NotifyEvent("attention", "t", "b", "k"))
     assert "rejected by apprise" in stream.getvalue()


### PR DESCRIPTION
Reworks the (unreleased) notification layer into the model we designed: an actionability **tier dial**, a **per-loop rollup**, and an **edge-triggered lifecycle** with persistence. No shipped contract is broken — all pre-release.

## The dial — `NOTIFY_LEVEL` (ADR-0011)
One cumulative knob, keyed on *who must act*, default **`attention`** (renamed from `action` so the human is the subject — "raise attention," not "force an action"):

| Level | You get |
|---|---|
| **`attention`** *(default)* | only when you must act: failed recovery/remediation, refused start, flaky-site advisory |
| `recovery` | + self-healed incidents |
| `activity` | + non-fault changes |
| `all` | + firehose |

## Per-loop rollup (ADR-0011)
A cycle's surviving events group into **one digest** (worst tier sets the color). Our restarts are fast, so a loop can fire a burst — grouping prevents storms. Rollup is intrinsic, not a toggle.

## Edge-triggered lifecycle (ADR-0012, new `AlertState`)
The alert-fatigue fix: an ongoing problem announces **once**, reminds every `NOTIFY_REPEAT_INTERVAL` **loops** (default `0` = once), and on ending distinguishes:
- **cleared** (subject still live) → a resolve note at the alert's tier (you hear it broke *and* that it's back), vs
- **removed** (site dropped / dependent excluded) → silent clear (a "recovered" would be a lie).

State **persists** to `NOTIFY_STATE_FILE`, so restarting the monitor neither re-spams still-broken problems nor misses a resolve.

## Smart logging
Startup logs exactly what you signed up for **including what stays silent**; per-event `DEBUG` explains every decision. URLs are never logged (schemes/counts only).

## Diagrams
ADR-0011/0012 carry four mermaid diagrams: the dial, event→tier classification (with the threshold gate), the pipeline, and the lifecycle state machine.

## Tests / gate
Drops the notifier's per-key throttle (re-notification moved to the lifecycle). New `test_alert_state.py` covers new/repeat/resolve/removed + persistence-across-restart. Gate green: ruff + mypy + **97.8%** coverage; the real-apprise localhost-sink test still gates apprise auto-merge.

## Follow-ups (separate)
Dependent-flapping advisory; effort-based escalation (retries/backoff, #27); a true ack/silence control surface.