### PR TITLE
ci: fix auto-merge-release YAML parse error (quote label if-expr)

### DIFF
--- a/.github/workflows/auto-merge-release.yml
+++ b/.github/workflows/auto-merge-release.yml
@@ -19,7 +19,8 @@ permissions:
 jobs:
   auto-merge:
     # Only release-please's Release PRs (it labels them 'autorelease: pending').
-    if: contains(github.event.pull_request.labels.*.name, 'autorelease: pending')
+    # Quoted because the label's colon-space would otherwise break YAML parsing.
+    if: "contains(github.event.pull_request.labels.*.name, 'autorelease: pending')"
     runs-on: ubuntu-latest
     steps:
       - name: Auto-merge iff the release is all-Dependabot


### PR DESCRIPTION
The `autorelease: pending` label's colon-space broke the unquoted `if:` expression — the workflow failed to parse (failed runs with no jobs) and never evaluated its gate. Quoting the expression fixes it. Caught by watching the live runs.