### PR TITLE
ci: drop Python 3.13, go 3.14-only

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,10 +12,11 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
-      # We declare requires-python >=3.13, so test the range we support — and this
-      # is what lets us safely bump the image's base Python (e.g. to 3.14).
+      # 3.14-only: the product is a single python:3.14-slim image, so that's the only
+      # runtime worth testing. (A future base bump temporarily adds the candidate
+      # here — e.g. 3.14 + 3.15 — validates, switches the base, then drops the old.)
       matrix:
-        python-version: ["3.13", "3.14"]
+        python-version: ["3.14"]
     steps:
       - uses: actions/checkout@v6
 
@@ -80,7 +81,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          python-version: "3.13"
+          python-version: "3.14"
 
       - name: Install package + pinned dev tooling
         run: pip install -e . -r requirements-dev.txt

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ version = "2.1.0"
 description = "Dependent-aware connectivity monitor and self-healer for gluetun VPN stacks"
 readme = "README.md"
 license = { file = "LICENSE" }
-requires-python = ">=3.13"
+requires-python = ">=3.14"
 authors = [{ name = "Charles Marshall" }]
 keywords = ["gluetun", "vpn", "docker", "monitoring", "healthcheck"]
 dependencies = [
@@ -44,7 +44,7 @@ packages = ["gluetun_monitor"]
 # 120, not 80 — modern wide displays, not a 1980s terminal. Wide enough to not
 # fight you; a guardrail for diffs/side-by-side review, not a straitjacket.
 line-length = 120
-target-version = "py313"
+target-version = "py314"
 src = ["gluetun_monitor", "tests"]
 
 [tool.ruff.lint]
@@ -80,7 +80,7 @@ convention = "pep257"
 known-first-party = ["gluetun_monitor"]
 
 [tool.mypy]
-python_version = "3.13"
+python_version = "3.14"
 strict = true
 warn_unreachable = true
 warn_redundant_casts = true


### PR DESCRIPTION
The product is a single `python:3.14-slim` image, so 3.13 only added a CI matrix leg, a 3.13-compat burden, and a `requires-python` promise for a runtime nobody ships. `requires-python >=3.14`, ruff/mypy target 3.14, CI matrix → 3.14 only. (Required-checks already updated to drop the `(3.13)` context.)