### PR TITLE
fix(recreate): close the destructive remove→create window

### DIFF
--- a/gluetun_monitor/docker_client.py
+++ b/gluetun_monitor/docker_client.py
@@ -92,6 +92,10 @@ class DockerClient(Protocol):
         """Create a container from a raw API create body; return the new id."""
         ...
 
+    def rename(self, name_or_id: str, new_name: str) -> None:
+        """Rename a container (running or not); raises if ``new_name`` is taken."""
+        ...
+
     def start(self, name_or_id: str) -> None:
         """Start an existing (created) container."""
         ...
@@ -157,6 +161,12 @@ class DockerPyClient:
         """``POST /containers/create`` from a raw API body → the new container id."""
         result = self._api.create_container_from_config(config, name=name)
         return str(result["Id"])
+
+    def rename(self, name_or_id: str, new_name: str) -> None:
+        """``POST /containers/{id}/rename`` — same CONTAINERS+POST proxy class as
+        create/remove/start (ADR-0002), so no new socket-proxy permission needed.
+        """
+        self._api.rename(name_or_id, new_name)
 
     def start(self, name_or_id: str) -> None:
         """``POST /containers/{id}/start``."""

--- a/gluetun_monitor/monitor.py
+++ b/gluetun_monitor/monitor.py
@@ -32,6 +32,7 @@ from .dns_check import DnsResult, DnsStatus, validate_dns
 from .endpoint import get_endpoint_info
 from .notify import Notifier, NotifyEvent, NullNotifier
 from .recovery import remediate_dependent, restart_gluetun
+from .recreate import sweep_recreate_leftovers
 from .site_stats import SiteStatsStore, format_window
 from .sites import (
     SiteSpec,
@@ -834,6 +835,10 @@ class Monitor:
 
     def announce(self) -> None:
         """Log the post-prerequisite startup context (connection, dependents, endpoint)."""
+        # Before anything else, heal any recreate that a previous monitor died in
+        # the middle of (SIGKILL/power loss) — restore or retire the parked
+        # container (#76), so discovery below sees the true state.
+        sweep_recreate_leftovers(self.client, self.log)
         if self.config.docker_host:
             self.log.info(f"Docker connection: socket proxy ({self.config.docker_host})")
         else:

--- a/gluetun_monitor/recovery.py
+++ b/gluetun_monitor/recovery.py
@@ -15,7 +15,7 @@ from typing import TYPE_CHECKING
 
 from .dependents import interface_check, remediation_action
 from .endpoint import get_endpoint_info
-from .recreate import recreate_dependent
+from .recreate import gc_recreate_leftover, recreate_dependent
 from .state import InterfaceStatus, RemediationAction
 
 if TYPE_CHECKING:
@@ -176,6 +176,12 @@ def remediate_dependent(
     info = client.inspect(dep_name)
     if info is None:
         logger.error(f"Cannot remediate {dep_name}: container not found")
+        return False
+
+    # A parked twin from an interrupted recreate shares every volume with this
+    # container — restarting/recreating alongside it risks two writers on the
+    # same data. Clear it first; refuse to act if it can't be cleared (#76).
+    if not gc_recreate_leftover(client, dep_name, logger):
         return False
 
     action = remediation_action(info, gluetun_id)

--- a/gluetun_monitor/recreate.py
+++ b/gluetun_monitor/recreate.py
@@ -20,11 +20,22 @@ data-loss guards are unit-testable:
 from __future__ import annotations
 
 import copy
+import os
+import signal
+import threading
+from collections.abc import Iterator
+from contextlib import contextmanager
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from .docker_client import DockerClient
     from .logging_setup import Logger
+
+# While a recreate is mid-flight the original container is parked under this
+# suffix (rename-aside), so every intermediate state is recoverable (#76).
+# Docker name charset allows '.', and the suffix is specific enough not to
+# collide with a real container name.
+_OLD_SUFFIX = ".gm-recreate-old"
 
 # Config fields the daemon rejects (or that are meaningless) when NetworkMode is
 # container:<id> — the shared netns owns the hostname and the port surface.
@@ -114,6 +125,98 @@ def build_create_body(inspect_raw: dict[str, Any], new_gluetun_id: str) -> dict[
     return body
 
 
+@contextmanager
+def _defer_stop_signals(logger: Logger) -> Iterator[None]:
+    """Hold SIGTERM/SIGINT for the duration of the recreate critical section.
+
+    The CLI's handlers exit immediately; a stop signal landing mid-recreate
+    (e.g. ``docker compose up -d`` recreating the monitor itself) would strand
+    the sequence half-done (#76). Signals received while held are re-delivered
+    to the restored handlers on exit, so shutdown still happens — just after
+    the container work is consistent. No-op off the main thread (CPython only
+    delivers signals to the main thread, and ``signal.signal`` would raise).
+    """
+    if threading.current_thread() is not threading.main_thread():
+        yield
+        return
+    pending: list[int] = []
+
+    def _hold(signum: int, _frame: object) -> None:
+        if signum not in pending:
+            pending.append(signum)
+        logger.warn(
+            f"Received {signal.Signals(signum).name} during a recreate — "
+            f"deferring shutdown until the container is consistent"
+        )
+
+    previous = {s: signal.signal(s, _hold) for s in (signal.SIGTERM, signal.SIGINT)}
+    try:
+        yield
+    finally:
+        for s, handler in previous.items():
+            signal.signal(s, handler)
+        for signum in pending:
+            os.kill(os.getpid(), signum)  # re-deliver to the restored handler
+
+
+def gc_recreate_leftover(client: DockerClient, dep_name: str, logger: Logger) -> bool:
+    """Remove a parked ``<dep>.gm-recreate-old`` left by an interrupted recreate.
+
+    Called before ANY remediation of ``dep_name``: if the leftover still exists
+    alongside the (already-replaced or about-to-be-replaced) dependent, it holds
+    the same volume mounts — starting/recreating the dependent with it still
+    around risks two instances writing the same data. Returns False when a
+    leftover exists but cannot be removed (the caller must NOT proceed).
+    """
+    leftover = f"{dep_name}{_OLD_SUFFIX}"
+    if client.inspect(leftover) is None:
+        return True
+    try:
+        client.remove(leftover, volumes=False)
+    except Exception as exc:
+        logger.error(
+            f"Cannot remove leftover {leftover} from an interrupted recreate: {exc} "
+            f"— refusing to remediate {dep_name} while it exists (shared volumes)"
+        )
+        return False
+    logger.warn(f"Removed leftover {leftover} from a previously interrupted recreate")
+    return True
+
+
+def sweep_recreate_leftovers(client: DockerClient, logger: Logger) -> None:
+    """Startup recovery for a recreate interrupted by SIGKILL/power loss (#76).
+
+    A ``<dep>.gm-recreate-old`` container found at startup means a recreate died
+    mid-sequence. If the real name is free (interrupted between rename and
+    create), the parked container IS the workload — rename it back. If the real
+    name exists (replacement was created), the parked one is condemned — remove
+    it (volumes preserved; they belong to the replacement now).
+    """
+    for cid in client.list_running_ids():
+        info = client.inspect(cid)
+        if info is None or not info.name.endswith(_OLD_SUFFIX):
+            continue
+        original = info.name[: -len(_OLD_SUFFIX)]
+        if client.inspect(original) is None:
+            try:
+                client.rename(info.name, original)
+                logger.warn(
+                    f"Restored {original}: an interrupted recreate had left it "
+                    f"parked as {info.name}"
+                )
+            except Exception as exc:
+                logger.error(f"Could not restore {info.name} to {original}: {exc}")
+        else:
+            try:
+                client.remove(info.name, volumes=False)
+                logger.warn(
+                    f"Removed {info.name}: leftover from an interrupted recreate "
+                    f"({original} was already replaced)"
+                )
+            except Exception as exc:
+                logger.error(f"Could not remove leftover {info.name}: {exc}")
+
+
 def recreate_dependent(
     client: DockerClient,
     dep_name: str,
@@ -122,8 +225,15 @@ def recreate_dependent(
 ) -> bool:
     """Recreate ``dep_name`` re-homed onto ``new_gluetun_id``. Returns success.
 
-    Order is remove-then-create because the new container reuses the same name.
-    ``volumes=False`` on remove is the data-preservation guarantee (ROC, ADR-0005).
+    The new container must reuse the same name, but remove-then-create left a
+    window where a failure (Docker API error, stop signal) destroyed the
+    dependent unrecoverably (#76). Instead: **rename aside → create → remove old
+    → start**, under deferred stop signals. Every intermediate state is
+    recoverable — a create failure rolls the rename back; anything harder is
+    healed by :func:`sweep_recreate_leftovers` at the next start. The old
+    container is removed *before* the new one starts because they share every
+    mount (two live instances would corrupt the volumes). ``volumes=False`` on
+    remove is the data-preservation guarantee (ROC, ADR-0005).
     """
     info = client.inspect(dep_name)
     if info is None:
@@ -136,14 +246,46 @@ def recreate_dependent(
         logger.error(f"Cannot recreate {dep_name}: failed to build spec: {exc}")
         return False
 
+    old_name = f"{dep_name}{_OLD_SUFFIX}"
     logger.warn(f"Recreating {dep_name} (re-homing netns onto gluetun {new_gluetun_id[:12]})")
-    try:
-        client.remove(dep_name, volumes=False)  # preserve named + anonymous volumes
-        new_id = client.create_from_config(body, name=dep_name)
-        client.start(new_id)
-    except Exception as exc:
-        logger.error(f"Recreate of {dep_name} failed: {exc}")
-        return False
+    with _defer_stop_signals(logger):
+        # 1. Park the original (still running; fully reversible).
+        try:
+            client.rename(dep_name, old_name)
+        except Exception as exc:
+            logger.error(f"Recreate of {dep_name} failed renaming the original: {exc}")
+            return False
+        # 2. Create the replacement under the real name; roll back on failure.
+        try:
+            new_id = client.create_from_config(body, name=dep_name)
+        except Exception as exc:
+            logger.error(f"Recreate of {dep_name} failed at create: {exc} — rolling back")
+            try:
+                client.rename(old_name, dep_name)
+                logger.info(f"{dep_name} restored (recreate rolled back; container unchanged)")
+            except Exception as rollback_exc:
+                logger.error(
+                    f"Rollback rename of {dep_name} also failed: {rollback_exc} — the "
+                    f"original is still intact as {old_name}; the startup sweep will "
+                    f"restore it"
+                )
+            return False
+        # 3. Retire the original BEFORE starting the replacement — they share
+        #    every mount, and two live instances would corrupt the volumes.
+        try:
+            client.remove(old_name, volumes=False)  # preserve named + anon volumes
+        except Exception as exc:
+            logger.error(
+                f"Recreate of {dep_name}: could not remove the old container: {exc} — "
+                f"NOT starting the replacement (shared volumes); will retry next loop"
+            )
+            return False
+        # 4. Start the replacement.
+        try:
+            client.start(new_id)
+        except Exception as exc:
+            logger.error(f"Recreate of {dep_name}: created but failed to start: {exc}")
+            return False
 
     logger.info(f"{dep_name} recreated as {new_id[:12]} and started")
     return True

--- a/tests/fakes.py
+++ b/tests/fakes.py
@@ -78,6 +78,7 @@ class FakeDockerClient:
         self.removed: list[tuple[str, bool]] = []  # (name_or_id, volumes)
         self.created: list[tuple[dict[str, Any], str]] = []  # (body, name)
         self.started: list[str] = []
+        self.renamed: list[tuple[str, str]] = []  # (name_or_id, new_name)
         self._id_seq = 1000
 
     # ----- test setup helpers -----
@@ -151,6 +152,15 @@ class FakeDockerClient:
         self._store[new_id] = raw
         self.created.append((config, name))
         return new_id
+
+    def rename(self, name_or_id: str, new_name: str) -> None:
+        raw = self._resolve(name_or_id)
+        if raw is None:
+            raise RuntimeError(f"no such container: {name_or_id}")
+        if self._resolve(new_name) is not None:
+            raise RuntimeError(f"name already in use: {new_name}")
+        raw["Name"] = f"/{new_name}"
+        self.renamed.append((name_or_id, new_name))
 
     def start(self, name_or_id: str) -> None:
         raw = self._resolve(name_or_id)

--- a/tests/test_distroless_fallback.py
+++ b/tests/test_distroless_fallback.py
@@ -81,4 +81,4 @@ def test_distroless_moved_id_is_recreated_end_to_end(tmp_path: Path) -> None:
     mon = _mon(fake, config_file=str(conf), dependent_containers="distroless")
     mon.run_once()
     assert len(fake.created) == 1  # recreated onto the current gluetun id
-    assert fake.removed == [("distroless", False)]
+    assert fake.removed == [("distroless.gm-recreate-old", False)]  # parked old, volumes kept

--- a/tests/test_monitor.py
+++ b/tests/test_monitor.py
@@ -123,7 +123,7 @@ def test_stranded_dependent_with_moved_gluetun_id_is_recreated(sites_file: str) 
     fake.on_exec = handler
     _monitor(fake, sites_file, dependent_containers="dep").run_once()
     assert len(fake.created) == 1
-    assert fake.removed == [("dep", False)]
+    assert fake.removed == [("dep.gm-recreate-old", False)]  # parked old, volumes kept
     assert fake.restarted == []
 
 
@@ -157,7 +157,7 @@ def test_remembered_dependent_recreated_after_live_gluetun_recreate(sites_file: 
 
     mon.run_once()  # loop 2: dep no longer matches current id, but is remembered
     assert len(fake.created) == 1  # recreated onto the new gluetun id
-    assert fake.removed[-1] == ("dep", False)
+    assert fake.removed[-1] == ("dep.gm-recreate-old", False)  # parked old, volumes kept
 
 
 def test_viability_failure_accumulates_to_threshold(sites_file: str) -> None:

--- a/tests/test_recovery.py
+++ b/tests/test_recovery.py
@@ -147,7 +147,7 @@ def test_remediate_recreate_path() -> None:
     fake.on_exec = _live_exec
     ok = remediate_dependent(fake, "dep", GLUETUN_ID, Config(), _logger(), sleep=lambda _s: None)
     assert ok is True
-    assert fake.removed == [("dep", False)]
+    assert fake.removed == [("dep.gm-recreate-old", False)]  # parked old, volumes kept
     assert len(fake.created) == 1
     assert fake.restarted == []  # recreate, not restart
 

--- a/tests/test_recreate.py
+++ b/tests/test_recreate.py
@@ -147,7 +147,7 @@ def test_recreate_dependent_removes_without_volumes_then_creates() -> None:
     ok = recreate_dependent(fake, "qbittorrent", NEW_GLUETUN_ID, _logger())
     assert ok is True
     # The data-preservation guarantee: remove must NOT delete volumes.
-    assert fake.removed == [("qbittorrent", False)]
+    assert fake.removed == [("qbittorrent.gm-recreate-old", False)]
     assert len(fake.created) == 1
     body, name = fake.created[0]
     assert name == "qbittorrent"

--- a/tests/test_recreate_window.py
+++ b/tests/test_recreate_window.py
@@ -1,0 +1,157 @@
+"""The recreate critical section is no longer destructive (#76).
+
+Why: remove-then-create had a window where a stop signal or Docker API failure
+permanently destroyed the dependent (the create body existed only in memory).
+The rename-aside sequence (park → create → remove old → start) makes every
+intermediate state recoverable: create failures roll back, stop signals are
+deferred until the containers are consistent, and a SIGKILL/power-loss leftover
+is healed by the startup sweep. These tests pin each of those guarantees.
+"""
+
+from __future__ import annotations
+
+import io
+import os
+import signal
+from typing import Any
+
+from gluetun_monitor.logging_setup import Logger
+from gluetun_monitor.recreate import (
+    gc_recreate_leftover,
+    recreate_dependent,
+    sweep_recreate_leftovers,
+)
+
+from .fakes import FakeDockerClient
+
+OLD_ID = "b" * 64
+GLUETUN_ID = "a" * 64
+
+
+def _logger() -> Logger:
+    return Logger(log_file=None, level="DEBUG", stream=io.StringIO())
+
+
+def _stranded_dep(fake: FakeDockerClient, name: str = "dep") -> None:
+    fake.add_container(name, network_mode=f"container:{OLD_ID}")
+
+
+# ----- signal deferral: SIGTERM mid-recreate must not strand the sequence -----
+
+def test_sigterm_mid_recreate_is_deferred_until_consistent() -> None:
+    """A SIGTERM landing between park and create (the compose-restart trigger)
+    is held until the sequence completes, then re-delivered — the dependent
+    exists and is started BEFORE the shutdown handler runs."""
+    received: list[int] = []  # started-count observed when the signal arrives
+
+    class _KillDuringCreate(FakeDockerClient):
+        def create_from_config(self, config: dict[str, Any], name: str) -> str:
+            os.kill(os.getpid(), signal.SIGTERM)  # lands mid-critical-section
+            return super().create_from_config(config, name)
+
+    fake = _KillDuringCreate()
+    _stranded_dep(fake)
+
+    def _record(signum: int, _frame: object) -> None:
+        received.append(len(fake.started))  # how far the recreate got by delivery
+
+    original = signal.signal(signal.SIGTERM, _record)
+    try:
+        assert recreate_dependent(fake, "dep", GLUETUN_ID, _logger()) is True
+    finally:
+        signal.signal(signal.SIGTERM, original)  # never leak handlers (see #90)
+
+    # The signal WAS re-delivered — but only after the replacement was started.
+    assert received == [1]
+    info = fake.inspect("dep")
+    assert info is not None and info.running
+    assert info.network_mode == f"container:{GLUETUN_ID}"
+
+
+# ----- API failures at each step leave a recoverable state -----
+
+def test_rename_failure_changes_nothing() -> None:
+    class _RenameRaises(FakeDockerClient):
+        def rename(self, name_or_id: str, new_name: str) -> None:
+            raise RuntimeError("socket died")
+
+    fake = _RenameRaises()
+    _stranded_dep(fake)
+    assert recreate_dependent(fake, "dep", GLUETUN_ID, _logger()) is False
+    assert fake.removed == [] and fake.created == [] and fake.started == []
+    assert fake.inspect("dep") is not None  # untouched
+
+
+def test_remove_old_failure_does_not_start_the_replacement() -> None:
+    """If the parked original can't be removed, the replacement must NOT start:
+    both containers share every mount, and two live instances would corrupt
+    the volumes. The next loop retries (restart path GCs the leftover first)."""
+    class _RemoveRaises(FakeDockerClient):
+        def remove(self, name_or_id: str, *, volumes: bool) -> None:
+            raise RuntimeError("socket died")
+
+    fake = _RemoveRaises()
+    _stranded_dep(fake)
+    assert recreate_dependent(fake, "dep", GLUETUN_ID, _logger()) is False
+    assert fake.started == []  # no double-mount
+    # Replacement exists under the real name; original is parked — both alive,
+    # neither started: the exact state gc_recreate_leftover + restart heal.
+    assert fake.inspect("dep") is not None
+    assert fake.inspect("dep.gm-recreate-old") is not None
+
+
+# ----- leftover GC before any remediation -----
+
+def test_gc_removes_leftover_and_blocks_when_it_cannot() -> None:
+    fake = FakeDockerClient()
+    _stranded_dep(fake)
+    fake.add_container("dep.gm-recreate-old", network_mode=f"container:{OLD_ID}")
+    assert gc_recreate_leftover(fake, "dep", _logger()) is True
+    assert ("dep.gm-recreate-old", False) in fake.removed
+
+    class _RemoveRaises(FakeDockerClient):
+        def remove(self, name_or_id: str, *, volumes: bool) -> None:
+            raise RuntimeError("socket died")
+
+    blocked = _RemoveRaises()
+    _stranded_dep(blocked)
+    blocked.add_container("dep.gm-recreate-old", network_mode=f"container:{OLD_ID}")
+    assert gc_recreate_leftover(blocked, "dep", _logger()) is False  # caller must not act
+
+
+def test_gc_noop_without_leftover() -> None:
+    fake = FakeDockerClient()
+    _stranded_dep(fake)
+    assert gc_recreate_leftover(fake, "dep", _logger()) is True
+    assert fake.removed == []
+
+
+# ----- startup sweep: SIGKILL/power-loss recovery -----
+
+def test_sweep_restores_parked_container_when_name_is_free() -> None:
+    """Killed between park and create: the parked container IS the workload —
+    rename it back so discovery and remediation see it again."""
+    fake = FakeDockerClient()
+    fake.add_container("app.gm-recreate-old", network_mode=f"container:{OLD_ID}")
+    sweep_recreate_leftovers(fake, _logger())
+    assert fake.inspect("app") is not None
+    assert fake.inspect("app.gm-recreate-old") is None
+    assert ("app.gm-recreate-old", "app") in [(o, n) for o, n in fake.renamed]
+
+
+def test_sweep_removes_parked_container_when_replaced() -> None:
+    """Killed after create: the replacement owns the name (and the volumes) —
+    the parked original is condemned."""
+    fake = FakeDockerClient()
+    fake.add_container("app", network_mode=f"container:{GLUETUN_ID}")
+    fake.add_container("app.gm-recreate-old", network_mode=f"container:{OLD_ID}")
+    sweep_recreate_leftovers(fake, _logger())
+    assert ("app.gm-recreate-old", False) in fake.removed
+    assert fake.inspect("app") is not None  # replacement untouched
+
+
+def test_sweep_ignores_unrelated_containers() -> None:
+    fake = FakeDockerClient()
+    fake.add_container("app", network_mode=f"container:{GLUETUN_ID}")
+    sweep_recreate_leftovers(fake, _logger())
+    assert fake.removed == [] and fake.renamed == []

--- a/tests/test_remediation_branches.py
+++ b/tests/test_remediation_branches.py
@@ -97,10 +97,15 @@ class _CreateRaises(FakeDockerClient):
         raise RuntimeError("simulated create failure")
 
 
-def test_recreate_create_failure_after_remove_returns_false() -> None:
-    """If create fails after the remove, recreate returns False (the dependent is
-    left removed — documented, hard to make atomic given Docker name reuse)."""
+def test_recreate_create_failure_rolls_back_the_rename() -> None:
+    """#76: a create failure must NOT destroy the dependent. The rename-aside
+    sequence rolls back — the original container survives, under its original
+    name, still running (pre-fix: remove-then-create left it permanently gone)."""
     fake = _CreateRaises()
     fake.add_container("dep", network_mode=f"container:{OLD_ID}")
     assert recreate_dependent(fake, "dep", GLUETUN_ID, _logger()) is False
-    assert fake.removed == [("dep", False)]  # remove happened, with volumes preserved
+    assert fake.removed == []  # nothing destroyed
+    info = fake.inspect("dep")
+    assert info is not None and info.running  # original restored, intact
+    # Park + rollback are both recorded.
+    assert fake.renamed == [("dep", "dep.gm-recreate-old"), ("dep.gm-recreate-old", "dep")]


### PR DESCRIPTION
Closes #76.

## Problem

`recreate_dependent` was remove-then-create with no rollback. A Docker API failure (socket/proxy dying, daemon rejecting the rebuilt body) or a stop signal (`docker compose up -d` recreating the monitor mid-loop — the CLI handler `sys.exit(0)`s immediately) landing between `remove()` and `create_from_config()` destroyed the dependent permanently: the create body existed only in memory, and every subsequent loop logged "Cannot remediate: container not found". The one place restart-as-repair couldn't recover the stack.

One state (post-remove) from which no path leads back to a running workload:

```mermaid
stateDiagram-v2
    direction TB
    state "Running (stranded on old netns)" as Running
    state "Spec built (build_create_body)" as Spec
    state "☠ REMOVED — workload gone" as Removed
    state "Created (stopped)" as Created
    state "Running, re-homed ✅" as Done
    state "❌ LOST — nothing left to retry against" as Lost

    [*] --> Running
    Running --> Spec: inspect + build spec (pure)
    Spec --> Removed: remove(dep, volumes=False)
    Removed --> Created: create(name=dep, netns=new gluetun)
    Created --> Done: start()
    Done --> [*]

    Removed --> Lost: create fails · SIGTERM/SIGINT · crash

    note right of Removed
        The destructive window:
        between remove and create the
        dependent does not exist — only its
        volumes survive. No rollback path,
        and stop signals were not deferred.
        Every subsequent loop logs
        "container not found".
    end note
```

## Fix

New sequence — **rename aside → create → remove old → start** — chosen so every intermediate state is recoverable:

| failure point | outcome |
|---|---|
| rename fails | nothing changed |
| create fails | rename rolled back — original container untouched (pre-fix: gone) |
| remove-old fails | replacement **not** started (shared mounts — two live instances would corrupt volumes); next loop GCs the parked leftover, then restarts the replacement |
| start fails | replacement exists; next loop's not-running remediation restarts it |
| SIGTERM/SIGINT mid-sequence | deferred, re-delivered once containers are consistent |
| SIGKILL / power loss | healed at next start by `sweep_recreate_leftovers()`: parked container restored if its name is free (it *is* the workload), removed if the replacement exists |

Every state has an exit that ends with either the original or the replacement running, volumes preserved throughout:

```mermaid
stateDiagram-v2
    direction TB
    state "GC: leftover dep.gm-recreate-old?" as GC
    state "⛔ Remediation refused (unremovable twin — shared volumes)" as Refused
    state "Running (stranded)" as Running
    state "Parked as dep.gm-recreate-old (still running, fully reversible)" as Parked
    state "Replacement created under real name (stopped)" as Created
    state "Old removed — volumes=False, data kept" as Retired
    state "Running, re-homed ✅" as Done
    state "Retry next monitor loop" as Retry
    state "Leftover parked container (SIGKILL / rollback failed)" as Leftover
    state "Leftover condemned (replacement owns the volumes)" as Condemned

    [*] --> GC: before ANY remediation
    GC --> Refused: leftover exists and remove fails
    GC --> Running: clean (or leftover removed)

    Running --> Parked: ① rename aside
    Parked --> Created: ② create
    Created --> Retired: ③ remove old FIRST (shared mounts — never two live instances)
    Retired --> Done: ④ start
    Done --> [*]: held SIGTERM/SIGINT re-delivered

    Running --> Retry: ① rename fails (pure no-op)
    Parked --> Running: ② create fails → rollback rename
    Parked --> Leftover: rollback also fails · SIGKILL mid-flight
    Created --> Retry: ③ remove-old fails → replacement NOT started
    Retired --> Retry: ④ start fails (container exists, next loop starts it)

    Leftover --> Running: startup sweep — real name free → rename back
    Leftover --> Condemned: startup sweep — name taken → remove leftover

    note right of Parked
        Steps ①–④ run with SIGTERM/SIGINT
        held (_defer_stop_signals); signals
        re-deliver once container state is
        consistent. Every intermediate state
        is either rolled back inline or healed
        by sweep_recreate_leftovers() at the
        next startup.
    end note
```

Supporting changes:

- `rename()` added to the `DockerClient` seam. `POST /containers/{id}/rename` is the same CONTAINERS+POST socket-proxy class as the create/remove/start calls the recreate path already makes (ADR-0002) — **no new proxy permission required**.
- `gc_recreate_leftover()` runs before *any* remediation of a dependent and refuses to proceed while an unremovable parked twin exists (volume-safety).
- The sweep runs once at startup in `Monitor.announce()`.
- The old container is parked under `<name>.gm-recreate-old` — specific enough not to collide, and the volume-preservation guarantee (`volumes=False`) is unchanged, now applied to the parked name.

## Tests

- `test_recreate_create_failure_rolls_back_the_rename` — replaces the old characterization ("dependent left removed — documented, hard to make atomic") with the rollback contract; **verified red against pre-fix code**.
- `test_recreate_window.py` (new): SIGTERM mid-create is deferred and delivered only after start (asserts ordering via started-count at delivery; handler save/restored, no leak); rename-failure changes nothing; remove-old failure starts nothing; GC removes/blocks; sweep restores vs condemns; unrelated containers untouched.
- Five existing assertions updated to the parked name (same volume guarantee).

Full suite, ruff, mypy green locally.

## Dogfood note

Worth exercising once on rosa before the 2.2.2 release: trigger a real recreate (recreate gluetun, let the monitor re-home a dependent) and confirm the rename path behaves through the actual socket-proxy.
