### PR TITLE
CI: rolling :edge channel + SLSA provenance/SBOM (ADR-0013)

### DIFF
--- a/.github/workflows/edge.yml
+++ b/.github/workflows/edge.yml
@@ -1,19 +1,28 @@
-name: Release
+name: Edge
+
+# Rolling bleeding-edge image: rebuilt on every push to main and published as
+# `:edge` (+ an addressable `:edge-<sha>` per build). NOT guaranteed stable — see
+# docs/VERSIONING.md. Decoupled from releases: `:latest`/`:MAJOR` move only on a cut
+# release (ADR-0013). Stable releases are built by release.yml on a tag.
 
 on:
   push:
-    tags:
-      - 'v*'
+    branches: [main]
+
+# A burst of merges only needs the newest edge built.
+concurrency:
+  group: edge-${{ github.ref }}
+  cancel-in-progress: true
 
 env:
   IMAGE_NAME: gluetun-monitor
 
 jobs:
-  release:
-    name: Build and Push
+  edge:
+    name: Build and push :edge
     runs-on: ubuntu-latest
     permissions:
-      contents: write
+      contents: read
       packages: write
 
     steps:
@@ -46,14 +55,12 @@ jobs:
           images: |
             ghcr.io/${{ github.repository }}
             docker.io/${{ secrets.DOCKERHUB_USERNAME }}/${{ env.IMAGE_NAME }}
-          # latest=auto: `:latest` follows non-prerelease semver tags only. The EOL
-          # v1 branch sets latest=false so old-major patches never claim `:latest`.
+          # Never claim :latest — edge is explicitly not a stable release.
           flavor: |
-            latest=auto
+            latest=false
           tags: |
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-            type=semver,pattern={{major}}
+            type=raw,value=edge
+            type=sha,prefix=edge-,format=short
 
       - name: Build and push
         uses: docker/build-push-action@v7
@@ -64,13 +71,8 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           # Supply-chain trail (ADR-0013): SLSA provenance (records the base image
-          # digest the drift-check reads) + an SBOM, attached as attestations.
+          # digest the future drift-check reads) + an SBOM, attached as attestations.
           provenance: mode=max
           sbom: true
           cache-from: type=gha
           cache-to: type=gha,mode=max
-
-      - name: Create GitHub Release
-        uses: softprops/action-gh-release@v3
-        with:
-          generate_release_notes: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Rolling **`:edge`** image tag — rebuilt on every push to `main` (bleeding edge, not
+  guaranteed stable; see `docs/VERSIONING.md`), plus an addressable `:edge-<sha>` per
+  build. Decoupled from releases: `:latest`/`:MAJOR` still move only on a cut release.
+- Published images now carry **SLSA provenance + an SBOM** attestation — a supply-chain
+  trail (and the source the planned base-image drift check will read). (ADR-0013)
+
 ## [2.1.0] - 2026-06-05
 
 ### Added

--- a/docs/VERSIONING.md
+++ b/docs/VERSIONING.md
@@ -16,6 +16,13 @@ Every release publishes, to both GHCR and Docker Hub:
 | `MAJOR.MINOR` | `2.0` | latest patch of that minor | pinning to a feature line |
 | **`MAJOR`** | **`2`** | latest release within that major | **recommended for production** |
 | `latest` | — | newest **stable** release, **including across a major** | "always newest", attended updates |
+| `edge` | — | **every push to `main`** (rebuilt each merge) | testing the bleeding edge |
+
+> ⚠️ **`:edge` is not a release and is not guaranteed stable.** It is the current
+> `main`, rebuilt on every merge — unreleased fixes *and* unreviewed work in progress.
+> It does **not** move `:latest`/`:MAJOR`, carries no SemVer, and may break. Pin it
+> only to try the newest changes early; never for production. There's also an
+> addressable `:edge-<sha>` per build if you need to pin a specific one.
 
 `:latest` tracks the newest **non-pre-release** version only (the workflow uses
 `latest=auto`). Two guarantees follow, both enforced in CI config rather than by


### PR DESCRIPTION
Phase 1 of the ADR-0013 release automation — the low-risk, watchable pieces.

## What
- **`:edge` rolling channel** (`edge.yml`): builds + pushes `:edge` (+ addressable `:edge-<sha>`) on every push to `main`. Multi-arch, never claims `:latest`, concurrency-cancelled so a burst of merges only builds the newest. Decouples "available now" from "stable release."
- **SLSA provenance (`mode=max`) + SBOM** on both the release and edge builds — a supply-chain trail, and the source the planned weekly **base-image drift check** reads the base digest from.
- `VERSIONING.md`: `:edge` documented with a loud "not guaranteed stable" caveat.

## Not in this PR (Phase 2 — needs a live cycle to validate)
release-please + authorship-based auto-merge of the Release PR + the weekly drift check, and the hashed dep lockfile (alters the install path → its own PR).

## Validation
The `:edge` build first fires when this merges to `main` — I'll watch the multi-arch build + attestations succeed there (they only run on a real push, not in PR CI).