### PR TITLE
feat(sites): per-URL probe tunables + --suggest-tunables doctor

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,8 +171,8 @@ docker compose up -d
 | [`DEPENDENT_CONTAINERS`](#dependent_containers) | `auto` | `auto` to discover dynamically, or comma-separated list (every named container must exist, else fatal) |
 | [`EXCLUDE_CONTAINERS`](#exclude_containers) | *(unset)* | Comma-separated container names to **never** manage (denylist). Filters auto-discovery and subtracts from an explicit list; exclude wins on overlap |
 | [`CHECK_INTERVAL`](#check_interval) | `30` | Seconds between health checks |
-| [`TIMEOUT`](#timeout) | `10` | Per-request network timeout, applied identically to every probe — `wget --timeout` (gluetun site tests **and** the dependent-container probes) and `ping -W` |
-| `WGET_TRIES` | `1` | Attempts per `wget` probe (the shuffle + consecutive-failure thresholds, not retries, are how noise is tolerated) |
+| [`TIMEOUT`](#timeout) | `10` | Per-request network timeout, applied identically to every probe — `wget --timeout` (gluetun site tests **and** the dependent-container probes) and `ping -W`. Overridable per URL — see [Per-URL tunables](#per-url-tunables) |
+| `WGET_TRIES` | `1` | Attempts per `wget` probe (the shuffle + consecutive-failure thresholds, not retries, are how noise is tolerated). Overridable per URL — see [Per-URL tunables](#per-url-tunables) |
 | [`FAIL_THRESHOLD`](#fail_threshold) | `2` | Consecutive site failures before restarting Gluetun |
 | [`HEALTHY_WAIT_TIMEOUT`](#healthy_wait_timeout) | `120` | Max seconds to wait for Gluetun to become healthy after restart |
 | `DEPENDENT_CONTAINER_FAILURES` | *(= `FAIL_THRESHOLD`)* | Consecutive per-dependent viability failures before remediating that dependent |
@@ -251,6 +251,10 @@ the in-container `wget`/`ping`), is **dropped with a startup warning** rather th
 probed. The probes also pass URLs/hosts after a `--` end-of-options separator, so
 a stray value can never be interpreted as a flag.
 
+An entry may also carry a `|key=value` suffix (e.g. `https://slow.example|timeout=25`)
+to override the probe timeout/retries for **that URL only** — see
+[Per-URL tunables](#per-url-tunables). A bare URL behaves exactly as before.
+
 #### `DOCKER_HOST`
 When unset, the Docker CLI connects via the local socket (`/var/run/docker.sock`). Set this to `tcp://<proxy-host>:2375` to connect through a [Docker socket proxy](#docker-socket-proxy) instead of mounting the socket directly. See the [Docker Socket Proxy](#docker-socket-proxy) section for setup details.
 
@@ -320,6 +324,72 @@ site per loop** (so over loops it covers many names) and only acts after
 design already absorbs a flaky site, so a single fast attempt (`WGET_TRIES=1`) is
 the right default — raise it only if your links are lossy enough that one in-loop
 retry meaningfully helps.
+
+### Per-URL tunables
+
+`TIMEOUT`/`WGET_TRIES` set the **defaults**, and they're right for almost every
+site. Occasionally one canary is *slow but alive* — it answers, just not within
+the global ceiling. (`wget --timeout` bounds each connect/read/DNS step
+**individually**, not the whole request, so a server that opens the connection and
+then takes its time sending headers trips the timeout even though it's up — you'll
+see `Read error (Operation timed out) in headers`.) Timing it out triggers a
+gluetun restart that can't fix anything external.
+
+For exactly that case you can override the probe knobs **per URL**, in either
+source, with a `|key=value` suffix after the URL:
+
+```bash
+# sites.conf — bare URLs are unchanged; add |key=value only where you need it
+https://www.google.com
+https://slow-api.example|timeout=25
+https://flaky.example|timeout=20|tries=2
+```
+
+```yaml
+# SITES env — comma between entries, pipe within an entry
+- SITES=https://www.google.com,https://slow-api.example|timeout=25
+```
+
+- **The separator is `|`** so one syntax works in both the file *and* the
+  comma-separated `SITES` env: a URL never contains a bare `|`, and it survives the
+  CSV split.
+- **Keys:** `timeout` (seconds) and `tries` (attempts) — the per-URL equivalents of
+  `TIMEOUT`/`WGET_TRIES`. A site with no override inherits the globals, so nothing
+  changes for the rest.
+- **Forgiving:** an unknown key or non-positive value is **warned about at startup
+  and skipped** — the URL is still monitored on the defaults; a typo never drops a
+  site.
+- File overrides are **re-read live** like the URLs themselves; the active
+  overrides are logged whenever the set loads (`Per-URL probe overrides: …`).
+
+#### Let the monitor suggest them — `--suggest-tunables`
+
+You don't have to guess. The monitor already records how every site behaves
+(latency percentiles, failure categories, restart effectiveness — see
+[Site stats & flaky-site advisory](#site-stats--flaky-site-advisory))
+and can read that history back as concrete recommendations:
+
+```bash
+docker exec gluetun-monitor gluetun-monitor --suggest-tunables
+# (or, without a running container)
+docker compose run --rm gluetun-monitor --suggest-tunables
+```
+
+It prints a ranked, evidence-backed list — the biggest restart driver first — with
+the exact line to paste:
+
+```
+slow-api.example
+  18 read-timeout failure(s) but answers within p99=2579ms / max=13544ms — slow,
+  not dead; a 25s timeout keeps it a useful canary instead of triggering restarts
+  → https://slow-api.example|timeout=25
+```
+
+When a longer timeout *wouldn't* help — a site whose restarts rarely clear it and
+whose failures are DNS/connection (genuinely unreachable, not merely slow) — it
+says so and points you at reviewing/removing it instead. The suggestions are
+**advisory only**: the monitor never edits your config. The flaky-site advisory in
+the logs and notifications carries the same suggestion inline when one applies.
 
 ### Site Test Success/Failure Logic
 

--- a/README.md
+++ b/README.md
@@ -295,6 +295,28 @@ Uses `wget --spider` which only fetches headers (no response body downloaded).
 
 ### Timeouts & retries — one model, everywhere
 
+**Every timeout the monitor exposes, at a glance:**
+
+| Knob | Default | Scope | Bounds | Per-URL? |
+|---|---|---|---|---|
+| `TIMEOUT` | `10` | per-request | each `wget --timeout` / `ping -W` (gluetun site tests **and** dependent probes) | ✅ [yes](#per-url-tunables) |
+| `WGET_TRIES` | `1` | per-request | attempts per `wget` probe | ✅ [yes](#per-url-tunables) |
+| `CHECK_INTERVAL` | `30` | loop cadence | sleep between check cycles | — |
+| `HEALTHY_WAIT_TIMEOUT` | `120` | post-restart budget | wait for gluetun's healthcheck after a restart | — |
+| `DNS_WAIT_TIMEOUT` | `30` | post-restart budget | poll for DNS to stabilize after a restart | — |
+| `NOTIFY_TIMEOUT` | `10` | per-send | max wait for one (off-thread) notification send | — |
+| `NOTIFY_REPEAT_INTERVAL` | `0` | alert cadence | reminder cadence for an ongoing problem (`0` = announce once) | — |
+
+(The Docker API client timeout isn't a separate knob — it's derived as
+`max(TIMEOUT × 2, 60)`.)
+
+**Only the two per-request knobs (`TIMEOUT`, `WGET_TRIES`) are per-URL-overridable**
+([Per-URL tunables](#per-url-tunables)) — because they're the only ones that act on
+*a specific URL's* probe. The rest are loop cadence (`CHECK_INTERVAL`), notification
+plumbing, or **gluetun-restart-scoped wait budgets** (`HEALTHY_WAIT_TIMEOUT`,
+`DNS_WAIT_TIMEOUT`) that wait on the *gluetun container* recovering, not on probing
+any one site — so a per-URL value would be meaningless. See below for that split.
+
 There is **one per-request timeout knob, `TIMEOUT`**, and it is applied identically
 to every network probe the monitor makes:
 
@@ -361,6 +383,14 @@ https://flaky.example|timeout=20|tries=2
   site.
 - File overrides are **re-read live** like the URLs themselves; the active
   overrides are logged whenever the set loads (`Per-URL probe overrides: …`).
+
+> **Why only `timeout`/`tries`?** These are the only **per-request** knobs — they
+> bound *this URL's* probe, so a per-URL value is meaningful. The other timeouts
+> are not per-URL-overridable by design: `CHECK_INTERVAL` is the loop cadence, and
+> `HEALTHY_WAIT_TIMEOUT`/`DNS_WAIT_TIMEOUT` are **gluetun-restart-scoped wait
+> budgets** — they wait for the *gluetun container* to recover, which has nothing to
+> do with any single site, so there's nothing to scope to a URL. See
+> [Timeouts & retries](#timeouts--retries--one-model-everywhere) for the full split.
 
 #### Let the monitor suggest them — `--suggest-tunables`
 

--- a/gluetun_monitor/cli.py
+++ b/gluetun_monitor/cli.py
@@ -13,7 +13,9 @@ from .docker_client import DockerClient, DockerPyClient
 from .logging_setup import Logger, install_bash_format_on_root
 from .monitor import Monitor
 from .notify import Notifier, NotifyEvent, build_notifier
-from .sites import load_sites_report
+from .site_stats import SiteStatsStore
+from .sites import hostname_of, load_sites_report
+from .tunables import suggest_tunables
 
 
 def check_prerequisites(client: DockerClient, config: Config, logger: Logger) -> bool:
@@ -168,7 +170,56 @@ def _parse_args(argv: list[str] | None) -> argparse.Namespace:
         action="store_true",
         help="send a test notification to APPRISE_URLS and exit (verifies your config)",
     )
+    parser.add_argument(
+        "--suggest-tunables",
+        action="store_true",
+        help="print per-URL timeout/tries suggestions from the persisted site stats "
+        "and exit (paste the '|key=value' lines into sites.conf — see README)",
+    )
     return parser.parse_args(argv)
+
+
+def _run_suggest_tunables(config: Config, logger: Logger) -> int:
+    """Print per-URL tunable suggestions derived from the persisted site stats (#60).
+
+    A read-only report to stdout (not the rotating log): for each site that keeps
+    causing avoidable restarts, the paste-ready ``url|key=value`` override the data
+    supports — or, when no knob helps, the advice to review/remove it. Suggestions
+    are advisory only; nothing is changed.
+    """
+    store = SiteStatsStore(config.stats_file)
+    if not store.sites:
+        logger.info(
+            f"No site stats yet at {config.stats_file or '(STATS_FILE unset)'} — "
+            "run the monitor a while, then retry."
+        )
+        return 0
+    suggestions = suggest_tunables(
+        store.sites, global_timeout=config.timeout, global_tries=config.wget_tries
+    )
+    print("gluetun-monitor — per-URL tunable suggestions")
+    print(
+        f"  source: {config.stats_file}   "
+        f"globals: TIMEOUT={config.timeout}s WGET_TRIES={config.wget_tries}\n"
+    )
+    if not suggestions:
+        print(
+            f"  No suggestions — all {len(store.sites)} site(s) are behaving within "
+            "the global defaults."
+        )
+        return 0
+    flagged = set()
+    for s in suggestions:
+        flagged.add(s.url)
+        print(f"  {hostname_of(s.url)}")
+        print(f"    {s.rationale}")
+        print(f"    → {s.config_line}" if s.config_line
+              else "    → review / remove, or enable auto-backoff (#27)")
+        print()
+    healthy = sorted(hostname_of(u) for u in store.sites if u not in flagged)
+    if healthy:
+        print(f"  Healthy (no change): {', '.join(healthy)}")
+    return 0
 
 
 def _run_notify_test(config: Config, notifier: Notifier, logger: Logger) -> int:
@@ -204,6 +255,9 @@ def main(argv: list[str] | None = None) -> int:
 
     if args.notify_test:
         return _run_notify_test(config, notifier, logger)
+
+    if args.suggest_tunables:
+        return _run_suggest_tunables(config, logger)
 
     _install_signal_handlers(logger)
     _announce_banner(config, logger)

--- a/gluetun_monitor/monitor.py
+++ b/gluetun_monitor/monitor.py
@@ -33,8 +33,16 @@ from .endpoint import get_endpoint_info
 from .notify import Notifier, NotifyEvent, NullNotifier
 from .recovery import remediate_dependent, restart_gluetun
 from .site_stats import SiteStatsStore, format_window
-from .sites import hostname_of, ip_pool, is_ip_literal, load_sites, resolvable_pool
+from .sites import (
+    SiteSpec,
+    hostname_of,
+    ip_pool,
+    is_ip_literal,
+    load_specs,
+    resolvable_pool,
+)
 from .state import Counter, InterfaceStatus, RemediationAction
+from .tunables import suggest_tunables
 
 if TYPE_CHECKING:
     from .config import Config
@@ -115,6 +123,10 @@ class Monitor:
         self.site_failures = Counter()
         self.dependent_failures = Counter()
         self._last_sites: set[str] | None = None
+        # url -> SiteSpec for the current loop, so probe call sites can resolve a
+        # per-URL timeout/tries override (#60). Refreshed each loop in _run_once_body
+        # alongside the (deduplicated) URL list; empty until the first load.
+        self._specs: dict[str, SiteSpec] = {}
         # Dependents seen at least once. A dependent stranded by a gluetun
         # *recreate* still points at the dead old id, so current-id discovery no
         # longer matches it — but we remember it from before the recreate and
@@ -155,6 +167,38 @@ class Monitor:
 
     # ----- gluetun root test (nodes 2-3) -----
 
+    def _probe_knobs(self, url: str) -> tuple[int, int]:
+        """Effective (timeout, tries) for ``url``: its per-URL override if set,
+        else the global ``TIMEOUT``/``WGET_TRIES`` (#60). A URL with no SiteSpec
+        (e.g. an IP-literal pool entry, or one not in the current set) inherits the
+        globals — so behavior is unchanged for un-annotated sites.
+        """
+        spec = self._specs.get(url)
+        timeout = spec.timeout if spec and spec.timeout is not None else self.config.timeout
+        tries = spec.tries if spec and spec.tries is not None else self.config.wget_tries
+        return timeout, tries
+
+    def _log_site_overrides(self) -> None:
+        """Surface per-URL probe overrides so the operator sees what's in effect
+        (#60) — INFO when any exist (discoverability, like the notify summary), a
+        DEBUG confirmation of the global defaults otherwise.
+        """
+        overrides: list[str] = []
+        for url in sorted(self._specs):
+            spec = self._specs[url]
+            knobs = [f"{k}={v}{u}" for k, v, u in (
+                ("timeout", spec.timeout, "s"), ("tries", spec.tries, "")
+            ) if v is not None]
+            if knobs:
+                overrides.append(f"{hostname_of(url)} {' '.join(knobs)}")
+        defaults = f"TIMEOUT={self.config.timeout}s, WGET_TRIES={self.config.wget_tries}"
+        if overrides:
+            self.log.info(
+                f"Per-URL probe overrides: {'; '.join(overrides)} (others use {defaults})"
+            )
+        else:
+            self.log.debug(f"No per-URL probe overrides; all sites use {defaults}")
+
     def check_gluetun_sites(self, sites: list[str], *, record: bool = True) -> list[str]:
         """Test the full URL set from inside gluetun. Return the sites that have
         breached FAIL_THRESHOLD (empty = healthy).
@@ -174,6 +218,7 @@ class Monitor:
         current = set(sites)
         if record and self._last_sites is None:
             self.log.info(f"Loaded {len(sites)} sites (sites.conf + SITES env)")
+            self._log_site_overrides()
             self._last_sites = current
         elif record and current != self._last_sites:
             added = sorted(current - self._last_sites) if self._last_sites else sorted(current)
@@ -184,6 +229,7 @@ class Monitor:
             if removed:
                 parts.append(f"removed {', '.join(removed)}")
             self.log.info(f"Sites changed: {'; '.join(parts)} (now {len(sites)})")
+            self._log_site_overrides()
             self._notify(
                 "activity",
                 "sites.conf changed",
@@ -200,7 +246,7 @@ class Monitor:
 
         results = self._fan_out(
             sites, lambda url: probe_site(self.client, self.config.gluetun_container, url,
-                                          self.config.timeout, self.config.wget_tries)
+                                          *self._probe_knobs(url))
         )
 
         # Site tests run *inside the gluetun container* (the VPN gateway, through
@@ -347,7 +393,7 @@ class Monitor:
         # ``reason`` is the bare detail — "<host> (<why>) [<tool>]" — because the
         # caller prefixes the verb + verdict ("reach ok/fail/?").
         results = [
-            (h, validate_dns(self.client, dep, u, h, self.config.timeout, self.config.wget_tries))
+            (h, validate_dns(self.client, dep, u, h, *self._probe_knobs(u)))
             for (u, h) in resolvable_chosen
         ]
         oks = [(h, r) for (h, r) in results if r.status is DnsStatus.OK]
@@ -557,7 +603,11 @@ class Monitor:
         # Re-read every loop so editing sites.conf is picked up live (the SITES
         # env contribution is fixed at startup). Startup validation guarantees a
         # non-empty set; a runtime edit down to empty just tests nothing this loop.
-        sites = load_sites(self.config.config_file, self.config.sites_env)
+        # Specs carry any per-URL |timeout/|tries overrides (#60); cache the url->spec
+        # map so the probe call sites can resolve a site's effective knobs.
+        specs = load_specs(self.config.config_file, self.config.sites_env)
+        self._specs = {s.url: s for s in specs}
+        sites = [s.url for s in specs]
 
         breached = self.check_gluetun_sites(sites)
         if not breached:
@@ -650,13 +700,17 @@ class Monitor:
         if adv is None:
             self._advised_site = None
             return
+        # Make the advisory actionable: if the stats support a specific per-URL knob
+        # (e.g. the site is slow-but-alive → a wider timeout), name it (#60) instead
+        # of only "consider removing it".
+        hint = self._advisory_hint(adv.site)
         self._problem(
             f"advisory:{adv.site}",
             "attention",
             f"flaky site: {adv.site}",
             f"{adv.site} caused {adv.site_restarts} of the last {adv.total_restarts} "
             f"gluetun restarts over {format_window(adv.window_seconds)} — it may be flaky; "
-            f"consider reviewing or removing it from sites.conf.",
+            f"consider reviewing or removing it from sites.conf.{hint}",
         )
         if adv.site == self._advised_site:
             return  # log + stats once per episode (the notification is deduped by AlertState)
@@ -666,8 +720,24 @@ class Monitor:
             f"FLAKY SITE: {adv.site} caused {adv.site_restarts} of the last "
             f"{adv.total_restarts} gluetun restarts over the last "
             f"{format_window(adv.window_seconds)} — it may be flaky; consider "
-            f"reviewing or removing it from sites.conf"
+            f"reviewing or removing it from sites.conf.{hint}"
         )
+
+    def _advisory_hint(self, site: str) -> str:
+        """A one-sentence per-URL tunable suggestion for ``site`` if the stats
+        support a concrete knob, else "" (#60). Appended to the flaky-site advisory
+        so the operator gets the specific fix, not just "consider removing it".
+        """
+        st = self.stats.sites.get(site)
+        if st is None:
+            return ""
+        sugg = suggest_tunables(
+            {site: st}, global_timeout=self.config.timeout, global_tries=self.config.wget_tries
+        )
+        if sugg and sugg[0].config_line:
+            return (f" The stats suggest `{sugg[0].config_line}` — run "
+                    "--suggest-tunables for the reasoning.")
+        return ""
 
     def _save_stats(self) -> None:
         """Prune stale sites (retention), then persist — every loop (best-effort;

--- a/gluetun_monitor/sites.py
+++ b/gluetun_monitor/sites.py
@@ -4,13 +4,79 @@ Parsing mirrors v1.x exactly: skip blank lines and ``#`` comments, trim
 whitespace. Classification (resolvable hostname vs IP-literal) feeds the
 ADR-0006 per-dependent viability pool — only hostname URLs exercise a
 dependent's DNS.
+
+**Per-URL tunables (#60).** An entry may carry optional ``|key=value`` overrides
+after the URL — ``https://slow.example|timeout=25|tries=2`` — to widen the probe
+timeout/retries for a *specific* slow-but-alive site without touching the global
+``TIMEOUT``/``WGET_TRIES``. ``|`` is the separator because it is URL-excluded
+(RFC 3986 — a real URL never contains a bare one, so it can't collide with URL
+content) *and* survives the comma-splitting of the ``SITES`` env CSV, so one
+syntax works identically in the file and the env. A bare URL (no ``|``) parses
+exactly as before. Parsing is forgiving + loud: an unknown key or bad value is
+warned about and skipped, never fatal — the URL is still monitored on the
+global defaults.
 """
 
 from __future__ import annotations
 
 import ipaddress
+from dataclasses import dataclass
 from pathlib import Path
 from urllib.parse import urlsplit
+
+# Per-URL option keys understood after the ``|`` separator. Both map onto
+# existing ``probe_site`` params, so honoring them needs no probe rework.
+_OPTION_KEYS = ("timeout", "tries")
+
+
+@dataclass(frozen=True, slots=True)
+class SiteSpec:
+    """A test URL plus any per-URL probe overrides.
+
+    ``timeout``/``tries`` are ``None`` when the entry carried no override, meaning
+    "inherit the global ``TIMEOUT``/``WGET_TRIES``" — so an un-annotated site
+    behaves exactly as it did before #60. A set value is the effective per-request
+    knob for *this* URL only.
+    """
+
+    url: str
+    timeout: int | None = None
+    tries: int | None = None
+
+
+def parse_entry(raw: str) -> tuple[SiteSpec | None, list[str]]:
+    """Parse one ``url[|key=value...]`` entry into a :class:`SiteSpec` + warnings.
+
+    Splits on ``|``: the first field is the URL, the rest are ``key=value``
+    options. Returns ``(None, [])`` for an empty entry (caller skips it like a
+    blank line). Forgiving + loud: a malformed option, unknown key, or
+    non-positive-integer value yields a human-readable warning and is skipped —
+    the URL is still returned on the global defaults rather than dropped over a
+    typo (Tenet 1). Warnings are surfaced once at startup by the report loaders.
+    """
+    parts = raw.split("|")
+    url = trim(parts[0])
+    if not url:
+        return None, []
+    values: dict[str, int] = {}
+    warnings: list[str] = []
+    for opt in parts[1:]:
+        opt = trim(opt)
+        if not opt:
+            continue
+        if "=" not in opt:
+            warnings.append(f"malformed option {opt!r} (expected key=value)")
+            continue
+        key, _, value = opt.partition("=")
+        key, value = trim(key).lower(), trim(value)
+        if key not in _OPTION_KEYS:
+            warnings.append(f"unknown option {key!r} (known: {', '.join(_OPTION_KEYS)})")
+            continue
+        if not value.isdigit() or int(value) < 1:
+            warnings.append(f"invalid {key} {value!r} (want a positive integer)")
+            continue
+        values[key] = int(value)
+    return SiteSpec(url, timeout=values.get("timeout"), tries=values.get("tries")), warnings
 
 
 def trim(s: str) -> str:
@@ -62,37 +128,64 @@ def unsafe_site_reason(site: str) -> str | None:
     return None
 
 
+def load_specs_report(
+    config_file: str | Path, sites_env: str | None
+) -> tuple[list[SiteSpec], list[tuple[str, str]]]:
+    """Effective :class:`SiteSpec` list + rejected ``(entry, reason)`` pairs.
+
+    The union of ``sites.conf`` and the ``SITES`` env CSV, each entry parsed for
+    per-URL ``|`` options (:func:`parse_entry`). Deduplicated by URL, first
+    occurrence wins (file entries first, then env-only), so a URL repeated with
+    different options keeps the first set. ``rejected`` carries both unsafe-URL
+    drops (see :func:`unsafe_site_reason`) and per-URL option warnings, so the
+    startup path can surface them all loudly in one place.
+    """
+    try:
+        file_entries = parse_sites_conf(config_file)
+    except FileNotFoundError:
+        file_entries = []
+    env_entries = parse_sites_csv(sites_env) if sites_env else []
+
+    seen: set[str] = set()
+    specs: list[SiteSpec] = []
+    rejected: list[tuple[str, str]] = []
+    for raw in (*file_entries, *env_entries):
+        spec, warnings = parse_entry(raw)
+        if spec is None or spec.url in seen:
+            continue
+        seen.add(spec.url)
+        reason = unsafe_site_reason(spec.url)
+        if reason is not None:
+            rejected.append((spec.url, reason))
+            continue  # an unsafe URL is dropped; its options are moot
+        rejected.extend((spec.url, w) for w in warnings)
+        specs.append(spec)
+    return specs, rejected
+
+
+def load_specs(config_file: str | Path, sites_env: str | None) -> list[SiteSpec]:
+    """Effective :class:`SiteSpec` list (URLs + per-URL overrides), warnings dropped.
+
+    The file is re-read on each call, so editing it (including its ``|`` options)
+    is picked up live; the env value is fixed at process start.
+    """
+    return load_specs_report(config_file, sites_env)[0]
+
+
 def load_sites_report(
     config_file: str | Path, sites_env: str | None
 ) -> tuple[list[str], list[tuple[str, str]]]:
     """Like :func:`load_sites`, but also returns rejected ``(entry, reason)`` pairs.
 
-    Used at startup so the operator gets a loud warning about dropped entries; the
-    per-loop path uses :func:`load_sites` and drops them silently (already warned).
+    Used at startup so the operator gets a loud warning about dropped entries and
+    bad per-URL options; the per-loop path uses :func:`load_specs` directly.
     """
-    try:
-        file_sites = parse_sites_conf(config_file)
-    except FileNotFoundError:
-        file_sites = []
-    env_sites = parse_sites_csv(sites_env) if sites_env else []
-
-    seen: set[str] = set()
-    safe: list[str] = []
-    rejected: list[tuple[str, str]] = []
-    for site in (*file_sites, *env_sites):
-        if site in seen:
-            continue
-        seen.add(site)
-        reason = unsafe_site_reason(site)
-        if reason is not None:
-            rejected.append((site, reason))
-        else:
-            safe.append(site)
-    return safe, rejected
+    specs, rejected = load_specs_report(config_file, sites_env)
+    return [s.url for s in specs], rejected
 
 
 def load_sites(config_file: str | Path, sites_env: str | None) -> list[str]:
-    """Effective test set: the union of ``sites.conf`` and the ``SITES`` env CSV.
+    """Effective test URL set: the union of ``sites.conf`` and the ``SITES`` env CSV.
 
     Either source is optional; both may be supplied. Duplicates are removed,
     first-occurrence order preserved (file entries first, then env-only ones).
@@ -101,7 +194,7 @@ def load_sites(config_file: str | Path, sites_env: str | None) -> list[str]:
     *combined* set being empty is fatal). The file is re-read on each call, so
     editing it is picked up live; the env value is fixed at process start.
     """
-    return load_sites_report(config_file, sites_env)[0]
+    return [s.url for s in load_specs(config_file, sites_env)]
 
 
 def hostname_of(url: str) -> str:

--- a/gluetun_monitor/tunables.py
+++ b/gluetun_monitor/tunables.py
@@ -1,0 +1,150 @@
+"""Data-driven per-URL tunable suggestions (#60).
+
+A pure analysis over the persisted per-site stats (ADR-0008): given how each site
+has actually behaved, recommend the per-URL ``|timeout=`` / ``|tries=`` override
+that would stop it causing needless gluetun restarts — or, when no knob can help
+(it's genuinely unreachable), point the operator at removal / the #27 backoff.
+
+This is advisory only and never auto-applies (Tenet 1). It leans entirely on data
+already in ``site-stats.json``, so it's a side report the operator runs on demand
+(``--suggest-tunables``) — no new collection, no log noise, and trivially testable
+against a stats fixture.
+
+The discriminator is the same one the live data validated: a site that *times out*
+yet has *answered* at latencies near/above the current ceiling is **slow, not
+dead** — widen its timeout and keep it a useful canary. A site whose restarts
+rarely clear it (low ``restart_effectiveness``) and whose failures are DNS/connect
+(not slow reads) is the site's fault, not the VPN's — a longer timeout won't help.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+
+from .site_stats import SiteStat
+
+# A site counts as "slow, not dead" when it has answered at >= this fraction of the
+# current timeout ceiling — proof a wider timeout would convert its read-timeouts
+# into passes (rather than the failure being a hard hang a longer wait won't fix).
+_SLOW_LATENCY_FRACTION = 0.7
+# Minimum read-timeout failures before suggesting a wider timeout — a pattern, not
+# a one-off blip (a single slow read on an otherwise-fast site isn't worth pinning
+# a higher per-URL timeout that would only delay detecting a real outage).
+_MIN_TIMEOUT_FAILURES = 3
+# Headroom (seconds) added above the slowest observed *successful* response when
+# suggesting a new timeout — enough that the occasional slow read still lands.
+_TIMEOUT_HEADROOM_S = 5
+# Minimum restarts before the "restarts don't help — investigate" advice fires;
+# below this it's noise, not a pattern.
+_INVESTIGATE_MIN_RESTARTS = 3
+
+
+@dataclass(frozen=True, slots=True)
+class Suggestion:
+    """One per-URL recommendation derived from a site's history.
+
+    ``config_line`` is the paste-ready ``url|key=value`` for the ``timeout``/
+    ``tries`` kinds, or ``None`` for ``investigate`` (there's nothing to paste —
+    the advice is to review/remove the site or enable the #27 backoff).
+    """
+
+    url: str
+    kind: str  # "timeout" | "tries" | "investigate"
+    config_line: str | None
+    rationale: str
+    restarts: int
+
+
+def _round_up_5(n: int) -> int:
+    """Round ``n`` up to the nearest 5 — tidy, human-friendly timeout values."""
+    return ((n + 4) // 5) * 5
+
+
+def _latency(st: SiteStat) -> dict[str, int]:
+    """Best available latency summary: lifetime histogram if it has samples, else
+    the recent ring (a freshly-seen site may only have the ring populated).
+    """
+    lifetime = st.lifetime_latency.summary()
+    return lifetime if lifetime.get("samples", 0) else st.latency_summary()
+
+
+def _suggest_one(
+    url: str, st: SiteStat, *, global_timeout: int, global_tries: int
+) -> Suggestion | None:
+    """The single best suggestion for one site, or None if it's behaving fine.
+
+    Priority is by *which fix actually helps*: a wider timeout for a slow-but-alive
+    site (the surgical keep-it-useful fix), else "investigate" when restarts are
+    ineffective and the cause isn't slowness, else a retry bump to absorb isolated
+    one-poll blips that tripped a restart.
+    """
+    reasons = st.failure_reasons
+    timeouts = reasons.get("timeout", 0)
+    unreachable = reasons.get("dns", 0) + reasons.get("connection", 0)
+    lat = _latency(st)
+    max_ms, p99 = lat.get("max", 0), lat.get("p99", 0)
+    eff = st.restart_effectiveness
+
+    # (1) Slow-but-alive: a *pattern* of read-timeouts AND it has answered
+    # near/over the ceiling (so a wider timeout converts those into passes).
+    if timeouts >= _MIN_TIMEOUT_FAILURES and max_ms >= global_timeout * 1000 * _SLOW_LATENCY_FRACTION:
+        suggested = _round_up_5(math.ceil(max_ms / 1000) + _TIMEOUT_HEADROOM_S)
+        if suggested > global_timeout:
+            return Suggestion(
+                url, "timeout", f"{url}|timeout={suggested}",
+                f"{timeouts} read-timeout failure(s) but answers within "
+                f"p99={p99}ms / max={max_ms}ms — slow, not dead; a {suggested}s timeout "
+                f"keeps it a useful canary instead of triggering restarts",
+                st.restarts_triggered,
+            )
+
+    # (2) Restarts don't help and it isn't slowness — review/remove or #27 backoff.
+    if (
+        eff is not None and eff < 0.5
+        and st.restarts_triggered >= _INVESTIGATE_MIN_RESTARTS
+        and unreachable >= timeouts
+    ):
+        return Suggestion(
+            url, "investigate", None,
+            f"triggered {st.restarts_triggered} restart(s) that cleared it only "
+            f"{eff:.0%} of the time, mostly DNS/connection failures — a longer timeout "
+            f"won't help; review/remove it or enable auto-backoff (#27)",
+            st.restarts_triggered,
+        )
+
+    # (3) Isolated one-poll blips that nonetheless tripped a restart — a retry
+    # absorbs the transient before it counts (only when not already retrying).
+    if (
+        global_tries < 2
+        and st.restarts_triggered > 0
+        and st.total_failures > 0
+        and st.longest_fail_streak <= 1
+    ):
+        return Suggestion(
+            url, "tries", f"{url}|tries=2",
+            f"{st.total_failures} isolated single-poll failure(s) triggering "
+            f"{st.restarts_triggered} restart(s); tries=2 retries the blip before it "
+            f"counts as a failure",
+            st.restarts_triggered,
+        )
+
+    return None
+
+
+def suggest_tunables(
+    sites: dict[str, SiteStat], *, global_timeout: int, global_tries: int
+) -> list[Suggestion]:
+    """Per-URL tunable suggestions across all sites, ranked by restarts triggered.
+
+    Pure function of the persisted stats — feed it a ``SiteStatsStore.sites`` map.
+    Returns only sites worth acting on (healthy sites yield nothing), most-impactful
+    first so the operator fixes the biggest restart driver before the long tail.
+    """
+    out = [
+        s for url, st in sites.items()
+        if (s := _suggest_one(url, st, global_timeout=global_timeout,
+                              global_tries=global_tries)) is not None
+    ]
+    out.sort(key=lambda s: s.restarts, reverse=True)
+    return out

--- a/sites.conf.example
+++ b/sites.conf.example
@@ -10,6 +10,14 @@
 # - Include sites you actually need to reach through the VPN
 # - Mix general sites with service-specific endpoints
 # - More sites = more comprehensive testing (minimal overhead due to parallel execution)
+#
+# Per-URL tunables:
+# - A slow-but-alive site can get its own probe timeout/retries with a
+#   "|key=value" suffix, overriding the global TIMEOUT/WGET_TRIES for that URL only:
+#       https://slow-api.example|timeout=25
+#       https://flaky.example|timeout=20|tries=2
+#   A bare URL (no "|") behaves exactly as before. Run the monitor with
+#   --suggest-tunables to have it recommend these from observed history.
 
 # General connectivity tests
 https://www.google.com
@@ -19,3 +27,4 @@ https://1.1.1.1
 # Add your custom sites below
 # https://your-service.com
 # https://api.example.com
+# https://slow-api.example|timeout=25

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -5,9 +5,16 @@ from __future__ import annotations
 import io
 from pathlib import Path
 
-from gluetun_monitor.cli import _log_notify_summary, check_prerequisites
+import pytest
+
+from gluetun_monitor.cli import (
+    _log_notify_summary,
+    _run_suggest_tunables,
+    check_prerequisites,
+)
 from gluetun_monitor.config import Config
 from gluetun_monitor.logging_setup import Logger
+from gluetun_monitor.site_stats import SiteStatsStore
 
 from .fakes import FakeDockerClient
 
@@ -70,3 +77,33 @@ def test_notify_summary_enabled_masks_urls() -> None:
     assert "ENABLED" in out and "ntfy" in out  # scheme shown
     assert "super-secret-token" not in out  # but never the URL/token
     assert "announced once" in out  # repeat=0 behavior is stated
+
+
+# ----- --suggest-tunables doctor (#60) -----
+
+def _stats_with_slow_site(path: str) -> None:
+    """Persist a stats file whose one site is slow-but-alive (read-timeouts plus
+    successful responses over the ceiling) so the doctor has a clear suggestion."""
+    store = SiteStatsStore(path)
+    for _ in range(4):
+        store.record_poll("https://slow.example", False, 0, "Operation timed out")
+    store.record_poll("https://slow.example", True, 13000, "")
+    for _ in range(8):
+        store.record_restart("https://slow.example")
+    assert store.save()
+
+
+def test_suggest_tunables_prints_paste_ready_line(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    stats = str(tmp_path / "site-stats.json")
+    _stats_with_slow_site(stats)
+    cfg = Config(stats_file=stats, timeout=10, wget_tries=1)
+    assert _run_suggest_tunables(cfg, _logger()) == 0
+    out = capsys.readouterr().out
+    assert "slow.example" in out
+    assert "https://slow.example|timeout=" in out  # the paste-ready override
+
+
+def test_suggest_tunables_no_stats_is_graceful(tmp_path: Path) -> None:
+    """No stats file yet → a friendly message and a clean exit, not a crash."""
+    cfg = Config(stats_file=str(tmp_path / "absent.json"))
+    assert _run_suggest_tunables(cfg, _logger()) == 0

--- a/tests/test_site_specs.py
+++ b/tests/test_site_specs.py
@@ -1,0 +1,149 @@
+"""Per-URL probe tunables (#60): the ``url|key=value`` parsing and how the
+resolved override reaches the wget inside gluetun.
+
+Why: a slow-but-alive canary needs a wider timeout than the global default, set
+on *that* URL only — without dropping it (the global TIMEOUT stays the floor for
+everyone else). These tests pin the forgiving parser (a typo never drops a site)
+and prove the override actually lands on the exec'd command end to end.
+"""
+
+from __future__ import annotations
+
+import io
+import random
+from pathlib import Path
+
+import pytest
+
+from gluetun_monitor.config import Config
+from gluetun_monitor.docker_client import ExecResult
+from gluetun_monitor.logging_setup import Logger
+from gluetun_monitor.monitor import Monitor
+from gluetun_monitor.sites import SiteSpec, load_specs, load_specs_report, parse_entry
+
+from .fakes import FakeDockerClient
+
+GLUETUN_ID = "a" * 64
+
+
+# ----- parse_entry: the forgiving |key=value parser -----
+
+def test_bare_url_has_no_overrides() -> None:
+    """A URL with no ``|`` parses exactly as before — both knobs inherit (None)."""
+    spec, warnings = parse_entry("https://www.google.com")
+    assert spec == SiteSpec("https://www.google.com", timeout=None, tries=None)
+    assert warnings == []
+
+
+def test_single_and_multiple_options() -> None:
+    spec, warnings = parse_entry("https://slow.example|timeout=25")
+    assert spec == SiteSpec("https://slow.example", timeout=25, tries=None)
+    assert warnings == []
+    spec, warnings = parse_entry("http://x|timeout=20|tries=2")
+    assert spec == SiteSpec("http://x", timeout=20, tries=2)
+    assert warnings == []
+
+
+def test_whitespace_around_url_and_options_is_tolerated() -> None:
+    spec, warnings = parse_entry("  https://x | timeout = 30 ")
+    assert spec == SiteSpec("https://x", timeout=30)
+    assert warnings == []
+
+
+def test_empty_entry_is_skipped() -> None:
+    assert parse_entry("") == (None, [])
+    assert parse_entry("   ") == (None, [])
+    # An entry that is only options with no URL is nothing to test.
+    spec, _ = parse_entry("|timeout=10")
+    assert spec is None
+
+
+@pytest.mark.parametrize(
+    ("entry", "fragment"),
+    [
+        ("https://x|nope=5", "unknown option"),
+        ("https://x|timeout", "malformed option"),
+        ("https://x|timeout=abc", "invalid timeout"),
+        ("https://x|timeout=0", "invalid timeout"),
+        ("https://x|tries=-1", "invalid tries"),
+    ],
+)
+def test_bad_options_warn_but_keep_the_url(entry: str, fragment: str) -> None:
+    """Forgiving + loud: a bad option is warned about and skipped, never fatal —
+    the URL is still monitored on the global defaults (Tenet 1)."""
+    spec, warnings = parse_entry(entry)
+    assert spec is not None and spec.url == "https://x"
+    assert spec.timeout is None and spec.tries is None  # the bad option didn't stick
+    assert any(fragment in w for w in warnings)
+
+
+def test_one_bad_option_does_not_void_a_good_one() -> None:
+    spec, warnings = parse_entry("https://x|timeout=25|bogus=1")
+    assert spec == SiteSpec("https://x", timeout=25)
+    assert len(warnings) == 1 and "unknown option" in warnings[0]
+
+
+# ----- load_specs / load_specs_report: file + env, dedup, reporting -----
+
+def _conf(tmp_path: Path, text: str) -> str:
+    p = tmp_path / "sites.conf"
+    p.write_text(text)
+    return str(p)
+
+
+def test_load_specs_from_file_and_env(tmp_path: Path) -> None:
+    conf = _conf(tmp_path, "https://a|timeout=25\n# comment\nhttps://b\n")
+    specs = load_specs(conf, "https://c|tries=2,https://d")
+    by_url = {s.url: s for s in specs}
+    assert by_url["https://a"].timeout == 25
+    assert by_url["https://b"] == SiteSpec("https://b")
+    assert by_url["https://c"].tries == 2
+    assert by_url["https://d"] == SiteSpec("https://d")
+
+
+def test_dedup_by_url_keeps_first_occurrence(tmp_path: Path) -> None:
+    """A URL repeated (file then env) keeps the *first* options — file wins."""
+    conf = _conf(tmp_path, "https://a|timeout=25\n")
+    specs = load_specs(conf, "https://a|timeout=99")
+    assert [s.url for s in specs] == ["https://a"]
+    assert specs[0].timeout == 25
+
+
+def test_report_surfaces_option_warnings_and_unsafe_drops(tmp_path: Path) -> None:
+    conf = _conf(tmp_path, "https://good|bogus=1\n-flaggy\n")
+    specs, rejected = load_specs_report(conf, None)
+    assert [s.url for s in specs] == ["https://good"]  # bad option kept the URL
+    reasons = dict(rejected)
+    assert "unknown option" in reasons["https://good"]
+    assert "flag" in reasons["-flaggy"]  # leading-dash URL dropped as unsafe
+
+
+def test_missing_file_is_not_fatal(tmp_path: Path) -> None:
+    specs = load_specs(str(tmp_path / "nope.conf"), "https://only-env")
+    assert [s.url for s in specs] == ["https://only-env"]
+
+
+# ----- end to end: the override reaches the wget inside gluetun -----
+
+def test_per_url_timeout_lands_on_the_probe(tmp_path: Path) -> None:
+    """The override is not just parsed — it reaches the exec'd wget for that URL
+    only, while every other site keeps the global TIMEOUT."""
+    conf = _conf(tmp_path, "https://fast.example\nhttps://slow.example|timeout=25|tries=3\n")
+    fake = FakeDockerClient()
+    fake.add_container("gluetun", id=GLUETUN_ID)
+    cmds: list[list[str]] = []
+
+    def handler(name: str, cmd: list[str]) -> ExecResult:
+        cmds.append(cmd)
+        return ExecResult(0, "  HTTP/1.1 200 OK\n")
+
+    fake.on_exec = handler
+    cfg = Config(config_file=conf, gluetun_container="gluetun", timeout=10, wget_tries=1)
+    logger = Logger(log_file=None, level="DEBUG", stream=io.StringIO())
+    Monitor(fake, cfg, logger, rng=random.Random(0), sleep=lambda _s: None).run_once()
+
+    probes = {c[-1]: c for c in cmds if c and c[0] == "wget" and c[-1].startswith("http")}
+    assert "--timeout=25" in probes["https://slow.example"]
+    assert "--tries=3" in probes["https://slow.example"]
+    assert "--timeout=10" in probes["https://fast.example"]  # global, untouched
+    assert "--tries=1" in probes["https://fast.example"]

--- a/tests/test_tunables.py
+++ b/tests/test_tunables.py
@@ -1,0 +1,105 @@
+"""The data-driven per-URL tunable suggestion engine (#60).
+
+Why: the suggestion is what turns the persisted stats into action — it must (a)
+tell a slow-but-alive site (widen its timeout) from a genuinely-dead one (a longer
+timeout won't help → review/#27), (b) not fire on one-off blips, and (c) rank the
+biggest restart driver first. Pure function over SiteStat, so it's pinned here
+against hand-built fixtures rather than a live run.
+"""
+
+from __future__ import annotations
+
+from gluetun_monitor.site_stats import SiteStat
+from gluetun_monitor.tunables import suggest_tunables
+
+
+def _stat(**kw: object) -> SiteStat:
+    st = SiteStat(first_seen=0.0)
+    for key, value in kw.items():
+        setattr(st, key, value)
+    return st
+
+
+def _suggest(sites: dict[str, SiteStat], *, timeout: int = 10, tries: int = 1):
+    return suggest_tunables(sites, global_timeout=timeout, global_tries=tries)
+
+
+def test_slow_but_alive_gets_a_timeout_bump() -> None:
+    """A pattern of read-timeouts plus successful responses near/over the ceiling
+    → widen the timeout, anchored above the slowest observed success."""
+    st = _stat(
+        total_polls=100, total_failures=5, failure_reasons={"timeout": 5},
+        restarts_triggered=10, restarts_cleared=4,
+        recent_latencies=[1500, 1800, 13000],  # max well over the 10s ceiling
+    )
+    (s,) = _suggest({"https://slow": st})
+    assert s.kind == "timeout"
+    assert s.config_line == "https://slow|timeout=20"  # round_up_5(ceil(13)+5)
+    assert "slow, not dead" in s.rationale
+
+
+def test_single_timeout_blip_is_not_a_pattern() -> None:
+    """One read-timeout on an otherwise-fast site is noise — no per-URL override
+    (it would only delay detecting a real outage)."""
+    st = _stat(
+        total_polls=100, total_failures=1, failure_reasons={"timeout": 1},
+        restarts_triggered=0, recent_latencies=[600, 11000],
+    )
+    assert _suggest({"https://fast": st}) == []
+
+
+def test_ineffective_dns_failures_point_at_removal_or_backoff() -> None:
+    """Restarts that rarely clear it + DNS/connection failures (not slowness) →
+    'investigate' advice, no paste-able knob (a timeout won't help)."""
+    st = _stat(
+        total_polls=200, total_failures=25,
+        failure_reasons={"dns": 20, "connection": 5},
+        restarts_triggered=10, restarts_cleared=0,  # effectiveness 0.0
+        recent_latencies=[800, 900],
+    )
+    (s,) = _suggest({"https://dead": st})
+    assert s.kind == "investigate"
+    assert s.config_line is None
+    assert "#27" in s.rationale
+
+
+def test_isolated_blips_suggest_a_retry() -> None:
+    """Single-poll failures (never chaining) that still trip a restart → tries=2
+    absorbs the transient before it counts."""
+    st = _stat(
+        total_polls=100, total_failures=3, failure_reasons={"connection": 3},
+        restarts_triggered=3, restarts_cleared=3, longest_fail_streak=1,
+        recent_latencies=[700, 800],
+    )
+    (s,) = _suggest({"https://blippy": st})
+    assert s.kind == "tries"
+    assert s.config_line == "https://blippy|tries=2"
+
+
+def test_tries_not_suggested_when_already_retrying() -> None:
+    """If WGET_TRIES is already >1, the retry suggestion is moot — stay silent."""
+    st = _stat(
+        total_polls=100, total_failures=3, failure_reasons={"connection": 3},
+        restarts_triggered=3, restarts_cleared=3, longest_fail_streak=1,
+        recent_latencies=[700],
+    )
+    assert _suggest({"https://blippy": st}, tries=2) == []
+
+
+def test_healthy_site_yields_nothing() -> None:
+    st = _stat(total_polls=10000, total_failures=2, recent_latencies=[600, 700])
+    assert _suggest({"https://good": st}) == []
+
+
+def test_suggestions_ranked_by_restarts() -> None:
+    """Most-impactful first so the operator fixes the biggest restart driver."""
+    big = _stat(
+        total_polls=100, total_failures=20, failure_reasons={"timeout": 20},
+        restarts_triggered=50, restarts_cleared=20, recent_latencies=[13000],
+    )
+    small = _stat(
+        total_polls=100, total_failures=4, failure_reasons={"timeout": 4},
+        restarts_triggered=5, restarts_cleared=2, recent_latencies=[12000],
+    )
+    out = _suggest({"https://small": small, "https://big": big})
+    assert [s.url for s in out] == ["https://big", "https://small"]


### PR DESCRIPTION
Closes #60.

## What

Per-URL probe tunables — override `timeout`/`tries` for a single URL with a
`|key=value` suffix that works identically in `sites.conf` and the `SITES` env CSV
— plus a `--suggest-tunables` doctor that recommends those overrides from the
stats we already persist.

```
# sites.conf — bare URLs unchanged; add |key=value only where needed
https://www.google.com
https://slow-api.example|timeout=25
https://flaky.example|timeout=20|tries=2
```

## Why

A slow-but-alive canary that answers just over the global `TIMEOUT` trips a
read-timeout (`wget --timeout` is per-operation, not total) and triggers a gluetun
restart that can't fix anything external. A live-log review found one such indexer
driving ~⅓ of all restarts (evidence in #27). A per-site timeout is the surgical
fix that keeps the canary useful instead of demoting it; the global default is
unchanged for everyone else.

## How

- `SiteSpec(url, timeout|None, tries|None)` + a forgiving `parse_entry` (a bad
  option warns and is skipped, never drops the site). `|` chosen because it's
  URL-excluded (RFC 3986) and survives the CSV split, so one syntax covers both
  sources. `load_sites` kept backward-compatible; the monitor caches a `url→spec`
  map each loop and resolves effective `(timeout, tries)` per probe.
- `--suggest-tunables`: a read-only report over the persisted stats — ranked,
  evidence-backed, paste-ready `url|key=value` lines. Slow-but-alive → wider
  timeout; isolated blips → `tries=2`; restarts that don't clear it on
  DNS/connection failures → review/remove (points at #27). Advisory only — never
  edits config. The flaky-site advisory carries the matching suggestion inline.
- Docs: README "Per-URL tunables" section, a consolidated "every timeout at a
  glance" table, and the rationale for why only the two per-request knobs are
  per-URL (the wait-budgets are gluetun-restart-scoped, not per-site).

## Scope

Per-URL applies to exactly the two per-request knobs (`TIMEOUT`, `WGET_TRIES`).
`CHECK_INTERVAL`, the notification knobs, and the post-restart wait budgets
(`HEALTHY_WAIT_TIMEOUT`, `DNS_WAIT_TIMEOUT`) are not per-URL by design.

The dependent-side false-positive hardening (confirm-before-strike) is tracked
separately in #61, on its own branch — kept out of this PR so the
recovery-path change reviews and reverts independently.

## Tests

New `test_site_specs.py` (parser, loader dedup/reporting, end-to-end override
landing on the in-container `wget`) and `test_tunables.py` (suggestion engine), plus
doctor CLI tests. `ruff`/`mypy --strict` clean; coverage 97.4% (floor 95%).
