### PR TITLE
fix(monitor): never treat recreate-parked containers as dependents (#97)

### DIFF
--- a/gluetun_monitor/monitor.py
+++ b/gluetun_monitor/monitor.py
@@ -33,7 +33,7 @@ from .endpoint import get_endpoint_info
 from .monitor_state import MonitorState
 from .notify import Notifier, NotifyEvent, NullNotifier
 from .recovery import remediate_dependent, restart_gluetun
-from .recreate import sweep_recreate_leftovers
+from .recreate import is_parked_name, sweep_recreate_leftovers
 from .site_stats import SiteStatsStore, format_window
 from .sites import (
     SiteSpec,
@@ -140,7 +140,12 @@ class Monitor:
         # longer matches it — but we remember it from before the recreate and
         # keep checking it (ADR-0004: track across cycles). Pruned to existing.
         # Seeded from the persisted memory; _resolve_dependents prunes to existing.
-        self._known_dependents: set[str] = set(self.mstate.known_dependents)
+        # Parked (*.gm-recreate-old) names are filtered even here: a state file
+        # written by a version without the parked-name guard may carry them, and
+        # they are recreate machinery, never dependents.
+        self._known_dependents: set[str] = {
+            n for n in self.mstate.known_dependents if not is_parked_name(n)
+        }
         # The set managed last loop — to retire an alert ("no longer monitored") when
         # a dependent leaves (excluded or gone), rather than a false "resolved" (ADR-0012).
         self._managed_dependents: set[str] = set()
@@ -487,7 +492,9 @@ class Monitor:
         # Re-arm the warning for any name that has since reappeared.
         self._warned_missing &= {name for name, exists in present.items() if not exists}
 
-        self._known_dependents.update(name for name, exists in present.items() if exists)
+        self._known_dependents.update(
+            name for name, exists in present.items() if exists and not is_parked_name(name)
+        )
         # Prune the remembered set to containers that still exist. Reuse the
         # existence we already learned for the current names; only inspect a
         # remembered name we haven't already checked this loop (e.g. one stranded
@@ -937,6 +944,11 @@ class Monitor:
                 continue  # name-form target resolves normally; not a dangling id
             referenced.add(target)
             if info.name in skip:
+                continue
+            if is_parked_name(info.name):
+                # Recreate machinery (gc/sweep territory) — adopting a parked
+                # twin would re-park it under a stacked suffix and mint a fresh
+                # orphan every loop (found by the #97 dogfood).
                 continue
             if self.client.inspect(target) is not None:
                 continue  # the netns parent still exists — not stranded

--- a/gluetun_monitor/recreate.py
+++ b/gluetun_monitor/recreate.py
@@ -37,6 +37,19 @@ if TYPE_CHECKING:
 # collide with a real container name.
 _OLD_SUFFIX = ".gm-recreate-old"
 
+
+def is_parked_name(name: str) -> bool:
+    """True if ``name`` is a recreate-parked container (``*.gm-recreate-old``).
+
+    Parked containers are recreate MACHINERY, owned exclusively by
+    :func:`gc_recreate_leftover` and :func:`sweep_recreate_leftovers`. Nothing
+    else — discovery, the remembered set, the orphan-adoption scan — may treat
+    one as a dependent: adopting a parked twin re-parks it under a stacked
+    suffix and mints a fresh orphan container every loop (observed live during
+    the #97 dogfood when an unremovable parked twin met the adoption scan).
+    """
+    return name.endswith(_OLD_SUFFIX)
+
 # Config fields the daemon rejects (or that are meaningless) when NetworkMode is
 # container:<id> — the shared netns owns the hostname and the port surface.
 _STRIP_CONFIG_FIELDS = ("Hostname", "Domainname", "ExposedPorts", "MacAddress")
@@ -235,6 +248,12 @@ def recreate_dependent(
     mount (two live instances would corrupt the volumes). ``volumes=False`` on
     remove is the data-preservation guarantee (ROC, ADR-0005).
     """
+    if is_parked_name(dep_name):
+        # Belt-and-braces for the same invariant guarded at the scan layer: a
+        # parked twin must never be treated as a dependent (stacked-suffix
+        # runaway). gc/sweep are the only paths allowed to touch these.
+        logger.error(f"Refusing to recreate {dep_name}: recreate-parked containers are machinery, not dependents")
+        return False
     info = client.inspect(dep_name)
     if info is None:
         logger.error(f"Cannot recreate {dep_name}: container not found")

--- a/tests/test_dependent_memory.py
+++ b/tests/test_dependent_memory.py
@@ -213,3 +213,67 @@ def test_gluetun_id_history_prunes_by_reference_not_count(tmp_path: Path) -> Non
     assert dep.id  # (dep was recreated; the old record is gone from the store)
     mon.run_once()
     assert mon.mstate.gluetun_ids == [NEW_ID]
+
+
+# ----- parked containers are machinery, never dependents (dogfood regression) -----
+
+
+def test_parked_twin_is_never_adopted(tmp_path: Path) -> None:
+    """The #97 dogfood runaway: an unremovable parked twin (dead former-gluetun
+    parent) met the adoption scan, was adopted as a 'dependent', re-parked under
+    a stacked suffix, and a fresh orphan was minted every loop. Parked names are
+    recreate machinery — the scan must skip them entirely."""
+    prior = MonitorState(str(tmp_path / "state.json"))
+    prior.record_gluetun_id(OLD_ID)
+    prior.save()
+
+    fake = FakeDockerClient()
+    fake.add_container("gluetun", id=NEW_ID)
+    fake.add_container(
+        "dep.gm-recreate-old", network_mode=f"container:{OLD_ID}", running=False
+    )
+    mon, stream = _monitor(fake, tmp_path / "state.json", tmp_path / "sites.conf")
+    mon.run_once()
+    mon.run_once()  # a second loop must not stack suffixes either
+
+    out = stream.getvalue()
+    assert "Adopting" not in out
+    assert fake.created == [] and fake.renamed == []  # no re-park, no minting
+    assert not any(
+        n.count(".gm-recreate-old") > 1
+        for n in (fake.inspect(cid).name for cid in fake.list_all_ids())
+    )
+
+
+def test_parked_name_seeded_from_old_state_is_ignored(tmp_path: Path) -> None:
+    """A state file written before the guard may carry parked names in
+    known_dependents — they must be filtered at seed time, not remediated."""
+    prior = MonitorState(str(tmp_path / "state.json"))
+    prior.record_gluetun_id(NEW_ID)
+    prior.set_known_dependents({"dep", "dep.gm-recreate-old"})
+    prior.save()
+
+    fake = FakeDockerClient()
+    fake.add_container("gluetun", id=NEW_ID)
+    fake.add_container("dep", network_mode=f"container:{NEW_ID}", running=True)
+    fake.add_container(
+        "dep.gm-recreate-old", network_mode=f"container:{NEW_ID}", running=False
+    )
+    mon, _ = _monitor(fake, tmp_path / "state.json", tmp_path / "sites.conf")
+    assert "dep.gm-recreate-old" not in mon._known_dependents
+    mon.run_once()
+    assert "dep.gm-recreate-old" not in mon.mstate.known_dependents
+
+
+def test_recreate_refuses_a_parked_name(tmp_path: Path) -> None:
+    """Belt-and-braces at the recreate layer: even if a parked name reaches
+    recreate_dependent, it must refuse rather than stack suffixes."""
+    from gluetun_monitor.recreate import recreate_dependent
+
+    fake = FakeDockerClient()
+    fake.add_container("dep.gm-recreate-old", network_mode=f"container:{OLD_ID}")
+    stream = io.StringIO()
+    logger = Logger(log_file=None, level="DEBUG", stream=stream)
+    assert recreate_dependent(fake, "dep.gm-recreate-old", NEW_ID, logger) is False
+    assert fake.renamed == [] and fake.created == []
+    assert "machinery" in stream.getvalue()


### PR DESCRIPTION
Follow-up to #101, found live by its dogfood (and only expressible when an OS-level zombie makes a parked twin unremovable — the same host condition behind #98).

## Problem

The adoption scan judged a container solely by "NetworkMode points at a dead former-gluetun id". The recreate machinery's own parked twin (`<dep>.gm-recreate-old`) satisfies that test: it IS the old dependent. When one survived (unremovable: ZFS dataset-busy zombie), the scan adopted it, remediation re-parked it under a stacked suffix and created a fresh container under the parked name — every loop:

```
flaresolverr.gm-recreate-old.gm-recreate-old
flaresolverr.gm-recreate-old.gm-recreate-old.gm-recreate-old
flaresolverr.gm-recreate-old.gm-recreate-old.gm-recreate-old.gm-recreate-old
```

A runaway container generator, one orphan per loop, admission-controlled only by the operator noticing.

## Fix

Parked names are machinery, owned exclusively by `gc_recreate_leftover` / `sweep_recreate_leftovers`. Enforced at three layers:

- `_scan_stranded_orphans` skips `*.gm-recreate-old` outright,
- the remembered set never accepts a parked name — from discovery or from a state file written before this guard,
- `recreate_dependent` refuses a parked target (belt and braces; also covers the explicit `DEPENDENT_CONTAINERS` path if an operator lists one).

## Tests

Red pre-fix: the two-loop no-stacking replay of the runaway (no adopt, no rename, no minted containers), the pre-guard state-file seed, and the recreate-layer refusal. Full suite, ruff, mypy green.