### PR TITLE
fix(monitor): persist dependent memory; adopt orphans of former gluetun ids (#97)

### DIFF
--- a/README.md
+++ b/README.md
@@ -460,6 +460,17 @@ This just works out of the box - no configuration needed. Discovery runs at star
 
 **Note:** Containers added after startup will be discovered and restarted when the next failure triggers a recovery. There's no continuous polling for new containers during normal operation.
 
+#### Dependent memory — surviving restarts and recreates together
+
+Discovery alone has a blind spot: a dependent stranded by a gluetun *recreate* points at the **old** container id, so current-id discovery can no longer see it — and if the monitor itself restarted moments earlier, its in-memory record of that dependent is gone too. The monitor closes this with a small persistent sidecar (`MONITOR_STATE_FILE`, default `/logs/monitor-state.json`) remembering two things Docker forgets:
+
+- every container id gluetun has run under (Docker ids are never reused, so a container whose `network_mode` points at a dead id from this list *provably* belonged to this gluetun), and
+- the names of dependents it has managed.
+
+Each loop the monitor scans **all** containers (including exited ones — a stranded dependent's own restart policy usually drives it to Exited) and **adopts** any container stranded on a dead former-gluetun id, healing it through the normal remediation path. A container stranded on a dead id the monitor has *never* seen as gluetun is only warned about, never touched — it might belong to some other network owner.
+
+The file is best-effort and human-readable; deleting it (or a corrupt file) simply resets the memory. One bootstrap gap: on the very first run there is no history yet, so dependents that were *already* stranded before the monitor ever saw gluetun can't be confirmed — list them explicitly in `DEPENDENT_CONTAINERS` for that one recovery. Details in [ADR-0014](docs/adr/0014-durable-dependent-memory.md).
+
 #### Advanced: Manual Override
 
 In rare cases where you need explicit control (e.g., restart only specific containers, or include containers that don't use network_mode), you can specify a manual list:

--- a/README.md
+++ b/README.md
@@ -183,6 +183,7 @@ docker compose up -d
 | `DRY_RUN` | `0` | Observe-only: run all detection/probing but **take no action** — log `[DRY-RUN] would …` instead of restarting/recreating. For soak-testing alongside an active monitor |
 | `STATS_FILE` | `/logs/site-stats.json` | Where persistent per-site stats are written (best-effort, atomic; survives restarts). See [Site stats & flaky-site advisory](#site-stats--flaky-site-advisory) |
 | `STATS_RETENTION_DAYS` | `90` | Drop a site's stats if it hasn't been tested (e.g. removed from `sites.conf`) for this many days; `0` keeps them forever |
+| `MONITOR_STATE_FILE` | `/logs/monitor-state.json` | Durable dependent memory: gluetun's container-id history + known dependent names, so dependents stranded by a gluetun recreate stay visible (and healable) across monitor restarts. Best-effort, atomic |
 | `ADVISORY_WINDOW` | `86400` | Window (seconds) for the flaky-site advisory |
 | `ADVISORY_MIN_RESTARTS` | `5` | Minimum gluetun restarts in the window before an advisory can fire |
 | `ADVISORY_DOMINANCE` | `0.5` | Fraction of those restarts one site must cause to be flagged flaky |

--- a/docs/adr/0014-durable-dependent-memory.md
+++ b/docs/adr/0014-durable-dependent-memory.md
@@ -1,0 +1,92 @@
+# ADR-0014: Durable dependent memory and id-history adoption
+
+- **Status:** Accepted
+- **Date:** 2026-07-02
+
+## Context
+
+The monitor's knowledge of its dependents lived in two places, and both fail at
+once. Auto-discovery matches `NetworkMode == container:<CURRENT gluetun id>`
+among **running** containers; the remembered set (ADR-0004) covers dependents
+stranded on an old id — but it was in-memory only, populated by the first
+completed dependent phase.
+
+A monitor restart followed closely by a gluetun recreate — one
+`docker compose up -d` can produce both — therefore blinded remediation
+permanently: the fresh monitor's memory was empty, the stranded dependents
+pointed at the dead old id (and were usually driven to Exited by their own
+restart policies, since a start onto a dead netns id fails hard), and discovery
+never matched them again. Observed live during the issue #76 dogfood, twice in
+one evening, in both forms (running-stranded and exited-stranded); the stack
+stayed down ~80 minutes until healed by hand (#97).
+
+The dangling-orphan scan already *found* these containers but could only warn:
+a dead parent id could not be confirmed as gluetun, and adopting someone else's
+container would violate Tenet 1.
+
+Designs considered and rejected:
+
+- **Threshold heuristics** ("if X% of last-seen dependents are missing…"):
+  needs tuning, misfires at small N, and fails in both directions (intentional
+  decommission → false alarm; a single stranded dependent → under threshold).
+- **Freshness gating / host boot-id in the state file**: Docker container ids
+  are 256-bit random and never reused, so a stale entry cannot become a false
+  positive — there is no id-reuse window for a boot epoch to guard. A reboot
+  merely converts running-stranded into exited-stranded, which is already the
+  adoption case. Stale state can only mean *missing* knowledge, which degrades
+  to the pre-#97 behavior — never wrong action.
+- **Persisting an id→containers mapping**: the association already has an
+  authoritative owner — each container's own `NetworkMode`, read live each
+  loop. A copy would need per-loop maintenance and could drift; and requiring
+  "name in our records" as an adoption condition would re-introduce the memory
+  race being fixed. The id alone is the strongest possible evidence.
+- **Fixed-size id history ("last N")**: a recreate storm could evict an id
+  that a long-exited dependent still references, and adoption would miss it.
+
+## Decision
+
+Persist **only what Docker forgets**, in a `monitor-state.json` sidecar
+(`MONITOR_STATE_FILE`, default `/logs/monitor-state.json`; atomic
+tmp+rename+fsync writes, write-on-change; a corrupt or missing file degrades to
+empty memory — state must never take monitoring down):
+
+- **`gluetun_ids`** — every container id gluetun has been seen under, newest
+  first. Pruned **by reference**: an id is dropped only when no existing
+  container's `NetworkMode` points at it, so an entry lives exactly as long as
+  it can matter to an adoption decision.
+- **`known_dependents`** — the ADR-0004 remembered set, seeded back into
+  memory at startup and mirrored after each prune.
+
+The orphan scan becomes **adopt-or-warn**, runs at startup and every loop, and
+inspects **all** containers including exited ones:
+
+- Dead parent id **in** the history → the container provably shared our
+  gluetun's netns (ids are never reused) → adopt into the managed set and
+  remediate through the normal path (`AUTO_RECREATE` gate applies).
+- Dead parent id **not** in the history → the pre-existing behavior: a
+  once-per-name warning suggesting `DEPENDENT_CONTAINERS` (running containers
+  only; an exited container on an unknown dead parent is ordinary leftover
+  junk, not a page).
+
+`schema_version` and `updated_at` are observability only — never decision
+inputs.
+
+## Consequences
+
+- The restart+recreate window is closed: a stranded dependent is adopted and
+  healed on the monitor's first loop instead of staying invisible. Replayed
+  against the observed incident, downtime drops from ~80 minutes (manual) to
+  one loop.
+- A second persistent sidecar joins site-stats and notify-state. Same contract
+  (best-effort, atomic, corrupt-tolerant), so the operational surface is
+  familiar; the file is human-readable for debugging ("why didn't it adopt?").
+- The monitor now acts on containers it never saw in-process, on the strength
+  of the persisted id history. The safety argument rests entirely on Docker
+  ids being unique forever; the negative path (unknown dead parent → warn
+  only) is pinned by tests.
+- Bootstrap gap, accepted: a first-ever run (empty history) against
+  already-stranded dependents cannot confirm parentage. The documented
+  workaround remains an explicit `DEPENDENT_CONTAINERS` list.
+- The per-loop scan now lists and inspects all containers (including exited)
+  rather than running ones only — a handful of extra inspects per loop through
+  the socket-proxy, accepted for the coverage.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -42,3 +42,4 @@ Format: [`_template.md`](_template.md). Status ∈ Proposed | Accepted | Superse
 | [0011](0011-notification-tiers-and-rollup.md) | Notification tiers (`NOTIFY_LEVEL` actionability dial) + per-loop rollup digest | Accepted |
 | [0012](0012-alert-lifecycle.md) | Edge-triggered alert lifecycle (announce once, repeat in loops, resolve vs silent-remove) + persisted state | Accepted |
 | [0013](0013-release-and-versioning-automation.md) | Release & versioning automation — gate by authorship (ours = human, upstream = auto); release-please + `:edge` + base-digest drift check | Accepted |
+| [0014](0014-durable-dependent-memory.md) | Durable dependent memory: persisted gluetun id history + known dependents; adopt-or-warn orphan scan (dead parent in history = provably ours) | Accepted |

--- a/gluetun_monitor/config.py
+++ b/gluetun_monitor/config.py
@@ -147,6 +147,9 @@ class Config:
     dry_run: bool = False
     # Persistent per-site stats sidecar (ADR-0008). Observability only; best-effort.
     stats_file: str = "/logs/site-stats.json"
+    # Durable dependent memory (#97): gluetun id history + known dependent names,
+    # so stranded dependents stay visible across monitor restarts. Best-effort.
+    monitor_state_file: str = "/logs/monitor-state.json"
     # Drop a site's stats if it hasn't been polled (e.g. removed from sites.conf)
     # for this many days; <=0 keeps them forever.
     stats_retention_days: int = 90
@@ -241,6 +244,7 @@ class Config:
             max_jitter_ms=_env_int("MAX_JITTER_MS", 0, errors, minimum=0),
             dry_run=_env_bool("DRY_RUN", False, errors),
             stats_file=os.environ.get("STATS_FILE", "/logs/site-stats.json"),
+            monitor_state_file=os.environ.get("MONITOR_STATE_FILE", "/logs/monitor-state.json"),
             # No lower bound: <= 0 intentionally means "keep stats forever".
             stats_retention_days=_env_int("STATS_RETENTION_DAYS", 90, errors),
             advisory_window=_env_int("ADVISORY_WINDOW", 86400, errors, minimum=1),

--- a/gluetun_monitor/docker_client.py
+++ b/gluetun_monitor/docker_client.py
@@ -68,6 +68,17 @@ class DockerClient(Protocol):
         """IDs of currently running containers."""
         ...
 
+    def list_all_ids(self) -> list[str]:
+        """IDs of ALL containers, including stopped/exited ones.
+
+        The stranded-orphan adoption scan (#97) must see exited containers: a
+        dependent stranded by a gluetun recreate is usually driven to Exited by
+        its own restart policy (a start onto a dead netns id fails hard), and a
+        running-only listing would hide exactly the containers most in need of
+        healing.
+        """
+        ...
+
     def inspect(self, name_or_id: str) -> ContainerInfo | None:
         """Inspect a container, or None if it does not exist."""
         ...
@@ -140,6 +151,10 @@ class DockerPyClient:
     def list_running_ids(self) -> list[str]:
         """``GET /containers/json`` (running only) → their ids."""
         return [c["Id"] for c in self._api.containers(all=False)]
+
+    def list_all_ids(self) -> list[str]:
+        """``GET /containers/json?all=1`` (every container) → their ids."""
+        return [c["Id"] for c in self._api.containers(all=True)]
 
     def inspect(self, name_or_id: str) -> ContainerInfo | None:
         """``GET /containers/{id}/json`` → ContainerInfo, or None if not found."""

--- a/gluetun_monitor/monitor.py
+++ b/gluetun_monitor/monitor.py
@@ -30,6 +30,7 @@ from .dependents import (
 )
 from .dns_check import DnsResult, DnsStatus, validate_dns
 from .endpoint import get_endpoint_info
+from .monitor_state import MonitorState
 from .notify import Notifier, NotifyEvent, NullNotifier
 from .recovery import remediate_dependent, restart_gluetun
 from .recreate import sweep_recreate_leftovers
@@ -93,6 +94,7 @@ class Monitor:
         sleep: Sleep = time.sleep,
         stats: SiteStatsStore | None = None,
         notifier: Notifier | None = None,
+        state: MonitorState | None = None,
     ) -> None:
         self.client = client
         self.config = config
@@ -129,17 +131,22 @@ class Monitor:
         # per-URL timeout/tries override (#60). Refreshed each loop in _run_once_body
         # alongside the (deduplicated) URL list; empty until the first load.
         self._specs: dict[str, SiteSpec] = {}
+        # Durable dependent memory (#97): gluetun id history + known dependent
+        # names, persisted so neither a monitor restart nor a gluetun recreate
+        # inside the first-loop window can blind remediation. Injectable for tests.
+        self.mstate = state if state is not None else MonitorState(config.monitor_state_file)
         # Dependents seen at least once. A dependent stranded by a gluetun
         # *recreate* still points at the dead old id, so current-id discovery no
         # longer matches it — but we remember it from before the recreate and
         # keep checking it (ADR-0004: track across cycles). Pruned to existing.
-        self._known_dependents: set[str] = set()
+        # Seeded from the persisted memory; _resolve_dependents prunes to existing.
+        self._known_dependents: set[str] = set(self.mstate.known_dependents)
         # The set managed last loop — to retire an alert ("no longer monitored") when
         # a dependent leaves (excluded or gone), rather than a false "resolved" (ADR-0012).
         self._managed_dependents: set[str] = set()
         # Dedup so a missing explicitly-listed dependent warns once, not per loop.
         self._warned_missing: set[str] = set()
-        # Dedup for the dangling-orphan warning (see _warn_dangling_orphans).
+        # Dedup for the dangling-orphan warning (see _scan_stranded_orphans).
         self._warned_orphans: set[str] = set()
         # Dedup for "can't validate DNS (no usable tool)" — re-armed if it later validates.
         self._warned_dns_unvalidated: set[str] = set()
@@ -490,6 +497,9 @@ class Monitor:
             if d not in existence:
                 existence[d] = self.client.inspect(d) is not None
         self._known_dependents = {d for d in self._known_dependents if existence.get(d, False)}
+        # Mirror the pruned remembered set into the durable memory (#97) so a
+        # monitor restart resumes with exactly what this instance knew.
+        self.mstate.set_known_dependents(self._known_dependents)
         excluded = set(parse_csv_names(self.config.exclude_containers))
         return sorted(self._known_dependents - excluded)
 
@@ -625,6 +635,7 @@ class Monitor:
             raise
         finally:
             self._flush_notifications()
+            self.mstate.save()  # dirty-checked; no-op unless the memory changed
 
     def _run_once_body(self) -> None:
         """Execute one monitoring cycle (no inter-loop sleep)."""
@@ -650,6 +661,11 @@ class Monitor:
             return
         if gluetun.health != "healthy":
             self.log.warn(f"Gluetun health status: {gluetun.health}")
+        # Remember every id gluetun runs under, and adopt any container stranded
+        # on a dead FORMER gluetun id (#97) — before dependent resolution, so an
+        # adopted orphan is probed and remediated in this same loop.
+        self.mstate.record_gluetun_id(gluetun.id)
+        self._scan_stranded_orphans(gluetun.id)
 
         # Observability before the site curls: log the gateway's own L3 interfaces
         # (symmetry with the dependent checks; presence of tun0 = tunnel up at L3).
@@ -864,22 +880,36 @@ class Monitor:
         excluded = parse_csv_names(self.config.exclude_containers)
         if excluded:
             self.log.info(f"Excluded from management (EXCLUDE_CONTAINERS): {','.join(excluded)}")
-        self._warn_dangling_orphans()
+        # Seed the id history with the current gluetun and adopt anything already
+        # stranded (#97) BEFORE the first loop, so a recreate that happened while
+        # the monitor was down is healed immediately rather than never seen.
+        gluetun_info = self.client.inspect(self.config.gluetun_container)
+        if gluetun_info is not None:
+            self.mstate.record_gluetun_id(gluetun_info.id)
+        self._scan_stranded_orphans(gluetun_info.id if gluetun_info is not None else None)
+        self.mstate.save()
         startup = get_endpoint_info(self.client, self.config.gluetun_container)
         self.log.endpoint(startup.format("STARTUP", "Monitor starting"))
 
-    def _warn_dangling_orphans(self) -> None:
-        """Surface a running container stranded on a *dead* netns parent that we
-        are not managing — most likely a gluetun dependent that was recreate-
-        stranded before the monitor started (its NetworkMode still points at
-        gluetun's old, now-gone id, so current-id discovery can't see it).
+    def _scan_stranded_orphans(self, current_gluetun_id: str | None) -> None:
+        """Adopt containers stranded on a dead FORMER gluetun id; warn about the
+        rest (#97). Also reference-prunes the persisted gluetun id history.
 
-        We *warn and suggest* DEPENDENT_CONTAINERS rather than recreate it: an
-        orphan whose parent is gone can't be confidently attributed to *this*
-        gluetun (it might belong to some other netns owner), and acting on that
-        guess could re-home or churn the wrong container (Tenet 1 — first, do no
-        harm). Names already listed or excluded are skipped (we either manage them
-        or were told not to touch them).
+        A container — running *or* exited — whose ``NetworkMode`` points at a
+        dead id is stranded. If that id is in the persisted gluetun history it
+        provably shared OUR gluetun's netns (Docker ids are never reused), so it
+        is adopted into the remembered set and healed through the normal
+        remediation path. A dead parent NOT in the history cannot be attributed
+        to this gluetun (it might belong to some other netns owner), so acting
+        on it could re-home the wrong container (Tenet 1) — those get the
+        pre-#97 behavior: a once-per-name warning suggesting
+        ``DEPENDENT_CONTAINERS``, and only when running (an exited container on
+        an unknown dead parent is ordinary leftover junk, not a page).
+
+        The scan must include exited containers: a stranded dependent's own
+        restart policy usually drives it to Exited (a start onto a dead netns id
+        fails hard) — the running-only view would hide exactly the containers
+        most in need of healing.
         """
         gluetun = self.config.gluetun_container
         listed = (
@@ -887,10 +917,17 @@ class Monitor:
             if self.config.dependent_containers == "auto"
             else set(parse_csv_names(self.config.dependent_containers))
         )
-        skip = listed | set(parse_csv_names(self.config.exclude_containers)) | {gluetun}
-        for cid in self.client.list_running_ids():
+        excluded = set(parse_csv_names(self.config.exclude_containers))
+        skip = listed | excluded | {gluetun} | self._known_dependents
+        # Every netns-parent id any existing container references: the keep-set
+        # for reference-based pruning of the id history (an id stays exactly as
+        # long as it can still matter to an adoption decision).
+        referenced: set[str] = set()
+        if current_gluetun_id:
+            referenced.add(current_gluetun_id)
+        for cid in self.client.list_all_ids():
             info = self.client.inspect(cid)
-            if info is None or info.name in skip:
+            if info is None:
                 continue
             nm = info.network_mode
             if not nm.startswith("container:"):
@@ -898,9 +935,20 @@ class Monitor:
             target = nm.split(":", 1)[1]
             if not is_container_id(target):
                 continue  # name-form target resolves normally; not a dangling id
+            referenced.add(target)
+            if info.name in skip:
+                continue
             if self.client.inspect(target) is not None:
                 continue  # the netns parent still exists — not stranded
-            if info.name not in self._warned_orphans:
+            if self.mstate.is_former_gluetun(target):
+                self.log.warn(
+                    f"Adopting stranded dependent '{info.name}': its network parent "
+                    f"({target[:12]}) was a previous {gluetun} container — it will be "
+                    f"remediated this loop"
+                )
+                self._known_dependents.add(info.name)
+                self._warned_orphans.discard(info.name)
+            elif info.running and info.name not in self._warned_orphans:
                 self.log.warn(
                     f"Container '{info.name}' is running but its network parent "
                     f"({target[:12]}) no longer exists; if it depends on gluetun, add it "
@@ -908,6 +956,7 @@ class Monitor:
                     f"its parent can't be confirmed as gluetun)"
                 )
                 self._warned_orphans.add(info.name)
+        self.mstate.prune_gluetun_ids(referenced)
 
     def run(self) -> None:
         """Run forever: loop run_once + sleep CHECK_INTERVAL."""

--- a/gluetun_monitor/monitor_state.py
+++ b/gluetun_monitor/monitor_state.py
@@ -1,0 +1,149 @@
+"""Durable dependent memory: gluetun id history + known dependent names (#97).
+
+The monitor's knowledge of its dependents lives in two places, and both fail at
+once when a monitor restart is followed closely by a gluetun recreate:
+auto-discovery matches ``container:<CURRENT gluetun id>`` among *running*
+containers (a stranded dependent points at the old id, and may be exited), and
+the in-memory remembered set (ADR-0004) starts empty. Result: stranded
+dependents become permanently invisible to remediation — observed live, twice
+in one evening, in both forms (running-stranded and exited-stranded).
+
+This module persists ONLY what Docker forgets:
+
+* ``gluetun_ids`` — every container id gluetun has been seen under. Docker ids
+  are 256-bit random and never reused, so an entry can never rot into a false
+  positive: any container whose ``NetworkMode`` references a dead id from this
+  list provably shared OUR gluetun's netns → it is safe to adopt and heal.
+  Pruned **by reference**, not by age or count: an id is dropped only when no
+  existing container references it (a fixed "last N" could evict an id a
+  long-exited dependent still points at). No freshness gating, no host boot-id
+  — a reboot merely converts running-stranded into exited-stranded, which is
+  already the adoption case.
+* ``known_dependents`` — the remembered set, so a monitor restart no longer
+  wipes it. Pruned to still-existing containers by the caller (same rule the
+  in-memory set already uses).
+
+Everything else (which container references which id, run state, mounts) is
+read fresh from the daemon each loop — Docker's records are the authoritative
+join, and duplicating them here would only create a second source of truth.
+
+``schema_version`` and ``updated_at`` are observability only, never decision
+inputs. Persistence follows the site-stats contract: atomic tmp+rename+fsync
+writes, and a corrupt/missing file degrades to empty memory (today's behavior)
+— state must never take monitoring down (#73 principle).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import time
+from collections.abc import Callable
+from pathlib import Path
+
+_SCHEMA_VERSION = 1
+
+
+class MonitorState:
+    """Load/hold/persist the dependent memory. Write-on-change only."""
+
+    def __init__(self, path: str | None, *, clock: Callable[[], float] = time.time) -> None:
+        self._path = Path(path) if path else None
+        self._clock = clock
+        self.gluetun_ids: list[str] = []  # newest first
+        self.known_dependents: set[str] = set()
+        self._dirty = False
+        self._load()
+
+    def _load(self) -> None:
+        if self._path is None:
+            return
+        try:
+            data = json.loads(self._path.read_text(encoding="utf-8"))
+            ids = data.get("gluetun_ids", [])
+            deps = data.get("known_dependents", [])
+            self.gluetun_ids = [str(i) for i in ids if isinstance(i, str) and i]
+            self.known_dependents = {str(d) for d in deps if isinstance(d, str) and d}
+        except FileNotFoundError:
+            pass  # first run — empty memory is the documented bootstrap gap
+        except (OSError, ValueError, TypeError, AttributeError):
+            # Corrupt/garbage state is non-fatal: degrade to empty memory (the
+            # pre-#97 behavior) rather than take the watchdog down over it.
+            self.gluetun_ids = []
+            self.known_dependents = set()
+
+    # ----- mutation (all write-on-change) -----
+
+    def record_gluetun_id(self, container_id: str) -> None:
+        """Remember ``container_id`` as gluetun's current id (newest first)."""
+        if not container_id:
+            return
+        if self.gluetun_ids[:1] == [container_id]:
+            return
+        if container_id in self.gluetun_ids:
+            self.gluetun_ids.remove(container_id)
+        self.gluetun_ids.insert(0, container_id)
+        self._dirty = True
+
+    def set_known_dependents(self, names: set[str]) -> None:
+        """Replace the persisted remembered set (caller has already pruned it)."""
+        if names != self.known_dependents:
+            self.known_dependents = set(names)
+            self._dirty = True
+
+    def prune_gluetun_ids(self, referenced: set[str]) -> None:
+        """Drop ids no existing container references (reference-based pruning).
+
+        ``referenced`` must include the CURRENT gluetun id and every id that any
+        existing container's ``NetworkMode`` points at — an id stays exactly as
+        long as it can still matter to an adoption decision.
+        """
+        kept = [i for i in self.gluetun_ids if i in referenced]
+        if kept != self.gluetun_ids:
+            self.gluetun_ids = kept
+            self._dirty = True
+
+    def is_former_gluetun(self, container_id: str) -> bool:
+        """True if ``container_id`` is a (current or former) gluetun id."""
+        return container_id in self.gluetun_ids
+
+    # ----- persistence -----
+
+    def save(self) -> bool:
+        """Persist if dirty. Atomic + fsync'd (site-stats pattern); best-effort —
+        an I/O failure leaves the previous complete file and never blocks the loop.
+        """
+        if self._path is None or not self._dirty:
+            return False
+        payload = {
+            # Observability only — never decision inputs.
+            "schema_version": _SCHEMA_VERSION,
+            "updated_at": self._clock(),
+            "gluetun_ids": self.gluetun_ids,
+            "known_dependents": sorted(self.known_dependents),
+        }
+        try:
+            self._path.parent.mkdir(parents=True, exist_ok=True)
+            tmp = self._path.with_suffix(self._path.suffix + ".tmp")
+            with tmp.open("w", encoding="utf-8") as fh:
+                json.dump(payload, fh, indent=2)
+                fh.flush()
+                os.fsync(fh.fileno())
+            tmp.replace(self._path)
+            self._fsync_dir(self._path.parent)
+            self._dirty = False
+            return True
+        except OSError:
+            return False
+
+    @staticmethod
+    def _fsync_dir(directory: Path) -> None:
+        """Best-effort fsync of a directory so a rename survives power loss."""
+        try:
+            fd = os.open(directory, os.O_RDONLY)
+            try:
+                os.fsync(fd)
+            finally:
+                os.close(fd)
+        except OSError:
+            pass

--- a/tests/fakes.py
+++ b/tests/fakes.py
@@ -120,6 +120,9 @@ class FakeDockerClient:
             if raw.get("State", {}).get("Running", False)
         ]
 
+    def list_all_ids(self) -> list[str]:
+        return list(self._store.keys())
+
     def inspect(self, name_or_id: str) -> ContainerInfo | None:
         raw = self._resolve(name_or_id)
         return ContainerInfo.from_inspect(raw) if raw is not None else None

--- a/tests/test_dependent_memory.py
+++ b/tests/test_dependent_memory.py
@@ -1,0 +1,215 @@
+"""Durable dependent memory: id-history adoption + persistence (#97).
+
+Why: the exact failure observed live (twice, in both forms) — a monitor restart
+followed closely by a gluetun recreate left every dependent stranded AND
+invisible: auto-discovery matches only running containers on the CURRENT
+gluetun id, and the remembered set was in-memory only. These tests pin the fix:
+the persisted gluetun id history makes a dead parent *confirmable* (Docker ids
+are never reused), so stranded containers — running or exited — are adopted and
+healed; dead parents NOT in the history keep the warn-only behavior (pinned in
+test_orphan_warn.py); the id history prunes by reference, never by count.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import random
+from pathlib import Path
+
+from gluetun_monitor.config import Config
+from gluetun_monitor.docker_client import ExecResult
+from gluetun_monitor.logging_setup import Logger
+from gluetun_monitor.monitor import Monitor
+from gluetun_monitor.monitor_state import MonitorState
+
+from .fakes import FakeDockerClient
+
+OLD_ID = "a" * 64
+NEW_ID = "b" * 64
+OTHER_ID = "e" * 64  # a dead parent that was never gluetun
+
+
+def _monitor(
+    fake: FakeDockerClient, state_file: Path, sites_file: Path, **cfg: object
+) -> tuple[Monitor, io.StringIO]:
+    sites_file.write_text("https://a.example\n")
+    cfg.setdefault("config_file", str(sites_file))
+    cfg.setdefault("gluetun_container", "gluetun")
+    cfg.setdefault("monitor_state_file", str(state_file))
+    stream = io.StringIO()
+    logger = Logger(log_file=None, level="DEBUG", stream=stream)
+    mon = Monitor(
+        fake, Config(**cfg), logger, rng=random.Random(0), sleep=lambda _s: None
+    )
+
+    def running_aware(name: str, cmd: list[str]) -> ExecResult:
+        # Real docker refuses exec into a non-running container — the probe
+        # relies on that to classify a stopped dependent as not-running.
+        info = fake.inspect(name)
+        if info is None or not info.running:
+            return ExecResult(126, "container is not running")
+        return ExecResult(0, "eth0\nlo\ntun0\n")
+
+    fake.on_exec = running_aware
+    return mon, stream
+
+
+# ----- MonitorState: persistence contract -----
+
+
+def test_state_round_trips(tmp_path: Path) -> None:
+    st = MonitorState(str(tmp_path / "state.json"))
+    st.record_gluetun_id(OLD_ID)
+    st.record_gluetun_id(NEW_ID)  # newest first
+    st.set_known_dependents({"dep1", "dep2"})
+    assert st.save()
+    reloaded = MonitorState(str(tmp_path / "state.json"))
+    assert reloaded.gluetun_ids == [NEW_ID, OLD_ID]
+    assert reloaded.known_dependents == {"dep1", "dep2"}
+
+
+def test_state_file_carries_observability_fields_only_as_extras(tmp_path: Path) -> None:
+    """schema_version/updated_at are present for humans and future migration —
+    and are never read back as decision inputs (reload ignores them)."""
+    st = MonitorState(str(tmp_path / "state.json"))
+    st.record_gluetun_id(OLD_ID)
+    st.save()
+    data = json.loads((tmp_path / "state.json").read_text())
+    assert data["schema_version"] == 1
+    assert "updated_at" in data
+
+
+def test_corrupt_state_degrades_to_empty_memory(tmp_path: Path) -> None:
+    """State must never take monitoring down (#73 principle): any shape of
+    garbage — not just truncation — loads as empty memory."""
+    p = tmp_path / "state.json"
+    for garbage in ('{"gluetun_ids": "not-a-list"', '["top", "level", "list"]', "ÿØÿà"):
+        p.write_text(garbage)
+        st = MonitorState(str(p))
+        assert st.gluetun_ids == [] and st.known_dependents == set()
+
+
+def test_save_is_write_on_change_only(tmp_path: Path) -> None:
+    st = MonitorState(str(tmp_path / "state.json"))
+    st.record_gluetun_id(OLD_ID)
+    assert st.save() is True
+    assert st.save() is False  # clean — nothing to write
+    st.record_gluetun_id(OLD_ID)  # already newest — not a change
+    assert st.save() is False
+
+
+# ----- THE regression: monitor restart + gluetun recreate window -----
+
+
+def test_restarted_monitor_heals_exited_stranded_dependent(tmp_path: Path) -> None:
+    """The production failure, exited form: state remembers the OLD gluetun id;
+    a fresh monitor (empty in-RAM memory) finds the dependent Exited on that
+    dead id → adopted and RECREATED in the first loop."""
+    prior = MonitorState(str(tmp_path / "state.json"))
+    prior.record_gluetun_id(OLD_ID)
+    prior.save()
+
+    fake = FakeDockerClient()
+    fake.add_container("gluetun", id=NEW_ID)
+    fake.add_container("dep", network_mode=f"container:{OLD_ID}", running=False)
+    mon, stream = _monitor(fake, tmp_path / "state.json", tmp_path / "sites.conf")
+    mon.run_once()
+
+    assert "Adopting stranded dependent 'dep'" in stream.getvalue()
+    assert fake.created and fake.created[0][1] == "dep"  # recreated under its name
+    assert f"container:{NEW_ID}" in json.dumps(fake.created[0][0])  # re-homed
+
+
+def test_restarted_monitor_heals_running_stranded_dependent(tmp_path: Path) -> None:
+    """The running-but-loopback form: same adoption, remediated via the probe
+    path (STRANDED interface check → recreate)."""
+    prior = MonitorState(str(tmp_path / "state.json"))
+    prior.record_gluetun_id(OLD_ID)
+    prior.save()
+
+    fake = FakeDockerClient()
+    fake.add_container("gluetun", id=NEW_ID)
+    fake.add_container("dep", network_mode=f"container:{OLD_ID}", running=True)
+    mon, stream = _monitor(fake, tmp_path / "state.json", tmp_path / "sites.conf")
+
+    def loopback_when_stranded(name: str, cmd: list[str]) -> ExecResult:
+        info = fake.inspect(name)
+        if info is None or not info.running:
+            return ExecResult(126, "container is not running")
+        if info.network_mode == f"container:{OLD_ID}" and cmd[:2] == ["ls", "/sys/class/net"]:
+            return ExecResult(0, "lo\n")  # stranded: loopback only
+        return ExecResult(0, "eth0\nlo\ntun0\n")
+
+    fake.on_exec = loopback_when_stranded
+    mon.run_once()
+
+    assert "Adopting stranded dependent 'dep'" in stream.getvalue()
+    assert fake.created and fake.created[0][1] == "dep"
+
+
+def test_dead_parent_not_in_history_is_never_adopted(tmp_path: Path) -> None:
+    """Negative pin: a container stranded on a dead id that was NEVER gluetun
+    keeps the warn-only behavior — adoption must not re-home someone else's
+    container (Tenet 1)."""
+    prior = MonitorState(str(tmp_path / "state.json"))
+    prior.record_gluetun_id(OLD_ID)
+    prior.save()
+
+    fake = FakeDockerClient()
+    fake.add_container("gluetun", id=NEW_ID)
+    fake.add_container("stranger", network_mode=f"container:{OTHER_ID}", running=True)
+    mon, stream = _monitor(fake, tmp_path / "state.json", tmp_path / "sites.conf")
+    mon.run_once()
+
+    out = stream.getvalue()
+    assert "Adopting" not in out
+    assert "can't be confirmed as gluetun" in out  # the pre-#97 warning
+    assert fake.created == []
+
+
+def test_exited_stranger_is_not_even_warned_about(tmp_path: Path) -> None:
+    """An exited container on an unknown dead parent is ordinary leftover junk —
+    adopting it would be wrong and warning about it every startup is noise."""
+    fake = FakeDockerClient()
+    fake.add_container("gluetun", id=NEW_ID)
+    fake.add_container("junk", network_mode=f"container:{OTHER_ID}", running=False)
+    mon, stream = _monitor(fake, tmp_path / "state.json", tmp_path / "sites.conf")
+    mon.run_once()
+    out = stream.getvalue()
+    assert "Adopting" not in out and "junk" not in out
+    assert fake.created == []
+
+
+# ----- memory maintenance -----
+
+
+def test_known_dependents_survive_a_monitor_restart(tmp_path: Path) -> None:
+    """A healthy dependent seen by instance 1 is in instance 2's remembered set
+    before its first discovery — the RAM-only gap is closed."""
+    fake = FakeDockerClient()
+    fake.add_container("gluetun", id=NEW_ID)
+    fake.add_container("dep", network_mode=f"container:{NEW_ID}", running=True)
+    mon1, _ = _monitor(fake, tmp_path / "state.json", tmp_path / "sites.conf")
+    mon1.run_once()
+
+    mon2, _ = _monitor(fake, tmp_path / "state.json", tmp_path / "sites.conf")
+    assert "dep" in mon2._known_dependents
+
+
+def test_gluetun_id_history_prunes_by_reference_not_count(tmp_path: Path) -> None:
+    """An id stays while ANY existing container references it — however many
+    recreates later — and is dropped the loop after nothing does."""
+    fake = FakeDockerClient()
+    fake.add_container("gluetun", id=NEW_ID)
+    dep = fake.add_container("dep", network_mode=f"container:{OLD_ID}", running=False)
+    mon, _ = _monitor(fake, tmp_path / "state.json", tmp_path / "sites.conf")
+    mon.mstate.record_gluetun_id(OLD_ID)
+    mon.mstate.record_gluetun_id(NEW_ID)
+
+    mon.run_once()  # dep (still referencing OLD_ID pre-recreate) kept it alive…
+    # …but the adoption already recreated dep onto NEW_ID, so on the NEXT loop
+    # nothing references OLD_ID any more and it is pruned.
+    assert dep.id  # (dep was recreated; the old record is gone from the store)
+    mon.run_once()
+    assert mon.mstate.gluetun_ids == [NEW_ID]

--- a/tests/test_monitor_branches.py
+++ b/tests/test_monitor_branches.py
@@ -145,5 +145,5 @@ def test_orphan_warn_skips_nameform_target() -> None:
     # dangling id, so no orphan warning.
     fake.add_container("buddy", network_mode="container:gluetun")
     mon = _mon(fake, dependent_containers="auto")
-    mon._warn_dangling_orphans()
+    mon._scan_stranded_orphans("f" * 64)
     assert "no longer exists" not in _stream(mon).getvalue()

--- a/tests/test_orphan_warn.py
+++ b/tests/test_orphan_warn.py
@@ -5,6 +5,10 @@ gluetun's old, now-gone id, so current-id discovery can't see it. We surface it
 with an actionable WARN suggesting DEPENDENT_CONTAINERS — but we deliberately do
 NOT auto-recreate it, because an orphan whose parent is gone can't be confirmed
 as *this* gluetun's dependent (Tenet 1, first do no harm).
+
+Since #97 these are the NEGATIVE-path pins for the adoption scan: a dead parent
+id that is NOT in the persisted gluetun history keeps exactly this warn-only
+behavior (the positive/adoption paths live in test_dependent_memory.py).
 """
 
 from __future__ import annotations
@@ -36,7 +40,7 @@ def test_warns_about_dangling_orphan_but_does_not_recreate() -> None:
     # 'orphan' points at a container id that doesn't exist (dead netns parent).
     fake.add_container("orphan", network_mode=f"container:{DEAD_ID}")
     mon, stream = _mon(fake)
-    mon._warn_dangling_orphans()
+    mon._scan_stranded_orphans(GLUETUN_ID)
     out = stream.getvalue()
     assert "orphan" in out and "no longer exists" in out
     assert "DEPENDENT_CONTAINERS" in out
@@ -49,7 +53,7 @@ def test_no_warn_when_netns_parent_exists() -> None:
     fake.add_container("gluetun", id=GLUETUN_ID)
     fake.add_container("dep", network_mode=f"container:{GLUETUN_ID}")
     mon, stream = _mon(fake)
-    mon._warn_dangling_orphans()
+    mon._scan_stranded_orphans(GLUETUN_ID)
     assert "no longer exists" not in stream.getvalue()
 
 
@@ -60,7 +64,7 @@ def test_no_warn_for_excluded_or_listed() -> None:
     fake.add_container("gluetun", id=GLUETUN_ID)
     fake.add_container("orphan", network_mode=f"container:{DEAD_ID}")
     mon, stream = _mon(fake, exclude_containers="orphan")
-    mon._warn_dangling_orphans()
+    mon._scan_stranded_orphans(GLUETUN_ID)
     assert "no longer exists" not in stream.getvalue()
 
 
@@ -69,6 +73,6 @@ def test_orphan_warning_dedups() -> None:
     fake.add_container("gluetun", id=GLUETUN_ID)
     fake.add_container("orphan", network_mode=f"container:{DEAD_ID}")
     mon, stream = _mon(fake)
-    mon._warn_dangling_orphans()
-    mon._warn_dangling_orphans()
+    mon._scan_stranded_orphans(GLUETUN_ID)
+    mon._scan_stranded_orphans(GLUETUN_ID)
     assert stream.getvalue().count("no longer exists") == 1


### PR DESCRIPTION
Closes #97.

## Problem

Dependent knowledge lived in two places, and both fail at once: auto-discovery matches `container:<CURRENT gluetun id>` among **running** containers, and the remembered set (ADR-0004) was in-memory only. A monitor restart followed closely by a gluetun recreate — one `docker compose up -d` can do both — left every dependent stranded AND invisible: `No dependent containers discovered`, every loop, forever. Observed live during the #76 dogfood, twice in one evening, in both forms: *exited-stranded* (the dependent's own restart policy fails onto the dead netns id and gives up) and *running-stranded* (alive on loopback only). The stack stayed down until healed by hand.

## Fix

Persist **only what Docker forgets**, in a `monitor-state.json` sidecar (atomic tmp+rename+fsync, write-on-change, corrupt file degrades to today's behavior):

- **`gluetun_ids`** — every id gluetun has run under. Docker ids are 256-bit random and never reused, so an entry can't rot into a false positive: a container whose `NetworkMode` references a dead id from this list *provably* shared our gluetun's netns. Pruned **by reference** (an id stays while any existing container points at it), never by count or age — no freshness gating, no boot-id; a host reboot just converts running-stranded into exited-stranded, which is already the adoption case.
- **`known_dependents`** — the remembered set, seeded back into memory at startup.

The dangling-orphan scan becomes an **adopt-or-warn** scan, runs at startup and every loop, and now includes **exited** containers (new `DockerClient.list_all_ids` — the running-only view hid exactly the containers most in need of healing):

```mermaid
stateDiagram-v2
    direction TB
    state "Container with NetworkMode container:&lt;id&gt;" as C
    state "dead parent?" as Dead <<choice>>
    state "id in gluetun history?" as Hist <<choice>>
    state "Healthy / normal discovery path" as OK
    state "ADOPTED into managed set → remediated this loop ✅" as Adopt
    state "WARN once: add to DEPENDENT_CONTAINERS (running only)" as Warn
    state "Ignored (exited junk on an unknown dead parent)" as Junk

    [*] --> C: scan (startup + every loop, ALL containers)
    C --> Dead
    Dead --> OK: parent exists
    Dead --> Hist: parent gone
    Hist --> Adopt: yes — provably ours (ids never reused)
    Hist --> Warn: no + running (pre-#97 behavior)
    Hist --> Junk: no + exited
```

Judged against the incident: with this fix, run 1 of the dogfood would have adopted all four dependents on the monitor's first loop (the state file from the previous instance carried the old gluetun id) and healed them ~9 minutes of downtime instead of ~80.

Known residual gap (documented in the issue): a **first-ever** run (empty history) against already-stranded dependents still can't confirm parentage — the explicit `DEPENDENT_CONTAINERS` workaround remains the answer there.

## Tests

`tests/test_dependent_memory.py` (10 tests) — red against pre-fix code:

- state round-trip, corrupt-file degradation (any garbage shape), write-on-change, observability fields
- **the production regression, both forms**: fresh monitor + state file with the old gluetun id + dependent exited/running-stranded on that dead id → adopted and recreated onto the current gluetun in the first loop
- negative pins: a dead parent NOT in the history is never adopted (running → warn-only, exited → ignored); existing `test_orphan_warn.py` re-pointed as the warn-path pins
- known dependents survive a monitor restart; id history prunes by reference and drops an id the loop after nothing references it

Full suite, ruff, mypy green. `MONITOR_STATE_FILE` documented in the README env table.
