### PR TITLE
fix(endpoint): bound the log fetch behind get_endpoint_info (#78)

### DIFF
--- a/gluetun_monitor/docker_client.py
+++ b/gluetun_monitor/docker_client.py
@@ -76,8 +76,13 @@ class DockerClient(Protocol):
         """Run ``cmd`` inside a container; return its exit code + combined output."""
         ...
 
-    def logs(self, name_or_id: str) -> str:
-        """Fetch a container's logs (stdout+stderr) as text."""
+    def logs(self, name_or_id: str, *, tail: int) -> str:
+        """Fetch the last ``tail`` lines of a container's logs (stdout+stderr).
+
+        ``tail`` is required: an unbounded fetch of a long-lived container's
+        history is potentially hundreds of MB decoded in memory, landing exactly
+        mid-recovery (#78) — every call site must state its window.
+        """
         ...
 
     def restart(self, name_or_id: str) -> None:
@@ -155,9 +160,11 @@ class DockerPyClient:
         # A still-running/unknown exec reports None; treat as a generic failure.
         return ExecResult(exit_code=exit_code if exit_code is not None else 1, output=output)
 
-    def logs(self, name_or_id: str) -> str:
-        """``GET /containers/{id}/logs`` (stdout+stderr) decoded to text."""
-        raw = self._api.logs(name_or_id, stdout=True, stderr=True)
+    def logs(self, name_or_id: str, *, tail: int) -> str:
+        """``GET /containers/{id}/logs`` (stdout+stderr, last ``tail`` lines)
+        decoded to text.
+        """
+        raw = self._api.logs(name_or_id, stdout=True, stderr=True, tail=tail)
         return raw.decode("utf-8", errors="replace") if raw else ""
 
     def restart(self, name_or_id: str) -> None:

--- a/gluetun_monitor/endpoint.py
+++ b/gluetun_monitor/endpoint.py
@@ -86,10 +86,19 @@ def parse_endpoint(logs: str) -> EndpointInfo:
     return EndpointInfo(public_ip=public_ip, country=country, city=city, wg_server=wg_server)
 
 
+# Log window for the endpoint parse (#78). Only the NEWEST ip/country/server
+# lines matter (each parse takes the last match), and gluetun re-announces all
+# of them on every (re)connect — a few thousand lines comfortably spans several
+# reconnect cycles plus health-check noise, while an unbounded fetch of a
+# long-lived container's history (potentially hundreds of MB, decoded and
+# split in memory) would land exactly mid-recovery.
+_ENDPOINT_LOG_TAIL = 2000
+
+
 def get_endpoint_info(client: DockerClient, container: str) -> EndpointInfo:
-    """Fetch and parse the current endpoint from ``container``'s logs."""
+    """Fetch and parse the current endpoint from ``container``'s recent logs."""
     try:
-        logs = client.logs(container)
+        logs = client.logs(container, tail=_ENDPOINT_LOG_TAIL)
     except Exception:
         return EndpointInfo()
     return parse_endpoint(logs)

--- a/tests/fakes.py
+++ b/tests/fakes.py
@@ -80,6 +80,7 @@ class FakeDockerClient:
         self.started: list[str] = []
         self.renamed: list[tuple[str, str]] = []  # (name_or_id, new_name)
         self.ensured_timeouts: list[int] = []  # every ensure_timeout() call (#77)
+        self.logs_tails: list[int] = []  # tail= of every logs() call (#78)
         self._id_seq = 1000
 
     # ----- test setup helpers -----
@@ -126,9 +127,14 @@ class FakeDockerClient:
     def exec_run(self, name_or_id: str, cmd: list[str]) -> ExecResult:
         return self.on_exec(name_or_id, cmd)
 
-    def logs(self, name_or_id: str) -> str:
+    def logs(self, name_or_id: str, *, tail: int) -> str:
+        # Honor the window like the daemon does (last N lines) and record the
+        # requested tail so tests can assert the fetch is bounded (#78).
+        self.logs_tails.append(tail)
         raw = self._resolve(name_or_id)
-        return raw.get("_logs", "") if raw else ""
+        text = raw.get("_logs", "") if raw else ""
+        lines = text.splitlines(keepends=True)
+        return "".join(lines[-tail:]) if len(lines) > tail else text
 
     def restart(self, name_or_id: str) -> None:
         raw = self._resolve(name_or_id)

--- a/tests/test_branches.py
+++ b/tests/test_branches.py
@@ -33,7 +33,7 @@ def test_get_endpoint_info_handles_logs_exception() -> None:
     logging is best-effort and must never gate the loop."""
     fake = FakeDockerClient()
 
-    def boom(name: str) -> str:
+    def boom(name: str, *, tail: int) -> str:
         raise RuntimeError("logs unavailable")
 
     fake.logs = boom  # type: ignore[method-assign]

--- a/tests/test_docker_client.py
+++ b/tests/test_docker_client.py
@@ -46,7 +46,9 @@ class _StubAPI:
     def exec_inspect(self, exec_id: str) -> dict[str, Any]:
         return {"ExitCode": self.exec_exit_code}
 
-    def logs(self, name: str, stdout: bool = True, stderr: bool = True) -> bytes:
+    def logs(self, name: str, stdout: bool = True, stderr: bool = True,
+             tail: int | str = "all") -> bytes:
+        self.logs_tail = tail
         return b"log line"
 
     def restart(self, name: str) -> None:
@@ -133,10 +135,12 @@ def test_exec_run_empty_output() -> None:
     assert client.exec_run("c", ["x"]).output == ""
 
 
-def test_logs_decodes() -> None:
-    """logs() returns decoded text (the endpoint parser consumes a str)."""
-    client, _ = _client()
-    assert client.logs("c") == "log line"
+def test_logs_decodes_and_passes_the_tail_bound() -> None:
+    """logs() returns decoded text (the endpoint parser consumes a str) and
+    forwards the required tail= window to the API — never an unbounded fetch (#78)."""
+    client, api = _client()
+    assert client.logs("c", tail=500) == "log line"
+    assert api.logs_tail == 500
 
 
 def test_restart_remove_create_start_delegate() -> None:

--- a/tests/test_endpoint.py
+++ b/tests/test_endpoint.py
@@ -94,3 +94,38 @@ def test_get_endpoint_info_from_client() -> None:
     fake.add(raw)
     info = get_endpoint_info(fake, "gluetun")
     assert info.public_ip == "31.40.215.70"
+
+
+def test_get_endpoint_info_fetch_is_bounded() -> None:
+    """The endpoint fetch must pass a bounded tail — an unbounded fetch of a
+    long-lived gluetun's history (potentially hundreds of MB, decoded in memory)
+    lands at startup and twice per restart, exactly mid-recovery (#78)."""
+    fake = FakeDockerClient()
+    raw = make_inspect("gluetun", id="gid")
+    raw["_logs"] = _IP_GETTER
+    fake.add(raw)
+    get_endpoint_info(fake, "gluetun")
+    assert fake.logs_tails, "logs() was never called"
+    assert all(isinstance(t, int) and 0 < t <= 10_000 for t in fake.logs_tails)
+
+
+def test_parse_finds_newest_lines_when_the_window_truncates_history() -> None:
+    """Only the NEWEST ip/country/server lines matter: with a long history where
+    the tail window drops the oldest matches, the parse still reports the most
+    recent (re)connect — truncation loses nothing the parse wanted (#78)."""
+    stale = (
+        "2026-05-09T02:00:00+02:00 INFO [wireguard] Connecting to 10.0.0.1:51820\n"
+        "2026-05-09T02:00:05+02:00 INFO [ip getter] Public IP address is 10.9.9.9 "
+        "(Nowhere, Oldtown - source: ipinfo)\n"
+    )
+    noise = "".join(f"2026-05-10T12:00:{i % 60:02d}+02:00 INFO healthy!\n" for i in range(5000))
+    fake = FakeDockerClient()
+    raw = make_inspect("gluetun", id="gid")
+    raw["_logs"] = stale + noise + f"{_WG}\n{_IP_GETTER}\n"
+    fake.add(raw)
+    info = get_endpoint_info(fake, "gluetun")
+    # The stale entries fell outside the window (the fake honors tail); the
+    # newest announcement is what's reported.
+    assert info.public_ip == "31.40.215.70"
+    assert info.wg_server == "185.156.46.20"
+    assert info.country == "Switzerland"

--- a/tests/test_real_daemon.py
+++ b/tests/test_real_daemon.py
@@ -122,7 +122,7 @@ def test_real_docker_paths_and_volume_survives_recreate(world: dict[str, Any]) -
     assert SENTINEL in read.output
 
     # logs: smoke — decodes to text without error
-    assert isinstance(client.logs(world["gluetun"]), str)
+    assert isinstance(client.logs(world["gluetun"], tail=2000), str)
 
     # restart preserves identity (same container id) and never touches the volume
     client.restart(dep)


### PR DESCRIPTION
Closes #78.

## Problem

`get_endpoint_info` fetched the container's **entire log history** (`tail='all'`), decoded it, and made two `splitlines()` passes — at startup and twice per gluetun restart (`recovery.py`). On a host without json-file rotation that's an unbounded fetch (potentially hundreds of MB), with the memory spike and multi-second stall landing exactly mid-recovery. Observed live during the #96 dogfood: the socket-proxy logged `GET /containers/<gluetun>/logs?...tail=all` returning ~590 KB mid-restart — *with* rotation caps; without them it grows without bound. Only the newest ip/country/server lines are ever wanted (each parse takes the last match).

## Fix

- `DockerClient.logs` now **requires** `tail=` — every call site must state its window, so an unbounded fetch can't silently come back with the next caller.
- The endpoint fetch is bounded at 2000 lines: gluetun re-announces IP/country/server on every (re)connect, so the window spans several reconnect cycles plus health-check noise with a wide margin. Parse unchanged.

## Tests

Red against pre-fix code, green after:

- `DockerPyClient.logs` forwards the `tail` bound to the API.
- `get_endpoint_info`'s fetch is asserted bounded (the fake records every `tail=` and now honors the window like the daemon).
- A long history whose oldest ip/server lines fall outside the window still parses to the **newest** announcement — truncation loses nothing the parse wanted.

Full suite, ruff, mypy green.
