### PR TITLE
fix(sites): never let a bad sites.conf entry crash or halt monitoring

### DIFF
--- a/gluetun_monitor/monitor.py
+++ b/gluetun_monitor/monitor.py
@@ -646,8 +646,18 @@ class Monitor:
         # non-empty set; a runtime edit down to empty just tests nothing this loop.
         # Specs carry any per-URL |timeout/|tries overrides (#60); cache the url->spec
         # map so the probe call sites can resolve a site's effective knobs.
-        specs = load_specs(self.config.config_file, self.config.sites_env)
-        self._specs = {s.url: s for s in specs}
+        # A failed reload (unreadable file, a parse bug) must never take the
+        # watchdog's checks down with it: fall back to the last good set and
+        # keep monitoring — a stale site list beats a silent halt (#73).
+        try:
+            specs = load_specs(self.config.config_file, self.config.sites_env)
+            self._specs = {s.url: s for s in specs}
+        except Exception as exc:
+            self.log.error(
+                f"Failed to reload sites config ({self.config.config_file}): {exc} "
+                f"— keeping the previous {len(self._specs)} site(s)"
+            )
+            specs = list(self._specs.values())
         sites = [s.url for s in specs]
 
         breached = self.check_gluetun_sites(sites)

--- a/gluetun_monitor/sites.py
+++ b/gluetun_monitor/sites.py
@@ -72,7 +72,10 @@ def parse_entry(raw: str) -> tuple[SiteSpec | None, list[str]]:
         if key not in _OPTION_KEYS:
             warnings.append(f"unknown option {key!r} (known: {', '.join(_OPTION_KEYS)})")
             continue
-        if not value.isdigit() or int(value) < 1:
+        # isascii() first: str.isdigit() is True for Unicode digits (e.g. '²')
+        # that int() refuses, so isdigit() alone lets the int() below raise —
+        # turning a config typo into a crash instead of a warn-and-skip (#73).
+        if not (value.isascii() and value.isdigit()) or int(value) < 1:
             warnings.append(f"invalid {key} {value!r} (want a positive integer)")
             continue
         values[key] = int(value)
@@ -89,18 +92,32 @@ def trim(s: str) -> str:
     return s.strip()
 
 
+def strip_inline_comment(line: str) -> str:
+    """Drop an inline ``#`` comment: a ``#`` preceded by whitespace starts a
+    comment (``https://a.example  # note`` → ``https://a.example``); a ``#``
+    with no whitespace before it is URL content (a fragment) and is kept.
+
+    v2 extension (v1 skipped whole-line comments only): without it the trailing
+    comment becomes part of the URL — a phantom site that fails every poll and
+    counts toward FAIL_THRESHOLD (#73).
+    """
+    for i, ch in enumerate(line):
+        if ch == "#" and (i == 0 or line[i - 1].isspace()):
+            return line[:i]
+    return line
+
+
 def parse_sites_conf(path: str | Path) -> list[str]:
     """Read a sites.conf and return the list of test URLs.
 
-    Skips blank/whitespace-only lines and ``#`` comments; trims each entry.
-    Raises FileNotFoundError if the file is missing (caller decides severity).
+    Skips blank/whitespace-only lines and ``#`` comments (whole-line and
+    inline — see :func:`strip_inline_comment`); trims each entry. Raises
+    FileNotFoundError if the file is missing (caller decides severity).
     """
     sites: list[str] = []
     text = Path(path).read_text(encoding="utf-8")
     for raw_line in text.splitlines():
-        if raw_line.lstrip().startswith("#"):
-            continue
-        site = trim(raw_line)
+        site = trim(strip_inline_comment(raw_line))
         if not site:
             continue
         sites.append(site)
@@ -119,10 +136,15 @@ def unsafe_site_reason(site: str) -> str | None:
     rather than a URL — e.g. ``--directory-prefix=/etc`` could write files inside
     a container (the exec layer also guards this with a ``--`` separator; this
     keeps such a bogus "flag URL" out of the test set entirely — Tenet 1). An
-    entry with no host component tests nothing.
+    entry with no host component tests nothing. Embedded whitespace never
+    belongs in a URL — it means something leaked past parsing (e.g. an inline
+    comment in a ``SITES`` env entry, which unlike the file is not
+    comment-stripped) and would only ever poll as a phantom failure (#73).
     """
     if site.startswith("-"):
         return "looks like a command-line flag (leading '-')"
+    if any(ch.isspace() for ch in site):
+        return "contains whitespace (inline comment or malformed entry?)"
     if not hostname_of(site):
         return "no host component"
     return None

--- a/sites.conf.example
+++ b/sites.conf.example
@@ -1,6 +1,7 @@
 # Gluetun Monitor - Sites to test for VPN connectivity
 # Add one URL per line
-# Lines starting with # are comments
+# Lines starting with # are comments; a "#" after whitespace starts an
+# inline comment (https://example.com  # like this)
 #
 # All sites are tested in parallel. If any site fails consecutively
 # (based on FAIL_THRESHOLD), Gluetun will be restarted.

--- a/tests/test_arg_injection.py
+++ b/tests/test_arg_injection.py
@@ -75,6 +75,16 @@ def test_unsafe_site_reason() -> None:
     assert unsafe_site_reason("1.1.1.1") is None  # bare IP is fine
 
 
+def test_unsafe_site_reason_rejects_embedded_whitespace() -> None:
+    """#73: whitespace never belongs in a URL — it means an inline comment (or
+    other garbage) leaked past parsing, e.g. via a SITES env entry, which unlike
+    the file is not comment-stripped. Rejecting it here keeps the phantom
+    always-failing 'site' out of the test set entirely."""
+    assert unsafe_site_reason("https://a.example # note") is not None
+    assert unsafe_site_reason("https://a.example\t#x") is not None
+    assert unsafe_site_reason("https://a.example") is None
+
+
 def test_load_sites_drops_unsafe_entries(tmp_path: Path) -> None:
     conf = tmp_path / "sites.conf"
     conf.write_text("https://ok.example\n--evil-flag\nhttp://\n", encoding="utf-8")

--- a/tests/test_site_specs.py
+++ b/tests/test_site_specs.py
@@ -66,6 +66,12 @@ def test_empty_entry_is_skipped() -> None:
         ("https://x|timeout=abc", "invalid timeout"),
         ("https://x|timeout=0", "invalid timeout"),
         ("https://x|tries=-1", "invalid tries"),
+        # #73: Unicode digits pass str.isdigit() but int() refuses them — must
+        # warn-and-skip like any other bad value, never raise (pre-fix this was
+        # an uncaught ValueError: a startup crash, or a silent monitoring halt
+        # when the file was edited live).
+        ("https://x|timeout=²", "invalid timeout"),
+        ("https://x|tries=¹²³", "invalid tries"),
     ],
 )
 def test_bad_options_warn_but_keep_the_url(entry: str, fragment: str) -> None:
@@ -121,6 +127,65 @@ def test_report_surfaces_option_warnings_and_unsafe_drops(tmp_path: Path) -> Non
 def test_missing_file_is_not_fatal(tmp_path: Path) -> None:
     specs = load_specs(str(tmp_path / "nope.conf"), "https://only-env")
     assert [s.url for s in specs] == ["https://only-env"]
+
+
+# ----- reload resilience (#73): a bad edit or reload failure never halts checks -----
+
+def _probing_monitor(conf: str) -> tuple[Monitor, list[list[str]], io.StringIO]:
+    """A Monitor against a healthy fake gluetun that records every exec'd command."""
+    fake = FakeDockerClient()
+    fake.add_container("gluetun", id=GLUETUN_ID)
+    cmds: list[list[str]] = []
+
+    def handler(name: str, cmd: list[str]) -> ExecResult:
+        cmds.append(cmd)
+        return ExecResult(0, "  HTTP/1.1 200 OK\n")
+
+    fake.on_exec = handler
+    stream = io.StringIO()
+    cfg = Config(config_file=conf, gluetun_container="gluetun")
+    logger = Logger(log_file=None, level="DEBUG", stream=stream)
+    return (
+        Monitor(fake, cfg, logger, rng=random.Random(0), sleep=lambda _s: None),
+        cmds,
+        stream,
+    )
+
+
+def _wget_urls(cmds: list[list[str]]) -> list[str]:
+    return [c[-1] for c in cmds if c and c[0] == "wget" and c[-1].startswith("http")]
+
+
+def test_bad_live_edit_does_not_halt_monitoring(tmp_path: Path) -> None:
+    """#73 regression: a live sites.conf edit that adds a Unicode-digit tunable
+    (`isdigit()`-true, `int()`-false) must warn-and-skip, not raise — pre-fix the
+    ValueError escaped run_once every loop and monitoring silently ceased."""
+    conf = _conf(tmp_path, "https://a.example\n")
+    mon, cmds, _ = _probing_monitor(conf)
+    mon.run_once()
+    Path(conf).write_text("https://a.example|timeout=²\n")
+    mon.run_once()  # pre-fix: uncaught ValueError
+    # Both loops probed the site; the bad override fell back to the global knobs.
+    assert _wget_urls(cmds).count("https://a.example") == 2
+
+
+def test_reload_failure_keeps_previous_sites_and_monitoring(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Defense in depth (#73): if the per-loop sites reload fails for ANY reason
+    (unreadable bind-mount, a future parse bug), the loop must fall back to the
+    last good site set and keep checking — a stale list beats a silent halt."""
+    conf = _conf(tmp_path, "https://a.example\n")
+    mon, cmds, stream = _probing_monitor(conf)
+    mon.run_once()  # loads the good set
+
+    def boom(*_a: object) -> list[SiteSpec]:
+        raise OSError("bind-mount blip")
+
+    monkeypatch.setattr("gluetun_monitor.monitor.load_specs", boom)
+    mon.run_once()
+    assert _wget_urls(cmds).count("https://a.example") == 2  # still probing
+    assert "Failed to reload sites config" in stream.getvalue()
 
 
 # ----- end to end: the override reaches the wget inside gluetun -----

--- a/tests/test_sites.py
+++ b/tests/test_sites.py
@@ -17,6 +17,7 @@ from gluetun_monitor.sites import (
     is_ip_literal,
     parse_sites_conf,
     resolvable_pool,
+    strip_inline_comment,
     trim,
 )
 
@@ -57,6 +58,41 @@ def test_parse_skips_comments_blanks_and_whitespace(tmp_path: Path) -> None:
         "https://cloudflare.com",
         "https://1.1.1.1",
     ]
+
+
+def test_parse_strips_inline_comments_but_keeps_fragments(tmp_path: Path) -> None:
+    """#73: a trailing ``# note`` must not become part of the URL (pre-fix it
+    produced a phantom permanently-failing site that counted toward
+    FAIL_THRESHOLD). A ``#`` with no whitespace before it is a URL fragment and
+    is preserved."""
+    conf = tmp_path / "sites.conf"
+    conf.write_text(
+        "https://a.example  # the slow one\n"
+        "https://b.example\t# tab comment\n"
+        "https://c.example#fragment\n"
+    )
+    assert parse_sites_conf(conf) == [
+        "https://a.example",
+        "https://b.example",
+        "https://c.example#fragment",
+    ]
+
+
+@pytest.mark.parametrize(
+    ("line", "expected"),
+    [
+        ("https://a.example  # note", "https://a.example  "),
+        ("# whole line", ""),
+        ("   # indented", "   "),
+        ("https://a.example#frag", "https://a.example#frag"),
+        ("https://a.example", "https://a.example"),
+        ("", ""),
+    ],
+)
+def test_strip_inline_comment(line: str, expected: str) -> None:
+    """The comment starts at a ``#`` that begins the line or follows whitespace;
+    trailing whitespace is left for trim() (the callers always trim after)."""
+    assert strip_inline_comment(line) == expected
 
 
 def test_parse_missing_file_raises(tmp_path: Path) -> None:


### PR DESCRIPTION
Closes #73.

## Problem

Two parsing gaps, both violating sites.py's own "warned about and skipped, never fatal" contract:

1. **Unicode-digit tunable values** (`|timeout=²`): `str.isdigit()` accepts characters `int()` refuses, so the validation guard itself raised an uncaught `ValueError`. At startup that's a traceback-death; on a **live edit** it aborted every loop via the run() catch-all — the monitor stayed "up" while performing zero checks and zero remediation, indefinitely.
2. **Inline comments** (`https://a.example  # note`): only whole-line comments were skipped, so the comment became part of the URL — a phantom permanently-failing site counting toward `FAIL_THRESHOLD` and able to drive real gluetun restarts.

## Fix

- `parse_entry`: `value.isascii() and value.isdigit()` — Unicode digits now warn-and-skip like any other bad value.
- `parse_sites_conf`: strip inline comments (`#` preceded by whitespace); a `#` inside a URL (fragment) is preserved. v2 extension — v1 only skipped whole-line comments, so nothing that parsed before changes meaning.
- `unsafe_site_reason`: reject embedded whitespace — catches inline comments arriving via the `SITES` env CSV (not comment-stripped) and any other malformed entry, loudly.
- **Defense in depth (monitor loop):** the per-loop sites reload is now guarded — if it raises for *any* reason (unreadable bind-mount, a future parse bug), the loop logs an error, keeps the last good site set, and keeps checking. A stale site list beats a silent watchdog halt. This also closes the pre-existing hole where a runtime `OSError` on the config file (bind-mount blip) would have aborted every loop the same way.
- `sites.conf.example`: documents inline-comment support.

## Tests

All verified **red against the pre-fix code**, green with the fix:

- `test_bad_options_warn_but_keep_the_url` — new `timeout=²` / `tries=¹²³` cases (warn-and-skip, never raise)
- `test_bad_live_edit_does_not_halt_monitoring` — live edit adding a Unicode-digit tunable; both loops still probe
- `test_reload_failure_keeps_previous_sites_and_monitoring` — reload raising `OSError` falls back to the previous set and logs
- `test_parse_strips_inline_comments_but_keeps_fragments` + `test_strip_inline_comment` — comment vs fragment boundary
- `test_unsafe_site_reason_rejects_embedded_whitespace` — env-CSV path

Full suite, ruff, and mypy pass locally.
