### PR TITLE
ci: skip auto-assign for Dependabot PRs (fix weekend perms failure)

### DIFF
--- a/.github/workflows/auto-assign.yml
+++ b/.github/workflows/auto-assign.yml
@@ -7,6 +7,9 @@ on:
 jobs:
   assign:
     name: Assign csmarshall
+    # Dependabot PRs run with a restricted token (the assign call 403s) AND Dependabot
+    # already self-assigns via dependabot.yml — so skip them entirely.
+    if: github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write


### PR DESCRIPTION
The 'Auto-assign PRs' run failed on the Dependabot PR #57: Dependabot-triggered workflows get a restricted token, so `addAssignees` 403s — and it's redundant since `dependabot.yml` already assigns csmarshall. Skip Dependabot PRs.