### PR TITLE
CI: weekly base-image drift check (ADR-0013) — Phase 2c

### DIFF
--- a/.github/workflows/auto-merge-release.yml
+++ b/.github/workflows/auto-merge-release.yml
@@ -37,10 +37,14 @@ jobs:
             --jq '[.commits[].author.login // "unknown"] | unique | join(",")')
           echo "Authors being released since ${last}: ${authors:-<none>}"
           if [ -z "$authors" ]; then echo "nothing to release — gate"; exit 0; fi
-          # -F: 'dependabot[bot]' contains regex metacharacters, so match it literally.
-          if echo "$authors" | tr ',' '\n' | grep -vqxF 'dependabot[bot]'; then
-            echo "Human-authored change present → leaving the Release PR for a manual click"
+          # Auto-merge allowlist: Dependabot (deps/security) + the base-drift bot
+          # (github-actions[bot], which commits the weekly base-image rebuild). -F
+          # because '[bot]' is regex-special; -x whole-line. Any other author = human.
+          human=$(echo "$authors" | tr ',' '\n' \
+            | grep -vxF -e 'dependabot[bot]' -e 'github-actions[bot]' || true)
+          if [ -n "$human" ]; then
+            echo "Human-authored change present (${human}) → leaving the Release PR for a manual click"
             exit 0
           fi
-          echo "All changes are Dependabot → auto-merging the release"
+          echo "All changes are automation (deps/base-drift) → auto-merging the release"
           gh pr merge --repo "$REPO" --auto --squash "$PR_URL"

--- a/.github/workflows/base-drift.yml
+++ b/.github/workflows/base-drift.yml
@@ -1,0 +1,57 @@
+name: base-drift
+
+# Weekly secure-by-default rebuild (ADR-0013). Resolves the CURRENT digest of
+# python:3.14-slim from the registry — a "faux build", no image build — and compares
+# it to the digest pinned in the Dockerfile. If upstream re-published the base (OS /
+# base-layer security patches), it bumps the pin via a `fix:` commit → release-please
+# opens a patch Release PR → auto-merge-release (github-actions[bot] is on its
+# allowlist) ships it → release.yml rebuilds on the new base. If unchanged, no-op:
+# semvers stay immutable, no churn. Manual `workflow_dispatch` for testing.
+
+on:
+  schedule:
+    - cron: "0 6 * * 1"  # Mondays 06:00 UTC
+  workflow_dispatch: {}
+
+permissions:
+  contents: write
+
+jobs:
+  drift:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          # Push via the PAT so the resulting commit triggers release-please (a
+          # GITHUB_TOKEN push would not).
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
+
+      - name: Bump the base-image pin if upstream moved
+        env:
+          REPO: library/python
+          TAG: "3.14-slim"
+        run: |
+          set -euo pipefail
+          token=$(curl -s "https://auth.docker.io/token?service=registry.docker.io&scope=repository:${REPO}:pull" | jq -r .token)
+          current=$(curl -sI \
+            -H "Authorization: Bearer ${token}" \
+            -H "Accept: application/vnd.oci.image.index.v1+json" \
+            -H "Accept: application/vnd.docker.distribution.manifest.list.v2+json" \
+            "https://registry-1.docker.io/v2/${REPO}/manifests/${TAG}" \
+            | grep -i '^docker-content-digest:' | awk '{print $2}' | tr -d '\r')
+          pinned=$(grep -oP 'FROM python:3\.14-slim@\K\S+' Dockerfile)
+          echo "pinned:  ${pinned}"
+          echo "current: ${current:-<none>}"
+          if [ -z "${current}" ]; then
+            echo "::warning::could not resolve current digest — skipping this run"; exit 0
+          fi
+          if [ "${current}" = "${pinned}" ]; then
+            echo "Base image unchanged — nothing to do."; exit 0
+          fi
+          echo "Base image re-published → bumping pin and cutting a patch."
+          sed -i "s|@${pinned}|@${current}|" Dockerfile
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add Dockerfile
+          git commit -m "fix(deps): rebuild on updated python:3.14-slim base (${current})"
+          git push

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,13 @@
 # gluetun-monitor v2 — Python (ADR-0007). docker-py talks the Docker API
 # directly (honoring DOCKER_HOST / the socket proxy), so the docker CLI is no
 # longer needed in the image.
-FROM python:3.14-slim
+#
+# Base pinned by digest for reproducible builds (ADR-0013). The weekly drift-check
+# workflow (.github/workflows/base-drift.yml) bumps this digest when upstream
+# python:3.14-slim is re-published (security patches) → a `fix:` commit → an
+# auto-merged patch release that rebuilds on the new base. Keep the human-readable
+# tag in the ref so it's obvious what major.minor this is.
+FROM python:3.14-slim@sha256:c845af9399020c7e562969a13689e929074a10fd057acd1b1fad06a2fb068e97
 
 # gosu lets the entrypoint drop privileges to PUID:PGID when the operator opts in
 # (LSIO-style). With no PUID/PGID the container runs as root — a drop-in match for


### PR DESCRIPTION
Final piece of ADR-0013. **Secure-by-default rebuilds without churn or mutable tags.**

- **Pin the base by digest** (`FROM python:3.14-slim@sha256:…`) for reproducible builds.
- **`base-drift.yml`** (weekly cron + `workflow_dispatch`): resolves the *current* `python:3.14-slim` digest from the registry (a "faux build" — no image build), compares to the pin. If upstream re-published the base (OS/security patches), it bumps the pin via a `fix:` commit (authored by `github-actions[bot]`) → release-please patch Release PR → auto-merge → `release.yml` rebuilds on the new base. **Unchanged → no-op.** Immutable semvers, only a version when inputs actually move.
- **Auto-merge gate** extended to allow `github-actions[bot]` (the drift bot) so these rebuilds auto-ship; **any human author still gates**. Verified for dependabot/drift/human/mixed.

## Validation
After merge I'll trigger `base-drift.yml` manually — right now pinned == current, so it should **no-op**, proving the resolve+compare path without cutting a spurious release. The drift→release→rebuild path proves out when upstream actually moves.