### PR TITLE
fix(dependents): confirm-before-strike on a single DNS-BROKEN

### DIFF
--- a/gluetun_monitor/monitor.py
+++ b/gluetun_monitor/monitor.py
@@ -360,16 +360,57 @@ class Monitor:
             )
             return DependentProbe(dep, status, True, True, detail, interfaces=ifs)
         if broken:
-            h, r = broken[0]
+            # Confirm-before-strike (#61): when we tested exactly ONE resolvable URL,
+            # a single DNS-BROKEN can't tell a dead *domain* from a broken *resolver*.
+            # Before counting a strike, draw one more *different* name and fail the
+            # dependent only if that also fails DNS — so a dead site in the pool can't
+            # by itself get a healthy container remediated (the 05:00-window false
+            # positive). Eager-N sampling already tested several names, so this is a
+            # no-op there (len(resolvable_chosen) > 1).
+            fh, fr = broken[0]
+            if len(resolvable_chosen) == 1:
+                confirm = self._confirm_dns(dep, pool, exclude=resolvable_chosen[0][0])
+                if confirm is not None:
+                    ch, cr = confirm
+                    if cr.status is DnsStatus.OK:
+                        detail = (f"{_fmt_reach(fh, fr)} but {_fmt_reach(ch, cr)} "
+                                  "— a dead site, not this container's DNS")
+                        return DependentProbe(dep, status, True, True, detail, interfaces=ifs)
+                    if cr.status is DnsStatus.BROKEN:
+                        detail = (f"{_fmt_reach(fh, fr)}; confirmed via "
+                                  f"{_fmt_reach(ch, cr)} — resolver broken")
+                        return DependentProbe(dep, status, True, False, detail, interfaces=ifs)
+                    # confirm UNVALIDATED (no usable tool) — keep the original verdict.
             detail = (
-                _fmt_reach(h, r) if len(results) == 1
-                else f"all {len(results)} sampled failed (e.g. {_fmt_reach(h, r)})"
+                _fmt_reach(fh, fr) if len(results) == 1
+                else f"all {len(results)} sampled failed (e.g. {_fmt_reach(fh, fr)})"
             )
             return DependentProbe(dep, status, True, False, detail, interfaces=ifs)
         # All sampled sites were UNVALIDATED (no usable DNS tool in the container).
         h, r = results[0]
         return DependentProbe(dep, status, True, None, _fmt_reach(h, r),
                               dns_unvalidated=True, interfaces=ifs)
+
+    def _confirm_dns(
+        self, dep: str, pool: list[str], *, exclude: str
+    ) -> tuple[str, DnsResult] | None:
+        """Re-test one *different* resolvable name from ``pool`` to confirm a single
+        DNS-BROKEN before it strikes (#61). Returns ``(host, result)``, or None when
+        the pool has no other resolvable URL to confirm against (nothing to
+        disambiguate — the caller keeps the original verdict). Bounded: exactly one
+        extra probe, drawn through the shuffle lock like every other sample.
+        """
+        candidates = [
+            u for u in pool if u != exclude and not is_ip_literal(hostname_of(u))
+        ]
+        if not candidates:
+            return None
+        with self._rng_lock:
+            url = self._rng.choice(candidates)
+        host = hostname_of(url)
+        return host, validate_dns(
+            self.client, dep, url, host, self.config.timeout, self.config.wget_tries
+        )
 
     def _resolve_dependents(self) -> list[str]:
         """Current dependent set: discovery (or manual list) unioned with the

--- a/tests/test_confirm_before_strike.py
+++ b/tests/test_confirm_before_strike.py
@@ -1,0 +1,132 @@
+"""Confirm-before-strike: a single dependent DNS-BROKEN is re-tested against a
+second name before it counts (#61).
+
+Why: with one shuffled viability name per loop, a single DNS-BROKEN can't tell a
+dead *domain* (a flaky site in the pool) from a broken *resolver* (the fault we
+remediate). When several pool names fail at once — the observed ~05:00 window —
+consecutive bad draws could remediate a healthy dependent on the back of dead
+sites. So on a lone BROKEN we draw one more *different* name and strike only if it
+also fails. These tests pin: a dead domain alone never strikes; a genuinely broken
+resolver still does; the confirm is bounded (one extra probe) and skipped when
+eager-N already tested several names or the pool has nothing to confirm against.
+"""
+
+from __future__ import annotations
+
+import io
+import random
+
+from gluetun_monitor.config import Config
+from gluetun_monitor.docker_client import ExecResult
+from gluetun_monitor.logging_setup import Logger
+from gluetun_monitor.monitor import Monitor
+
+from .fakes import FakeDockerClient
+
+GLUETUN_ID = "a" * 64
+BAD = ExecResult(1, "wget: bad address 'x'\n")  # DNS-BROKEN
+OK = ExecResult(0, "  HTTP/1.1 200 OK\n")  # resolved + responded
+
+
+def _mon(fake: FakeDockerClient, **cfg: object) -> Monitor:
+    config = Config(config_file="/dev/null", gluetun_container="gluetun", **cfg)
+    logger = Logger(log_file=None, level="DEBUG", stream=io.StringIO())
+    return Monitor(fake, config, logger, rng=random.Random(0), sleep=lambda _s: None)
+
+
+def _live_dep(*wget_results: ExecResult) -> tuple[FakeDockerClient, list[str]]:
+    """A LIVE dependent whose successive viability wget probes return ``wget_results``
+    in order (then the last result repeats). Records the probed hosts so a test can
+    assert how many probes ran."""
+    fake = FakeDockerClient()
+    fake.add_container("dep", network_mode=f"container:{GLUETUN_ID}")
+    probes: list[str] = []
+
+    def handler(name: str, cmd: list[str]) -> ExecResult:
+        if cmd[:2] == ["ls", "/sys/class/net"]:
+            return ExecResult(0, "eth0\nlo\n")  # LIVE (non-loopback present)
+        if cmd and cmd[0] == "wget":
+            i = len(probes)
+            probes.append(cmd[-1])
+            return wget_results[min(i, len(wget_results) - 1)]
+        return ExecResult(0, "")
+
+    fake.on_exec = handler
+    return fake, probes
+
+
+def test_dead_domain_alone_does_not_strike() -> None:
+    """First name DNS-fails but the confirm name resolves → viable (a dead site,
+    not the resolver). Exactly two probes run (the sample + one confirm)."""
+    fake, probes = _live_dep(BAD, OK)
+    probe = _mon(fake)._probe_dependent("dep", GLUETUN_ID, ["https://a", "https://b"], [])
+    assert probe.viability_ok is True
+    assert len(probes) == 2  # confirmed, and bounded to one extra
+    assert "dead site" in probe.reason
+
+
+def test_broken_resolver_still_strikes() -> None:
+    """Both the sample and the confirm DNS-fail → not viable (genuine resolver
+    fault — two independent names couldn't resolve)."""
+    fake, probes = _live_dep(BAD, BAD)
+    probe = _mon(fake)._probe_dependent("dep", GLUETUN_ID, ["https://a", "https://b"], [])
+    assert probe.viability_ok is False
+    assert len(probes) == 2
+    assert "resolver broken" in probe.reason
+
+
+def test_single_resolvable_url_falls_back_to_one_sample() -> None:
+    """Nothing to confirm against (one resolvable URL) → keep the single-sample
+    verdict and do NOT spend a second probe."""
+    fake, probes = _live_dep(BAD)
+    probe = _mon(fake)._probe_dependent("dep", GLUETUN_ID, ["https://only"], [])
+    assert probe.viability_ok is False
+    assert len(probes) == 1  # no confirm attempted
+
+
+def test_healthy_first_sample_costs_one_probe() -> None:
+    """The common case is untouched: a passing first sample → viable on one probe,
+    no confirm."""
+    fake, probes = _live_dep(OK)
+    probe = _mon(fake)._probe_dependent("dep", GLUETUN_ID, ["https://a", "https://b"], [])
+    assert probe.viability_ok is True
+    assert len(probes) == 1
+
+
+def test_eager_sampling_is_a_no_op() -> None:
+    """With DEPENDENT_VIABILITY_SAMPLES=2 the loop already tested two names; both
+    failing → strike with no extra confirm probe (no-op there)."""
+    fake, probes = _live_dep(BAD, BAD)
+    mon = _mon(fake, dependent_viability_samples=2)
+    probe = mon._probe_dependent("dep", GLUETUN_ID, ["https://a", "https://b"], [])
+    assert probe.viability_ok is False
+    assert len(probes) == 2  # the two eager samples, no third confirm
+    assert "sampled failed" in probe.reason
+
+
+def test_dead_domain_never_remediates_across_loops(tmp_path) -> None:
+    """End to end: a healthy dependent whose unlucky draw keeps hitting a dead
+    domain is never remediated, because each loop's confirm resolves."""
+    conf = tmp_path / "sites.conf"
+    conf.write_text("https://dead.example\nhttps://live.example\n")
+    fake = FakeDockerClient()
+    fake.add_container("gluetun", id=GLUETUN_ID)
+    fake.add_container("dep", network_mode=f"container:{GLUETUN_ID}")
+
+    def handler(name: str, cmd: list[str]) -> ExecResult:
+        if cmd[:2] == ["ls", "/sys/class/net"]:
+            return ExecResult(0, "eth0\nlo\n")
+        if name == "gluetun":
+            return OK  # gluetun root test always passes
+        # The dependent: the dead domain fails DNS, the live one resolves.
+        return BAD if cmd[-1] == "https://dead.example" else OK
+
+    fake.on_exec = handler
+    cfg = Config(config_file=str(conf), gluetun_container="gluetun",
+                 dependent_container_failures=2)
+    mon = Monitor(fake, cfg, Logger(log_file=None, stream=io.StringIO()),
+                  rng=random.Random(0), sleep=lambda _s: None)
+    for _ in range(5):
+        mon.run_once()
+    assert fake.restarted == []  # the confirm absorbs every dead-domain draw
+    assert mon.dependent_failures.get("dep") == 0


### PR DESCRIPTION
Closes #61.

## Problem

A dependent's viability check samples **one** shuffled name per loop by default
(`DEPENDENT_VIABILITY_SAMPLES=1`). A DNS-`BROKEN` on that single name counts a
consecutive-failure strike, and `DEPENDENT_CONTAINER_FAILURES` strikes → remediation.

Two existing layers limit false positives — the gated threshold (N *consecutive*
strikes) and the per-loop reshuffle (a different name each loop, reset on any OK) —
but neither distinguishes, *within a loop*, a dead **domain** (a flaky site in the
pool) from a broken **resolver** (the per-container fault we remediate). When
several pool names fail at once — the observed ~05:00 window where multiple indexer
domains NXDOMAIN together (#27) — consecutive unlucky draws become likely and a
*healthy* dependent can be remediated on the back of dead sites.

## Fix — lazy confirm-before-strike

On the first `BROKEN` sample, draw one more *different* resolvable name and strike
**only if it also fails DNS**. A dead domain can't make the container look broken
(the confirm hits a different name); only the resolver actually failing makes both
fail.

- **Cheap in the common case:** one probe when healthy (unlike eager-N).
- **Self-correcting** against a single dead domain (unlike trusting one sample +
  the probabilistic cross-loop shuffle).
- **Bounded:** at most one extra probe, drawn through the same shuffle lock.
- **No-op** when eager sampling (`DEPENDENT_VIABILITY_SAMPLES>1`) already tested
  several names, or when the pool has only one resolvable URL to confirm against
  (falls back to the single-sample verdict).

## Tests

`test_confirm_before_strike.py`: dead-domain-alone never strikes (and is bounded to
two probes); a genuinely broken resolver still strikes; one-resolvable-URL pool
falls back to a single probe; the healthy first sample stays one probe; eager-N is
a no-op; and an end-to-end loop where a dead domain in the pool never remediates a
healthy dependent. `ruff`/`mypy --strict` clean; coverage 97.8%.

## Relationship to #60

Independent of #60 (per-URL tunables, PR #62) — this is a correctness fix on the
recovery-sensitive remediation path, deliberately on its own branch so it reviews
and reverts separately. Branched from `main`; will rebase cleanly once #60 merges
(the two touch adjacent lines in `_probe_dependent` but not the same logic).
