### PR TITLE
Notify "no longer monitored" on subject removal (ADR-0012)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,8 +20,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     most-urgent tier — no storms from a fast restarter.
   - **Edge-triggered lifecycle:** an ongoing problem announces once, reminds every
     `NOTIFY_REPEAT_INTERVAL` loops (default `0` = once), and emits a resolve when it
-    clears (or clears silently if its subject was removed). State persists to
-    `NOTIFY_STATE_FILE` across monitor restarts.
+    clears (or a "no longer monitored" note if its subject was removed). State
+    persists to `NOTIFY_STATE_FILE` across monitor restarts.
   - Best-effort (Tenet 7): sent off the loop bounded by `NOTIFY_TIMEOUT`, failures
     swallowed; URLs never logged; startup logs exactly what you signed up for.
 

--- a/README.md
+++ b/README.md
@@ -584,7 +584,8 @@ starts** — not every 30-second loop it persists. `NOTIFY_REPEAT_INTERVAL` (in
 **loops**, default `0`) controls reminders: `0` = announce once then stay silent
 until it resolves; `N` = remind every `N` loops. When a problem **clears** you get a
 resolve note (so you hear it's back); when its subject is **removed** (site dropped,
-dependent excluded) it clears silently. This state persists to `NOTIFY_STATE_FILE`,
+dependent excluded) you get a "no longer monitored" note instead (the alert is
+retired, not recovered). This state persists to `NOTIFY_STATE_FILE`,
 so restarting the monitor neither re-spams still-broken problems nor misses a
 resolve (ADR-0012).
 

--- a/docs/adr/0012-alert-lifecycle.md
+++ b/docs/adr/0012-alert-lifecycle.md
@@ -38,7 +38,7 @@ stateDiagram-v2
     Inactive --> Active: reported (new) — announce
     Active --> Active: still true & repeat due — remind
     Active --> Inactive: cleared, subject still live — resolve note
-    Active --> Inactive: subject forgotten — silent clear
+    Active --> Inactive: subject removed — "no longer monitored" note
 ```
 
 - **Edge-triggered:** a problem announces once, when it goes Inactive→Active.
@@ -51,7 +51,9 @@ stateDiagram-v2
     note at the *same tier as the alert* (so an `attention` alert's closure reaches
     the quiet floor — you hear it broke *and* that it's back).
   - **removed** — the subject is gone (site dropped from `sites.conf`, dependent
-    excluded/removed) → **silent clear**. A "recovered" there would be a lie.
+    excluded/removed) → a **"no longer monitored"** deprecation note. A "recovered"
+    there would be a lie, but staying silent leaves the operator wondering where the
+    alert went — so we say plainly that it was retired because the subject left.
 - **Persisted** to a JSON sidecar (`NOTIFY_STATE_FILE`, mirroring ADR-0008's stats
   sidecar) — the active set *and* the loop counter. On startup it loads and
   reconciles on the first loop: still-broken problems are already Active so they

--- a/gluetun_monitor/alert_state.py
+++ b/gluetun_monitor/alert_state.py
@@ -12,8 +12,9 @@ subjects it has stopped managing via :meth:`forget`. At loop end :meth:`events` 
   announce once, then stay silent until it resolves),
 * a **resolve** (same tier as the alert) for a problem that **cleared** — its subject
   still exists, so "it's back" is true, and
-* **silent removal** for a problem whose subject was *forgotten* (site removed from
-  config, dependent excluded/gone) — a "recovered" there would be a lie.
+* a **deprecation** notice for a problem whose subject was *forgotten* (site removed
+  from config, dependent excluded/gone) — "no longer monitored", since a "recovered"
+  there would be a lie.
 
 State persists to a JSON sidecar, and the loop counter persists with it, so a restart
 of the monitor neither re-spams still-broken problems nor misses a resolve that
@@ -102,10 +103,19 @@ class AlertState:
             if key in self._reported:
                 continue
             active = self._active.pop(key)
-            if key in self._forgotten:
-                self._log.debug(f"notify: {key} subject removed — silent clear")
-                continue
             active_for = self._loop - active.since_loop
+            if key in self._forgotten:
+                # Subject removed (site dropped / dependent excluded): the alert is
+                # retired, not recovered — say so plainly rather than imply a fix.
+                self._log.debug(f"notify: {key} subject removed — deprecating alert")
+                out.append(NotifyEvent(
+                    tier=active.tier,
+                    title=f"no longer monitored: {active.title}",
+                    body=f"{active.title} — its subject was removed or excluded; "
+                    f"this alert is retired (it did not necessarily recover).",
+                    key=f"deprecated:{key}",
+                ))
+                continue
             self._log.debug(f"notify: {key} resolved after {active_for} loops")
             out.append(NotifyEvent(
                 tier=active.tier,

--- a/gluetun_monitor/monitor.py
+++ b/gluetun_monitor/monitor.py
@@ -120,8 +120,8 @@ class Monitor:
         # longer matches it — but we remember it from before the recreate and
         # keep checking it (ADR-0004: track across cycles). Pruned to existing.
         self._known_dependents: set[str] = set()
-        # The set managed last loop — to silently clear an alert when a dependent
-        # leaves (excluded or gone), rather than emit a false "resolved" (ADR-0012).
+        # The set managed last loop — to retire an alert ("no longer monitored") when
+        # a dependent leaves (excluded or gone), rather than a false "resolved" (ADR-0012).
         self._managed_dependents: set[str] = set()
         # Dedup so a missing explicitly-listed dependent warns once, not per loop.
         self._warned_missing: set[str] = set()
@@ -141,7 +141,9 @@ class Monitor:
         self.alerts.report(key, tier, title, body)
 
     def _forget(self, key: str) -> None:
-        """Drop a problem whose subject is no longer monitored (silent clear)."""
+        """Retire a problem whose subject is no longer monitored — a "no longer
+        monitored" deprecation notice, not a (false) "resolved" (ADR-0012).
+        """
         self.alerts.forget(key)
 
     def _flush_notifications(self) -> None:
@@ -190,7 +192,7 @@ class Monitor:
             )
             # A removed site keeps no live failure counter — a later re-add starts
             # clean rather than resuming near the threshold — and any active advisory
-            # for it is silently cleared (you removed it; "resolved" would be a lie).
+            # for it is retired with a "no longer monitored" notice (not a "resolved").
             for site in removed:
                 self.site_failures.discard(site)
                 self._forget(f"advisory:{site}")
@@ -406,7 +408,8 @@ class Monitor:
         """Probe every dependent and remediate those that fail (nodes 6-19)."""
         dependents = self._resolve_dependents()
         # A dependent that left the managed set (excluded or gone) gets its active
-        # alert silently cleared — a "resolved" would imply it recovered (ADR-0012).
+        # alert retired with a "no longer monitored" notice, not a "resolved" that
+        # would imply it recovered (ADR-0012).
         for gone in self._managed_dependents - set(dependents):
             self._forget(f"dependent-unhealthy:{gone}")
         self._managed_dependents = set(dependents)

--- a/tests/test_alert_state.py
+++ b/tests/test_alert_state.py
@@ -63,14 +63,17 @@ def test_resolve_when_condition_clears() -> None:
     assert "resolved" in resolved[0].title.lower()
 
 
-def test_forgotten_subject_clears_silently() -> None:
+def test_forgotten_subject_emits_deprecation_not_resolve() -> None:
     s = _state()
     s.begin_loop()
     s.report("k", "attention", "P", "b")
     s.events()
     s.begin_loop()
     s.forget("k")  # subject removed (site dropped / dependent excluded)
-    assert s.events() == []  # silent — no false "resolved"
+    events = s.events()
+    assert len(events) == 1
+    assert events[0].key == "deprecated:k"  # retired, NOT "resolve:k"
+    assert "no longer monitored" in events[0].title
 
 
 def test_active_count_reflects_firing_problems() -> None:


### PR DESCRIPTION
Follow-up to #43. When an active alert's subject is **removed** (site dropped from `sites.conf`, dependent excluded/gone), emit a **"no longer monitored"** deprecation note instead of clearing silently — a "resolved" would imply it recovered, but silence leaves you wondering where the alert went. `resolved` (cleared, subject still live) is unchanged. Small change to `AlertState` + tests + ADR-0012/README/CHANGELOG wording. Gate green (97.8%).