### PR TITLE
fix(probe): size the Docker transport from effective per-URL timeouts (#77)

### DIFF
--- a/gluetun_monitor/cli.py
+++ b/gluetun_monitor/cli.py
@@ -14,7 +14,7 @@ from .logging_setup import Logger, install_bash_format_on_root
 from .monitor import Monitor
 from .notify import Notifier, NotifyEvent, build_notifier
 from .site_stats import SiteStatsStore
-from .sites import hostname_of, load_sites_report
+from .sites import hostname_of, load_sites_report, load_specs, worst_case_probe_seconds
 from .tunables import suggest_tunables
 
 
@@ -194,8 +194,13 @@ def _run_suggest_tunables(config: Config, logger: Logger) -> int:
             "run the monitor a while, then retry."
         )
         return 0
+    try:
+        specs = {s.url: s for s in load_specs(config.config_file, config.sites_env)}
+    except Exception:
+        specs = {}  # unreadable sites config → judge against the globals, as before
     suggestions = suggest_tunables(
-        store.sites, global_timeout=config.timeout, global_tries=config.wget_tries
+        store.sites, global_timeout=config.timeout, global_tries=config.wget_tries,
+        specs=specs,  # judge each site against its EFFECTIVE knobs (#77)
     )
     print("gluetun-monitor — per-URL tunable suggestions")
     print(
@@ -220,6 +225,26 @@ def _run_suggest_tunables(config: Config, logger: Logger) -> int:
     if healthy:
         print(f"  Healthy (no change): {', '.join(healthy)}")
     return 0
+
+
+def _transport_timeout(config: Config) -> int:
+    """Initial Docker transport read-timeout: double the worst-case probe runtime,
+    floored at 60s (the pre-#77 shape, so no-override configs size identically).
+
+    Sized from the *effective* per-URL knobs, not just the global ``TIMEOUT``: a
+    ``|timeout=`` override above the global-derived ceiling would otherwise have
+    its probes killed by the transport — a slow success misreported as a failure,
+    by the very knob meant to stop that (#77). The monitor re-raises the ceiling
+    on every sites reload (``DockerClient.ensure_timeout``); this only has to be
+    right for startup.
+    """
+    worst = config.timeout * max(1, config.wget_tries)
+    try:
+        specs = load_specs(config.config_file, config.sites_env)
+        worst = worst_case_probe_seconds(specs, config.timeout, config.wget_tries)
+    except Exception:
+        pass  # unreadable sites config is reported at loop time; size from the globals
+    return max(worst * 2, 60)
 
 
 def _run_notify_test(config: Config, notifier: Notifier, logger: Logger) -> int:
@@ -274,7 +299,7 @@ def main(argv: list[str] | None = None) -> int:
         return 1
 
     try:
-        client: DockerClient = DockerPyClient(timeout=max(config.timeout * 2, 60))
+        client: DockerClient = DockerPyClient(timeout=_transport_timeout(config))
     except Exception as exc:
         logger.error(f"Failed to initialize Docker client: {exc}")
         notifier.notify(NotifyEvent(

--- a/gluetun_monitor/docker_client.py
+++ b/gluetun_monitor/docker_client.py
@@ -100,6 +100,17 @@ class DockerClient(Protocol):
         """Start an existing (created) container."""
         ...
 
+    def ensure_timeout(self, seconds: int) -> None:
+        """Raise the transport read-timeout to at least ``seconds``; never lower it.
+
+        Per-URL ``|timeout=`` overrides can push a probe's legitimate runtime past
+        the transport ceiling sized from the global ``TIMEOUT`` (#77) — the sites
+        set reloads every loop, so the ceiling must be able to follow it upward.
+        Raise-only: lowering mid-flight could clip a concurrent long probe, and
+        a too-generous ceiling costs nothing when everything is fast.
+        """
+        ...
+
 
 class DockerPyClient:
     """``DockerClient`` over docker-py's low-level API (honors DOCKER_HOST).
@@ -171,3 +182,9 @@ class DockerPyClient:
     def start(self, name_or_id: str) -> None:
         """``POST /containers/{id}/start``."""
         self._api.start(name_or_id)
+
+    def ensure_timeout(self, seconds: int) -> None:  # pragma: no cover - needs a live daemon
+        """Bump docker-py's per-request read-timeout (it reads ``api.timeout`` on
+        every call, so mutating it takes effect for subsequent requests).
+        """
+        self._api.timeout = max(self._api.timeout or 0, seconds)

--- a/gluetun_monitor/monitor.py
+++ b/gluetun_monitor/monitor.py
@@ -41,6 +41,7 @@ from .sites import (
     is_ip_literal,
     load_specs,
     resolvable_pool,
+    worst_case_probe_seconds,
 )
 from .state import Counter, InterfaceStatus, RemediationAction
 from .tunables import suggest_tunables
@@ -679,6 +680,13 @@ class Monitor:
             )
             specs = list(self._specs.values())
         sites = [s.url for s in specs]
+        # A per-URL |timeout= override can push a probe's legitimate runtime past
+        # the transport read-timeout sized from the globals — the probe would be
+        # killed by the transport and a slow SUCCESS misreported as a failure
+        # (#77). Track the worst case on every reload; raise-only, so a config
+        # edit can never clip a probe already in flight.
+        worst = worst_case_probe_seconds(specs, self.config.timeout, self.config.wget_tries)
+        self.client.ensure_timeout(max(worst * 2, 60))
 
         breached = self.check_gluetun_sites(sites)
         if not breached:
@@ -814,7 +822,9 @@ class Monitor:
         if st is None:
             return ""
         sugg = suggest_tunables(
-            {site: st}, global_timeout=self.config.timeout, global_tries=self.config.wget_tries
+            {site: st}, global_timeout=self.config.timeout,
+            global_tries=self.config.wget_tries,
+            specs=self._specs,  # judge against the site's EFFECTIVE knobs (#77)
         )
         if sugg and sugg[0].config_line:
             return (f" The stats suggest `{sugg[0].config_line}` — run "

--- a/gluetun_monitor/sites.py
+++ b/gluetun_monitor/sites.py
@@ -28,6 +28,16 @@ from urllib.parse import urlsplit
 # existing ``probe_site`` params, so honoring them needs no probe rework.
 _OPTION_KEYS = ("timeout", "tries")
 
+# Sanity ceilings for per-URL overrides (#77). The Docker transport read-timeout
+# is sized from the worst-case probe (see ``worst_case_probe_seconds``), so an
+# absurd override would silently stretch every loop and the transport with it —
+# a probe stuck for minutes stalls ALL site checks (they fan out, but the loop
+# joins them). 300s tolerates genuinely slow-but-alive sites; anything beyond
+# is a config mistake, warned about and skipped per the forgiving+loud contract.
+MAX_URL_TIMEOUT = 300
+MAX_URL_TRIES = 5
+_OPTION_CAPS = {"timeout": MAX_URL_TIMEOUT, "tries": MAX_URL_TRIES}
+
 
 @dataclass(frozen=True, slots=True)
 class SiteSpec:
@@ -78,8 +88,34 @@ def parse_entry(raw: str) -> tuple[SiteSpec | None, list[str]]:
         if not (value.isascii() and value.isdigit()) or int(value) < 1:
             warnings.append(f"invalid {key} {value!r} (want a positive integer)")
             continue
+        if int(value) > _OPTION_CAPS[key]:
+            warnings.append(
+                f"{key}={value} exceeds the maximum {_OPTION_CAPS[key]} (#77) — "
+                f"ignoring the override"
+            )
+            continue
         values[key] = int(value)
     return SiteSpec(url, timeout=values.get("timeout"), tries=values.get("tries")), warnings
+
+
+def worst_case_probe_seconds(
+    specs: list[SiteSpec], default_timeout: int, default_tries: int
+) -> int:
+    """Worst-case single-probe runtime across ``specs``: the max of each site's
+    *effective* ``timeout*tries`` (its overrides, else the globals).
+
+    This is what the Docker transport read-timeout must comfortably exceed (#77):
+    ``wget --spider`` emits nothing while it waits, so an exec that legitimately
+    runs long looks idle to the transport — if the transport gives up first, a
+    slow *success* is misreported as a probe failure, and a per-URL override
+    meant to stop restarts guarantees them instead.
+    """
+    worst = default_timeout * max(1, default_tries)
+    for s in specs:
+        timeout = s.timeout if s.timeout is not None else default_timeout
+        tries = s.tries if s.tries is not None else default_tries
+        worst = max(worst, timeout * max(1, tries))
+    return worst
 
 
 def trim(s: str) -> str:

--- a/gluetun_monitor/tunables.py
+++ b/gluetun_monitor/tunables.py
@@ -23,6 +23,7 @@ import math
 from dataclasses import dataclass
 
 from .site_stats import SiteStat
+from .sites import MAX_URL_TIMEOUT, SiteSpec
 
 # A site counts as "slow, not dead" when it has answered at >= this fraction of the
 # current timeout ceiling — proof a wider timeout would convert its read-timeouts
@@ -69,10 +70,28 @@ def _latency(st: SiteStat) -> dict[str, int]:
     return lifetime if lifetime.get("samples", 0) else st.latency_summary()
 
 
+def _config_line(url: str, *, timeout: int | None, tries: int | None) -> str:
+    """The paste-ready ``url|key=value...`` carrying EVERY override the site should
+    end up with — a suggestion for one knob must not silently drop an override the
+    operator already set for the other (#77).
+    """
+    line = url
+    if timeout is not None:
+        line += f"|timeout={timeout}"
+    if tries is not None:
+        line += f"|tries={tries}"
+    return line
+
+
 def _suggest_one(
-    url: str, st: SiteStat, *, global_timeout: int, global_tries: int
+    url: str, st: SiteStat, *, timeout: int, tries: int, spec: SiteSpec | None
 ) -> Suggestion | None:
     """The single best suggestion for one site, or None if it's behaving fine.
+
+    ``timeout``/``tries`` are the site's *effective* knobs — its ``|key=value``
+    overrides where set, else the globals (#77): evaluating an already-overridden
+    site against the globals re-suggests what's already set (or a lower value),
+    and the slow-not-dead discriminator misfires against the wrong ceiling.
 
     Priority is by *which fix actually helps*: a wider timeout for a slow-but-alive
     site (the surgical keep-it-useful fix), else "investigate" when restarts are
@@ -88,11 +107,16 @@ def _suggest_one(
 
     # (1) Slow-but-alive: a *pattern* of read-timeouts AND it has answered
     # near/over the ceiling (so a wider timeout converts those into passes).
-    if timeouts >= _MIN_TIMEOUT_FAILURES and max_ms >= global_timeout * 1000 * _SLOW_LATENCY_FRACTION:
-        suggested = _round_up_5(math.ceil(max_ms / 1000) + _TIMEOUT_HEADROOM_S)
-        if suggested > global_timeout:
+    # Capped at the parse-time maximum — suggesting a value parse_entry would
+    # reject is a paste-ready line that doesn't work.
+    if timeouts >= _MIN_TIMEOUT_FAILURES and max_ms >= timeout * 1000 * _SLOW_LATENCY_FRACTION:
+        suggested = min(
+            _round_up_5(math.ceil(max_ms / 1000) + _TIMEOUT_HEADROOM_S), MAX_URL_TIMEOUT
+        )
+        if suggested > timeout:
             return Suggestion(
-                url, "timeout", f"{url}|timeout={suggested}",
+                url, "timeout",
+                _config_line(url, timeout=suggested, tries=spec.tries if spec else None),
                 f"{timeouts} read-timeout failure(s) but answers within "
                 f"p99={p99}ms / max={max_ms}ms — slow, not dead; a {suggested}s timeout "
                 f"keeps it a useful canary instead of triggering restarts",
@@ -116,13 +140,14 @@ def _suggest_one(
     # (3) Isolated one-poll blips that nonetheless tripped a restart — a retry
     # absorbs the transient before it counts (only when not already retrying).
     if (
-        global_tries < 2
+        tries < 2
         and st.restarts_triggered > 0
         and st.total_failures > 0
         and st.longest_fail_streak <= 1
     ):
         return Suggestion(
-            url, "tries", f"{url}|tries=2",
+            url, "tries",
+            _config_line(url, timeout=spec.timeout if spec else None, tries=2),
             f"{st.total_failures} isolated single-poll failure(s) triggering "
             f"{st.restarts_triggered} restart(s); tries=2 retries the blip before it "
             f"counts as a failure",
@@ -133,18 +158,29 @@ def _suggest_one(
 
 
 def suggest_tunables(
-    sites: dict[str, SiteStat], *, global_timeout: int, global_tries: int
+    sites: dict[str, SiteStat],
+    *,
+    global_timeout: int,
+    global_tries: int,
+    specs: dict[str, SiteSpec] | None = None,
 ) -> list[Suggestion]:
     """Per-URL tunable suggestions across all sites, ranked by restarts triggered.
 
     Pure function of the persisted stats — feed it a ``SiteStatsStore.sites`` map.
+    ``specs`` (url → :class:`SiteSpec`) supplies each site's current overrides so
+    it is judged against its *effective* knobs, not the globals (#77); omitted
+    (or missing a URL) means the site inherits the globals, as before.
     Returns only sites worth acting on (healthy sites yield nothing), most-impactful
     first so the operator fixes the biggest restart driver before the long tail.
     """
-    out = [
-        s for url, st in sites.items()
-        if (s := _suggest_one(url, st, global_timeout=global_timeout,
-                              global_tries=global_tries)) is not None
-    ]
+    specs = specs or {}
+    out = []
+    for url, st in sites.items():
+        spec = specs.get(url)
+        timeout = spec.timeout if spec and spec.timeout is not None else global_timeout
+        tries = spec.tries if spec and spec.tries is not None else global_tries
+        s = _suggest_one(url, st, timeout=timeout, tries=tries, spec=spec)
+        if s is not None:
+            out.append(s)
     out.sort(key=lambda s: s.restarts, reverse=True)
     return out

--- a/tests/fakes.py
+++ b/tests/fakes.py
@@ -79,6 +79,7 @@ class FakeDockerClient:
         self.created: list[tuple[dict[str, Any], str]] = []  # (body, name)
         self.started: list[str] = []
         self.renamed: list[tuple[str, str]] = []  # (name_or_id, new_name)
+        self.ensured_timeouts: list[int] = []  # every ensure_timeout() call (#77)
         self._id_seq = 1000
 
     # ----- test setup helpers -----
@@ -168,3 +169,6 @@ class FakeDockerClient:
             raise RuntimeError(f"no such container: {name_or_id}")
         raw["State"]["Running"] = True
         self.started.append(name_or_id)
+
+    def ensure_timeout(self, seconds: int) -> None:
+        self.ensured_timeouts.append(seconds)

--- a/tests/test_timeout_ceiling.py
+++ b/tests/test_timeout_ceiling.py
@@ -1,0 +1,193 @@
+"""Per-URL timeout overrides vs the Docker transport read-timeout (#77).
+
+Why: ``wget --spider`` emits nothing while it waits, so a probe that legitimately
+runs past the transport ceiling is killed by docker-py and a slow *success* is
+reported as a probe failure — the ``|timeout=`` override an operator adds to STOP
+restarts would silently guarantee them. These tests pin the fix at each layer:
+the transport is sized from the worst-case *effective* probe (startup + every
+sites reload, raise-only), absurd overrides are rejected at parse time, and the
+tunables doctor judges each site against its effective knobs so it never
+re-suggests what's already set (or a lower value).
+"""
+
+from __future__ import annotations
+
+import io
+import random
+from pathlib import Path
+
+from gluetun_monitor.cli import _transport_timeout
+from gluetun_monitor.config import Config
+from gluetun_monitor.docker_client import ExecResult
+from gluetun_monitor.logging_setup import Logger
+from gluetun_monitor.monitor import Monitor
+from gluetun_monitor.site_stats import SiteStat
+from gluetun_monitor.sites import (
+    MAX_URL_TIMEOUT,
+    SiteSpec,
+    parse_entry,
+    worst_case_probe_seconds,
+)
+from gluetun_monitor.tunables import suggest_tunables
+
+from .fakes import FakeDockerClient
+
+GLUETUN_ID = "a" * 64
+
+
+# ----- worst_case_probe_seconds: the sizing input -----
+
+
+def test_worst_case_is_global_product_without_overrides() -> None:
+    specs = [SiteSpec("https://a.example"), SiteSpec("https://b.example")]
+    assert worst_case_probe_seconds(specs, 10, 1) == 10
+    assert worst_case_probe_seconds(specs, 10, 3) == 30
+
+
+def test_worst_case_tracks_the_largest_effective_override() -> None:
+    """timeout*tries is paired PER SITE: an override site uses its own knobs,
+    filling any unset knob from the global."""
+    specs = [
+        SiteSpec("https://fast.example"),
+        SiteSpec("https://slow.example", timeout=90),
+        SiteSpec("https://retry.example", timeout=40, tries=3),  # 120 — the worst
+    ]
+    assert worst_case_probe_seconds(specs, 10, 1) == 120
+
+
+# ----- parse_entry: absurd overrides are rejected, not transported -----
+
+
+def test_parse_entry_rejects_timeout_above_cap() -> None:
+    """An override beyond the sanity cap would stretch every loop and the
+    transport with it — warn-and-skip per the forgiving+loud contract; the URL
+    is still monitored on the global defaults."""
+    spec, warnings = parse_entry(f"https://a.example|timeout={MAX_URL_TIMEOUT + 1}")
+    assert spec is not None and spec.timeout is None
+    assert any("exceeds the maximum" in w for w in warnings)
+
+
+def test_parse_entry_accepts_timeout_at_cap() -> None:
+    spec, warnings = parse_entry(f"https://a.example|timeout={MAX_URL_TIMEOUT}")
+    assert spec is not None and spec.timeout == MAX_URL_TIMEOUT
+    assert warnings == []
+
+
+def test_parse_entry_rejects_tries_above_cap() -> None:
+    spec, warnings = parse_entry("https://a.example|tries=6")
+    assert spec is not None and spec.tries is None
+    assert any("exceeds the maximum" in w for w in warnings)
+
+
+# ----- the transport ceiling follows the overrides -----
+
+
+def test_startup_transport_is_sized_from_the_effective_worst_case(tmp_path: Path) -> None:
+    conf = tmp_path / "sites.conf"
+    conf.write_text("https://fast.example\nhttps://slow.example|timeout=90\n")
+    cfg = Config(config_file=str(conf), gluetun_container="gluetun")
+    assert _transport_timeout(cfg) == 180  # 90 * 1 try * 2
+
+
+def test_startup_transport_keeps_the_pre77_shape_without_overrides(tmp_path: Path) -> None:
+    """No overrides → max(TIMEOUT*2, 60): existing deployments size identically."""
+    conf = tmp_path / "sites.conf"
+    conf.write_text("https://a.example\n")
+    cfg = Config(config_file=str(conf), gluetun_container="gluetun")
+    assert _transport_timeout(cfg) == 60
+
+
+def test_startup_transport_survives_an_unreadable_sites_config(tmp_path: Path) -> None:
+    cfg = Config(config_file=str(tmp_path / "missing.conf"), gluetun_container="gluetun")
+    assert _transport_timeout(cfg) == 60  # falls back to the global-only sizing
+
+
+def test_loop_raises_the_ceiling_on_sites_reload(tmp_path: Path) -> None:
+    """The sites set reloads every loop; an override added at runtime must raise
+    the transport ceiling before its wider probe first runs — a slow success
+    within the override must never be misreported as a probe failure."""
+    conf = tmp_path / "sites.conf"
+    conf.write_text("https://slow.example|timeout=90\n")
+    fake = FakeDockerClient()
+    fake.add_container("gluetun", id=GLUETUN_ID)
+    fake.on_exec = lambda name, cmd: ExecResult(0, "")  # every probe passes
+    cfg = Config(config_file=str(conf), gluetun_container="gluetun")
+    logger = Logger(log_file=None, level="DEBUG", stream=io.StringIO())
+    Monitor(fake, cfg, logger, rng=random.Random(0), sleep=lambda _s: None).run_once()
+    assert 180 in fake.ensured_timeouts  # 90 * 1 try * 2
+
+
+# ----- tunables judge each site against its EFFECTIVE knobs -----
+
+
+def _stat(**kw: object) -> SiteStat:
+    st = SiteStat(first_seen=0.0)
+    for key, value in kw.items():
+        setattr(st, key, value)
+    return st
+
+
+def _slow_stat(max_latency_ms: int) -> SiteStat:
+    # longest_fail_streak > 1: a slow site's read-timeouts cluster, so the stat
+    # must not accidentally qualify for the isolated-blip retry suggestion.
+    return _stat(
+        total_polls=100, total_failures=5, failure_reasons={"timeout": 5},
+        restarts_triggered=10, restarts_cleared=4, longest_fail_streak=3,
+        recent_latencies=[1500, 1800, max_latency_ms],
+    )
+
+
+def test_no_resuggestion_at_or_below_the_existing_override() -> None:
+    """Globals would say timeout=20; the site already carries timeout=30 — the
+    doctor must judge against the effective knob and stay silent, not re-suggest
+    a value at/below what's already set."""
+    st = _slow_stat(13000)  # would suggest 20 against the 10s global
+    specs = {"https://slow": SiteSpec("https://slow", timeout=30)}
+    assert suggest_tunables(
+        {"https://slow": st}, global_timeout=10, global_tries=1, specs=specs
+    ) == []
+
+
+def test_overridden_site_still_gets_a_wider_suggestion_when_warranted() -> None:
+    """Genuinely slower than its existing override → suggest above the EFFECTIVE
+    value, and the paste-ready line carries the site's other override too."""
+    st = _slow_stat(40000)  # suggest round_up_5(40+5) = 45 > effective 30
+    specs = {"https://slow": SiteSpec("https://slow", timeout=30, tries=2)}
+    (s,) = suggest_tunables(
+        {"https://slow": st}, global_timeout=10, global_tries=1, specs=specs
+    )
+    assert s.config_line == "https://slow|timeout=45|tries=2"
+
+
+def test_timeout_suggestions_are_capped_at_the_parse_maximum() -> None:
+    """Never emit a paste-ready line parse_entry would reject."""
+    st = _slow_stat(400_000)  # would suggest 405s uncapped
+    (s,) = suggest_tunables({"https://glacial": st}, global_timeout=10, global_tries=1)
+    assert s.config_line == f"https://glacial|timeout={MAX_URL_TIMEOUT}"
+
+
+def test_tries_override_suppresses_the_retry_suggestion() -> None:
+    """A site already carrying |tries=2 must not be told to set tries=2 just
+    because the GLOBAL tries is 1."""
+    st = _stat(
+        total_polls=100, total_failures=3, failure_reasons={"connection": 3},
+        restarts_triggered=2, restarts_cleared=2, longest_fail_streak=1,
+        recent_latencies=[500],
+    )
+    specs = {"https://blippy": SiteSpec("https://blippy", tries=2)}
+    assert suggest_tunables(
+        {"https://blippy": st}, global_timeout=10, global_tries=1, specs=specs
+    ) == []
+
+
+def test_tries_suggestion_preserves_an_existing_timeout_override() -> None:
+    st = _stat(
+        total_polls=100, total_failures=3, failure_reasons={"connection": 3},
+        restarts_triggered=2, restarts_cleared=2, longest_fail_streak=1,
+        recent_latencies=[500],
+    )
+    specs = {"https://blippy": SiteSpec("https://blippy", timeout=25)}
+    (s,) = suggest_tunables(
+        {"https://blippy": st}, global_timeout=10, global_tries=1, specs=specs
+    )
+    assert s.config_line == "https://blippy|timeout=25|tries=2"


### PR DESCRIPTION
Closes #77.

## Problem

The docker-py transport read-timeout was sized once, at startup, from the **global** `TIMEOUT` only (`max(TIMEOUT*2, 60)`). A per-URL `|timeout=` override (#60) above that ceiling — including values `--suggest-tunables` itself emits — set up a silent trap: `wget --spider` emits nothing while it waits, so a probe legitimately running past the ceiling looks idle to the transport, gets killed, and a slow **success** is reported as a probe failure (exec exit −1). The override an operator adds to *stop* restarts guarantees them instead:

```mermaid
sequenceDiagram
    participant M as monitor (transport cap 60s)
    participant G as gluetun (wget --timeout=90)
    participant S as slow site
    M->>G: exec wget slow.example (override: 90s)
    G->>S: request
    Note over M,G: wget emits nothing while waiting…
    M--xG: transport read-timeout at 60s — exec killed
    S-->>G: 200 OK at 75s (a SUCCESS nobody saw)
    Note over M: probe recorded as FAILED → counts toward restart
```

Same fix surface: `suggest_tunables` / the flaky-site advisory hint evaluated every site against the **global** knobs even when it already carried an override — re-suggesting what's already set (or a lower value), and running the slow-not-dead discriminator against the wrong ceiling.

## Fix

- **Transport follows the config.** Sized at startup from the max effective `timeout×tries` across the loaded specs (`worst_case_probe_seconds`, same `×2, floor 60` shape — no-override deployments size identically), and re-raised on every sites reload via a new `DockerClient.ensure_timeout` (docker-py reads `api.timeout` per request, so a bump takes effect immediately). **Raise-only**: a config edit can never clip a probe already in flight.
- **Sanity caps at parse time.** `|timeout=` ≤ 300, `|tries=` ≤ 5; beyond that is warned about and the override skipped (forgiving+loud, the sites.conf contract) — an absurd value would stretch every loop and the transport with it.
- **Tunables judge effective knobs.** `suggest_tunables` takes the current specs; each site is evaluated against its own effective `timeout`/`tries`. Suggestions never re-emit ≤ the current value, are capped at the parse maximum (never emit a line `parse_entry` would reject), and the paste-ready line carries the site's *other* override so applying a suggestion can't silently drop it. Threaded through both consumers (`--suggest-tunables` and the flaky-site advisory hint).

## Tests

`tests/test_timeout_ceiling.py` (14 tests), red against pre-fix code (the new API doesn't exist; the behavioral assertions target post-fix semantics):

- worst-case sizing pairs `timeout×tries` per site; parse caps reject above-max overrides and accept at-cap.
- startup transport: 180s for a `|timeout=90` site, byte-identical 60s without overrides, safe fallback on unreadable config.
- the loop raises the ceiling on sites reload (a runtime-added override must widen the transport before its first wide probe) — a slow success within the override is never misreported as a failure.
- tunables: no re-suggestion ≤ an existing override; wider suggestion above the effective value preserves the other override; suggestions capped at the parse max; an existing `|tries=` suppresses the retry suggestion.

Full suite, ruff, mypy green.
