### PR TITLE
fix(alerts): hold active alerts on aborted loops; notify when gluetun is down

### DIFF
--- a/gluetun_monitor/alert_state.py
+++ b/gluetun_monitor/alert_state.py
@@ -16,6 +16,13 @@ subjects it has stopped managing via :meth:`forget`. At loop end :meth:`events` 
   from config, dependent excluded/gone) — "no longer monitored", since a "recovered"
   there would be a lie.
 
+A loop that could not evaluate every subject — it died on an exception, or bailed
+early (gluetun down, recovery failed) before reaching the dependent phase — must
+call :meth:`mark_incomplete`: on such a loop, silence is *absence of evidence*, not
+recovery, so unreported active alerts are held instead of resolved (#74). Problems
+that WERE reported (or explicitly forgotten) before the abort still process
+normally — they were evaluated.
+
 State persists to a JSON sidecar, and the loop counter persists with it, so a restart
 of the monitor neither re-spams still-broken problems nor misses a resolve that
 happened while it was down.
@@ -56,6 +63,7 @@ class AlertState:
         self._active: dict[str, _Active] = {}
         self._reported: dict[str, tuple[str, str, str]] = {}  # this loop: key -> (tier,title,body)
         self._forgotten: set[str] = set()  # this loop: subjects no longer monitored
+        self._incomplete = False  # this loop: aborted before evaluating everything
         self._load()
 
     # ----- per-loop input from the monitor -----
@@ -65,6 +73,15 @@ class AlertState:
         self._loop += 1
         self._reported = {}
         self._forgotten = set()
+        self._incomplete = False
+
+    def mark_incomplete(self) -> None:
+        """Declare that this loop did NOT evaluate every subject (it aborted on an
+        exception or bailed early). :meth:`events` will then hold unreported active
+        alerts instead of resolving them — an unevaluated problem didn't clear, we
+        just never looked (#74).
+        """
+        self._incomplete = True
 
     def report(self, key: str, tier: str, title: str, body: str) -> None:
         """Declare that problem ``key`` is currently true this loop."""
@@ -101,6 +118,11 @@ class AlertState:
 
         for key in list(self._active):
             if key in self._reported:
+                continue
+            if self._incomplete and key not in self._forgotten:
+                # The loop never got as far as evaluating this subject: hold the
+                # alert. A forget is an explicit statement and still processes.
+                self._log.debug(f"notify: {key} held (loop incomplete — not evaluated)")
                 continue
             active = self._active.pop(key)
             active_for = self._loop - active.since_loop

--- a/gluetun_monitor/monitor.py
+++ b/gluetun_monitor/monitor.py
@@ -615,6 +615,12 @@ class Monitor:
         self.alerts.begin_loop()
         try:
             self._run_once_body()
+        except Exception:
+            # The loop died partway (e.g. the Docker socket went away mid-cycle):
+            # subjects past the crash point were never evaluated, so the flush
+            # below must not read their silence as recovery (#74).
+            self.alerts.mark_incomplete()
+            raise
         finally:
             self._flush_notifications()
 
@@ -626,6 +632,19 @@ class Monitor:
         gluetun = self.client.inspect(self.config.gluetun_container)
         if gluetun is None or not gluetun.running:
             self.log.error("Gluetun container is not running!")
+            # The most severe condition must not be the quietest (#74): report it
+            # to the lifecycle so it notifies (once, edge-triggered) and resolves
+            # when gluetun returns. Nothing else was evaluated this loop, so the
+            # other active alerts are held, not "resolved".
+            self._problem(
+                "gluetun-down",
+                "attention",
+                f"gluetun is down ({self.config.gluetun_container})",
+                f"The gluetun container '{self.config.gluetun_container}' is "
+                f"{'not running' if gluetun is not None else 'gone (not found)'} — "
+                f"the monitor cannot check or heal the stack until it returns.",
+            )
+            self.alerts.mark_incomplete()
             return
         if gluetun.health != "healthy":
             self.log.warn(f"Gluetun health status: {gluetun.health}")
@@ -703,6 +722,7 @@ class Monitor:
                 f"Was failing on {', '.join(breached)}; restarted but it did not come back "
                 f"healthy — manual intervention may be required.",
             )
+            self.alerts.mark_incomplete()  # dependents were never evaluated (#74)
             return
 
         # Re-verify without recording (so the loop counts one poll per site, not two).
@@ -721,6 +741,7 @@ class Monitor:
                 f"{', '.join(reverify_breached)} — manual intervention may be required.",
             )
             self.site_failures.reset_all()
+            self.alerts.mark_incomplete()  # dependents left untouched = unevaluated (#74)
             return
 
         self.log.info("Connectivity verified after restart")

--- a/tests/test_alert_state.py
+++ b/tests/test_alert_state.py
@@ -76,6 +76,54 @@ def test_forgotten_subject_emits_deprecation_not_resolve() -> None:
     assert "no longer monitored" in events[0].title
 
 
+def test_incomplete_loop_holds_unreported_alerts() -> None:
+    """#74: a loop that aborted before evaluating everything must not read the
+    silence of an active alert as recovery — it is held, and resolves only on
+    the next COMPLETE loop that doesn't report it."""
+    s = _state()
+    s.begin_loop()
+    s.report("k", "attention", "P", "b")
+    s.events()
+
+    s.begin_loop()  # aborted loop: k never evaluated
+    s.mark_incomplete()
+    assert s.events() == []  # no false "resolved"
+    assert s.active_count() == 1  # still firing
+
+    s.begin_loop()  # complete loop, not reported → NOW it genuinely cleared
+    resolved = s.events()
+    assert [e.key for e in resolved] == ["resolve:k"]
+
+
+def test_incomplete_loop_still_fires_new_reports_and_forgets() -> None:
+    """A problem reported (or explicitly forgotten) before the abort WAS
+    evaluated — those process normally even on an incomplete loop."""
+    s = _state()
+    s.begin_loop()
+    s.report("old", "attention", "Old", "b")
+    s.events()
+
+    s.begin_loop()
+    s.report("new", "attention", "New", "b")  # evaluated before the abort
+    s.forget("old")  # explicit statement — still honored
+    s.mark_incomplete()
+    keys = {e.key for e in s.events()}
+    assert keys == {"new", "deprecated:old"}
+
+
+def test_incomplete_resets_each_loop() -> None:
+    """mark_incomplete applies to the current loop only."""
+    s = _state()
+    s.begin_loop()
+    s.report("k", "attention", "P", "b")
+    s.events()
+    s.begin_loop()
+    s.mark_incomplete()
+    s.events()
+    s.begin_loop()  # fresh loop: complete unless marked again
+    assert [e.key for e in s.events()] == ["resolve:k"]
+
+
 def test_active_count_reflects_firing_problems() -> None:
     s = _state()
     s.begin_loop()

--- a/tests/test_loop_abort_alerts.py
+++ b/tests/test_loop_abort_alerts.py
@@ -1,0 +1,122 @@
+"""Aborted monitoring loops must not lie to the operator (#74).
+
+Why: AlertState diffs "reported this loop" against the active set, and the
+monitor flushes in ``finally`` — so before #74, ANY loop that bailed early
+(gluetun down, recovery failed) or died on an exception flushed an empty report
+set and sent "resolved: …" for every active alert, precisely during the outage.
+And gluetun being flat-out down — the most severe observable condition — never
+notified at all. These tests pin both fixes end to end through Monitor.run_once.
+"""
+
+from __future__ import annotations
+
+import io
+import random
+from pathlib import Path
+
+import pytest
+
+from gluetun_monitor.config import Config
+from gluetun_monitor.docker_client import ContainerInfo, ExecResult
+from gluetun_monitor.logging_setup import Logger
+from gluetun_monitor.monitor import Monitor
+from gluetun_monitor.site_stats import SiteStatsStore
+
+from .fakes import FakeDockerClient, FakeNotifier
+
+GLUETUN_ID = "a" * 64
+
+
+class ExplodingClient(FakeDockerClient):
+    """A fake whose inspect() can be switched to raise — the docker socket
+    dying mid-loop (DockerPyClient only swallows NotFound; APIErrors propagate).
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.explode = False
+
+    def inspect(self, name_or_id: str) -> ContainerInfo | None:
+        if self.explode:
+            raise RuntimeError("docker socket died")
+        return super().inspect(name_or_id)
+
+
+def _monitor(fake: FakeDockerClient, conf: str) -> tuple[Monitor, FakeNotifier, io.StringIO]:
+    fake.on_exec = lambda n, c: ExecResult(0, "  HTTP/1.1 200 OK\n")
+    notifier = FakeNotifier()
+    stream = io.StringIO()
+    cfg = Config(config_file=conf, gluetun_container="gluetun")
+    mon = Monitor(
+        fake, cfg, Logger(log_file=None, level="DEBUG", stream=stream),
+        rng=random.Random(0), sleep=lambda _s: None,
+        stats=SiteStatsStore(None), notifier=notifier,
+    )
+    return mon, notifier, stream
+
+
+def _seed_active_alert(mon: Monitor, key: str) -> None:
+    """Make ``key`` an already-announced active alert (as if a dependent failed
+    remediation on an earlier loop)."""
+    mon.alerts.begin_loop()
+    mon.alerts.report(key, "attention", f"dependent unhealthy: {key}", "b")
+    assert len(mon.alerts.events()) == 1  # announced
+
+
+def _conf(tmp_path: Path) -> str:
+    p = tmp_path / "sites.conf"
+    p.write_text("https://a.example\n")
+    return str(p)
+
+
+def test_gluetun_down_notifies_and_resolves_on_return(tmp_path: Path) -> None:
+    """gluetun stopped at runtime: exactly one 'gluetun-down' attention alert
+    (edge-triggered, not per-loop), and a resolve when it comes back."""
+    fake = FakeDockerClient()
+    fake.add_container("gluetun", id=GLUETUN_ID, running=False)
+    mon, notifier, _ = _monitor(fake, _conf(tmp_path))
+
+    mon.run_once()
+    mon.run_once()  # still down: edge-triggered → no re-announce
+    down = [e for e in notifier.events if e.key == "gluetun-down"]
+    assert len(down) == 1 and down[0].tier == "attention"
+
+    fake.restart("gluetun")  # it returns healthy
+    mon.run_once()
+    assert "resolve:gluetun-down" in notifier.event_keys()
+
+
+def test_gluetun_down_loop_holds_other_active_alerts(tmp_path: Path) -> None:
+    """The early return must not flush-resolve alerts it never evaluated —
+    pre-fix this sent 'resolved: dependent unhealthy' during the outage."""
+    fake = FakeDockerClient()
+    fake.add_container("gluetun", id=GLUETUN_ID, running=False)
+    mon, notifier, _ = _monitor(fake, _conf(tmp_path))
+    _seed_active_alert(mon, "dependent-unhealthy:app")
+
+    mon.run_once()  # gluetun down → incomplete loop
+    assert not [k for k in notifier.event_keys() if k.startswith("resolve:")]
+    assert mon.alerts.active_count() == 2  # dependent alert + gluetun-down
+
+    fake.restart("gluetun")
+    mon.run_once()  # complete loop: dependent healthy again → genuine resolve
+    assert "resolve:dependent-unhealthy:app" in notifier.event_keys()
+
+
+def test_exception_mid_loop_holds_active_alerts(tmp_path: Path) -> None:
+    """A loop that dies on a propagating Docker error (socket gone) must hold
+    active alerts, not resolve them — and still re-raise for run()'s catch-all."""
+    fake = ExplodingClient()
+    fake.add_container("gluetun", id=GLUETUN_ID)
+    mon, notifier, _ = _monitor(fake, _conf(tmp_path))
+    _seed_active_alert(mon, "dependent-unhealthy:app")
+
+    fake.explode = True
+    with pytest.raises(RuntimeError):
+        mon.run_once()
+    assert not [k for k in notifier.event_keys() if k.startswith("resolve:")]
+    assert mon.alerts.active_count() == 1  # held
+
+    fake.explode = False
+    mon.run_once()  # next complete loop: now the resolve is genuine
+    assert "resolve:dependent-unhealthy:app" in notifier.event_keys()


### PR DESCRIPTION
Closes #74.

## Problem

`AlertState.events()` interprets "active but not reported this loop" as recovery, and `Monitor.run_once()` flushes in `finally`. Two abort paths produced a flush with an empty report set:

- **gluetun not running** — the early return logged an ERROR but never reported to the lifecycle, so the most severe observable condition produced **zero notifications at any level**, while every other active alert (`dependent-unhealthy:*`, `gluetun-unrecovered`, `advisory:*`) got a false **"resolved: …"** mid-outage, re-firing as "new" the next loop.
- **any exception escaping the loop body** — `DockerPyClient.inspect` only swallows NotFound; a dying socket's APIError propagates and triggered the same false-resolve flush.

Two additional early returns had the same defect for dependents: both failed-recovery paths return before the dependent phase, silently "resolving" dependent alerts that were never evaluated.

## Fix

- **`AlertState.mark_incomplete()`** — on a loop that didn't evaluate every subject, unreported active alerts are *held*, not resolved. Reported problems and explicit `forget()`s still process normally (they *were* evaluated). Resets each `begin_loop()`.
- **Monitor** marks the loop incomplete in four places: the exception path in `run_once` (still re-raised), the gluetun-not-running return, and both failed-recovery returns.
- **`gluetun-down` alert** — the not-running path now reports an attention-tier problem: announced once (edge-triggered), held while down, genuinely resolved when the container returns.

## Tests

All six verified **red against pre-fix code**:

Unit (`test_alert_state.py`): incomplete loop holds unreported alerts and resolves only on the next complete loop; new reports + forgets still fire during an incomplete loop; the flag resets per loop.

End-to-end (`test_loop_abort_alerts.py`, through `Monitor.run_once`): gluetun-down notifies exactly once and resolves on return; the gluetun-down loop holds a seeded dependent alert (pre-fix: false resolve mid-outage); an exception mid-loop holds alerts, still re-raises, and the resolve fires only on the next complete loop.

Full suite, ruff, mypy green locally.
