### PR TITLE
fix(advisory): evaluate the flaky-site advisory every loop, not only on breaches

### DIFF
--- a/gluetun_monitor/monitor.py
+++ b/gluetun_monitor/monitor.py
@@ -681,6 +681,13 @@ class Monitor:
 
         breached = self.check_gluetun_sites(sites)
         if not breached:
+            # Keep the flaky-site advisory current on HEALTHY loops too (#75):
+            # the lifecycle resolves any alert not re-reported each loop, so
+            # evaluating only on breach loops made the advisory flap — a false
+            # "resolved" on the first healthy loop after every breach, then a
+            # fresh announce on the next one. Evaluated every loop, the alert
+            # stays active until the dominance window genuinely clears.
+            self._emit_advisory()
             # Gluetun is up — proceed straight to the dependent phase (the #20 fix:
             # dependents are checked every loop, not only after a gluetun failure).
             self.run_dependent_phase(gluetun.id, sites)
@@ -760,9 +767,11 @@ class Monitor:
     def _emit_advisory(self) -> None:
         """Surface a flaky-site advisory when one site dominates recent restarts.
 
-        Reported to the alert lifecycle every loop it holds (which edge-triggers the
-        notification + resolves it when it clears); the log line + stats count fire
-        once per episode (``_advised_site``).
+        Called every loop — healthy and breached (#75) — so the alert lifecycle
+        sees the advisory continuously while the dominance window holds: the
+        notification edge-triggers once and resolves only when the window
+        genuinely clears, instead of flapping around each breach. The log line +
+        stats count still fire once per episode (``_advised_site``).
         """
         adv = self.stats.advisory(
             self.config.advisory_window,

--- a/tests/test_advisory_integration.py
+++ b/tests/test_advisory_integration.py
@@ -85,3 +85,60 @@ def test_advisory_deduped_not_per_loop(tmp_path: Path) -> None:
     for _ in range(6):
         mon.run_once()
     assert stream.getvalue().count("FLAKY SITE: https://flaky.example") == 1
+
+
+def test_advisory_holds_across_healthy_loops_no_flap(tmp_path: Path) -> None:
+    """#75: the realistic flaky-site pattern is breach → restart fixes it →
+    healthy loops → breach again. Pre-fix, the advisory was only evaluated on
+    breach loops, so the first healthy loop after each breach emitted a false
+    "resolved: flaky site" and the next breach re-announced it. The advisory
+    must stay active across healthy loops and resolve only when the dominance
+    window genuinely slides empty."""
+    from .fakes import FakeNotifier
+
+    conf = tmp_path / "sites.conf"
+    conf.write_text("https://flaky.example\n")
+
+    fake = FakeDockerClient()
+    fake.add_container("gluetun", id=GLUETUN_ID, health="healthy")
+
+    # fail_probe fails exactly ONE primary poll, then clears — so the restart's
+    # re-verify passes and the following loops are healthy (restart "fixed" it).
+    state = {"fail_probe": False}
+
+    def handler(name: str, cmd: list[str]) -> ExecResult:
+        is_site_probe = bool(cmd) and cmd[0] == "wget" and cmd[-1] == "https://flaky.example"
+        if is_site_probe and state["fail_probe"]:
+            state["fail_probe"] = False
+            return ExecResult(4, "")
+        return ExecResult(0, "")
+
+    fake.on_exec = handler
+    now = [1000.0]  # injectable clock drives the advisory window
+    notifier = FakeNotifier()
+    cfg = Config(config_file=str(conf), gluetun_container="gluetun", fail_threshold=1,
+                 dns_wait_timeout=2, advisory_window=500, advisory_min_restarts=2,
+                 advisory_dominance=0.5)
+    mon = Monitor(fake, cfg, Logger(log_file=None, stream=io.StringIO()),
+                  rng=random.Random(0), sleep=lambda _s: None,
+                  stats=SiteStatsStore(None, clock=lambda: now[0]), notifier=notifier)
+
+    state["fail_probe"] = True
+    mon.run_once()  # restart 1 (below min_restarts — no advisory yet)
+    mon.run_once()  # healthy
+    state["fail_probe"] = True
+    mon.run_once()  # restart 2 → advisory fires (2 restarts inside the window)
+    keys = notifier.event_keys()
+    assert keys.count("advisory:https://flaky.example") == 1
+
+    mon.run_once()  # healthy loops: the window still holds — no flap
+    mon.run_once()
+    keys = notifier.event_keys()
+    assert "resolve:advisory:https://flaky.example" not in keys  # pre-fix: emitted here
+    assert keys.count("advisory:https://flaky.example") == 1  # and no re-announce
+
+    now[0] += 600  # slide past the 500s window: the advisory genuinely clears
+    mon.run_once()
+    keys = notifier.event_keys()
+    assert keys.count("resolve:advisory:https://flaky.example") == 1
+    assert keys.count("advisory:https://flaky.example") == 1  # one episode, one announce


### PR DESCRIPTION
Closes #75.

## Problem

`_emit_advisory()` was only called on breach loops, but `AlertState` resolves any active key not re-reported each loop. With the realistic flaky-site pattern (breach → restart fixes it → healthy loops in between):

1. Breach loop: "flaky site: X" fires.
2. First healthy loop after: **"resolved: flaky site: X"** — while X still dominates the restart window.
3. Next breach: re-announces as **new**.

The existing integration tests only exercised breach-every-loop, where the key is re-reported each cycle, so the flap was uncharacterized.

## Fix

Call `_emit_advisory()` on healthy loops too (one line plus docs). It reads the in-memory recent-restarts list — no I/O — so the per-loop cost is nil. The alert now stays active while the dominance window holds and resolves exactly once, when the window genuinely slides empty. The `FLAKY SITE` log line and stats counter keep their once-per-episode dedup, and the #74 incomplete-loop semantics already hold the advisory correctly on aborted loops.

## Tests

`test_advisory_holds_across_healthy_loops_no_flap` — drives the intermittent pattern end to end through `run_once` with an injectable clock: two restarts trigger the advisory, healthy loops must produce **no** resolve and **no** re-announce (the pre-fix failure point, verified red), then sliding the clock past the window produces exactly one genuine resolve. One episode, one announce, one resolve.

Full suite, ruff, mypy green locally.
