### PR TITLE
fix(monitor): escalate wedged dependents — distinct alert with runbook, capped retry backoff (#98)

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,6 +199,8 @@ docker compose up -d
 | `NOTIFY_REPEAT_INTERVAL` | `0` | Re-notify cadence for an *ongoing* problem, in **loops**. `0` = announce once, then silent until it resolves; `N` = remind every `N` loops. Alerts are edge-triggered. See [Notifications](#notifications) |
 | `NOTIFY_STATE_FILE` | `/logs/notify-state.json` | Where the active-alert lifecycle persists (so a monitor restart doesn't re-spam or miss a resolve). Best-effort. See [Notifications](#notifications) |
 | `NOTIFY_TIMEOUT` | `10` | Max seconds to wait for a notification send before carrying on (sends run off the loop, so a slow backend can't stall the watchdog). See [Notifications](#notifications) |
+| `WEDGE_ESCALATE_AFTER` | `3` | Consecutive **identical** remediation failures on one dependent before it's declared wedged: a distinct `dependent WEDGED` alert (with the operator runbook when the blocker is an unremovable parked twin) replaces the generic one, and remediation attempts back off. See [Notifications](#notifications) |
+| `WEDGE_BACKOFF_CAP` | `600` | Ceiling (seconds) for the doubling remediation-retry backoff once wedged. Probes still run every loop — only the doomed remediation attempt is throttled. `0` = no backoff (retry every loop) but still escalate the alert |
 
 ### Configuration is validated — sane defaults, but bad config is fatal
 
@@ -307,6 +309,7 @@ Uses `wget --spider` which only fetches headers (no response body downloaded).
 | `DNS_WAIT_TIMEOUT` | `30` | post-restart budget | poll for DNS to stabilize after a restart | — |
 | `NOTIFY_TIMEOUT` | `10` | per-send | max wait for one (off-thread) notification send | — |
 | `NOTIFY_REPEAT_INTERVAL` | `0` | alert cadence | reminder cadence for an ongoing problem (`0` = announce once) | — |
+| `WEDGE_BACKOFF_CAP` | `600` | retry backoff | ceiling for the doubling remediation-retry delay on a wedged dependent (`0` = no backoff) | — |
 
 (The Docker API client timeout isn't a separate knob — it's derived as
 `max(TIMEOUT × 2, 60)`.)
@@ -700,6 +703,33 @@ dependent excluded) you get a "no longer monitored" note instead (the alert is
 retired, not recovered). This state persists to `NOTIFY_STATE_FILE`,
 so restarting the monitor neither re-spams still-broken problems nor misses a
 resolve (ADR-0012).
+
+### Wedged dependents — escalation with the runbook attached
+
+Most remediation failures are transient and the next loop's retry clears them. But
+some states **cannot** self-heal — the canonical one is an unremovable parked twin
+left by an interrupted recreate (a storage-driver `dataset is busy` refusal: the
+force-killed container's process tree survived and pinned the mount). Retrying is
+free but futile, and the failure looks identical every loop.
+
+When the **same** remediation failure repeats `WEDGE_ESCALATE_AFTER` consecutive
+times (default 3), the monitor declares the dependent **wedged**:
+
+- the generic `dependent unhealthy` alert is superseded by a distinct
+  **`dependent WEDGED`** alert carrying the exact error, the parked twin's inspect
+  state, and the **operator runbook** — the alert alone is enough to act on;
+- remediation attempts **back off** (doubling per failed attempt, capped at
+  `WEDGE_BACKOFF_CAP` seconds, default 10 min) instead of hammering the daemon with
+  a doomed removal every loop;
+- **probing never stops** — the dependent is still checked every loop, so once the
+  blocker is cleared (or the container recovers on its own) the monitor finishes
+  the heal itself and resolves the alert. A failure that *changes* restarts the
+  count: a new error is a new situation, not a deeper wedge.
+
+One deployment note: **a wedged alert is only as good as the `APPRISE_URLS` behind
+it**. In log-only mode (the default) every attention-tier alert — this one included
+— is just a log line, and "escalation" means hoping someone tails the log. If you
+rely on the monitor to summon you when it's stuck, configure notifications.
 
 ### Grouped, best-effort
 

--- a/gluetun_monitor/alert_state.py
+++ b/gluetun_monitor/alert_state.py
@@ -91,6 +91,25 @@ class AlertState:
         """Declare that ``key``'s subject is no longer monitored (silent clear)."""
         self._forgotten.add(key)
 
+    def is_active(self, key: str) -> bool:
+        """Whether ``key`` is currently an active (announced, unresolved) alert.
+
+        Lets the monitor recognize a problem it had already escalated before a
+        restart (#98) without persisting separate bookkeeping — the alert sidecar
+        already remembers.
+        """
+        return key in self._active
+
+    def supersede(self, key: str) -> None:
+        """Silently retire ``key``: a stronger alert for the same subject replaces
+        it (#98 unhealthy→wedged escalation). No resolve event (the problem did
+        not clear) and no deprecation (the subject is still monitored) — the
+        successor alert is the continuation of the same story.
+        """
+        if self._active.pop(key, None) is not None:
+            self._log.debug(f"notify: {key} superseded")
+        self._reported.pop(key, None)
+
     # ----- per-loop output -----
 
     def events(self) -> list[NotifyEvent]:

--- a/gluetun_monitor/config.py
+++ b/gluetun_monitor/config.py
@@ -180,6 +180,19 @@ class Config:
     # monitoring loop, so a slow/hung backend can't stall the watchdog). Tenet 7.
     notify_timeout: int = 10
 
+    # --- Wedged-remediation escalation + retry backoff (#98) ---
+    # Consecutive IDENTICAL remediation failures on one dependent before the
+    # monitor declares it wedged: a distinct attention alert (runbook included
+    # when the blocker is an unremovable parked twin) replaces the generic
+    # unhealthy alert, and remediation attempts back off. The first N-1 failures
+    # keep the pre-#98 behavior (retry every loop, generic alert).
+    wedge_escalate_after: int = 3
+    # Ceiling (seconds) for the doubling retry backoff once wedged. Probes still
+    # run every loop — only the doomed remediation attempt is throttled, so a
+    # wedge cleared by the operator is noticed within one retry interval at worst
+    # (and immediately if the dependent comes back healthy on its own).
+    wedge_backoff_cap: int = 600
+
     # Fatal config errors (malformed env values), collected during from_env and
     # surfaced by the CLI once the logger exists — the CLI then refuses to start.
     # Not an env var.
@@ -258,5 +271,8 @@ class Config:
             notify_repeat_interval=_env_int("NOTIFY_REPEAT_INTERVAL", 0, errors, minimum=0),
             notify_state_file=os.environ.get("NOTIFY_STATE_FILE", "/logs/notify-state.json"),
             notify_timeout=_env_int("NOTIFY_TIMEOUT", 10, errors, minimum=1),
+            wedge_escalate_after=_env_int("WEDGE_ESCALATE_AFTER", 3, errors, minimum=1),
+            # 0 = no backoff (retry every loop), but still escalate the alert.
+            wedge_backoff_cap=_env_int("WEDGE_BACKOFF_CAP", 600, errors, minimum=0),
             errors=tuple(errors),
         )

--- a/gluetun_monitor/monitor.py
+++ b/gluetun_monitor/monitor.py
@@ -32,7 +32,7 @@ from .dns_check import DnsResult, DnsStatus, validate_dns
 from .endpoint import get_endpoint_info
 from .monitor_state import MonitorState
 from .notify import Notifier, NotifyEvent, NullNotifier
-from .recovery import remediate_dependent, restart_gluetun
+from .recovery import RemediationOutcome, remediate_dependent, restart_gluetun
 from .recreate import is_parked_name, sweep_recreate_leftovers
 from .site_stats import SiteStatsStore, format_window
 from .sites import (
@@ -66,6 +66,26 @@ class DependentProbe:
     reason: str
     dns_unvalidated: bool = False  # True = no usable DNS tool in the container
     interfaces: str = "?"  # the dependent's net interfaces, for DEBUG visibility
+
+
+@dataclass(slots=True)
+class _WedgeTrack:
+    """Consecutive-identical-remediation-failure bookkeeping for one dependent (#98).
+
+    ``signature`` is the failure detail from the last attempt; a repeat with the
+    SAME signature increments ``consecutive``, a different one starts the track
+    over (a new failure is a new situation, not a deeper wedge). Once escalated,
+    ``backoff_loops`` doubles per failed attempt (capped) and ``skip_remaining``
+    counts down the loops until the next attempt — probing is never skipped,
+    only the doomed remediation.
+    """
+
+    signature: str
+    consecutive: int = 1
+    escalated: bool = False
+    backoff_loops: int = 0  # current retry delay, in loops
+    skip_remaining: int = 0  # loops left before the next attempt
+    body: str = ""  # last escalation-alert body, re-reported on skipped loops
 
 
 def _fmt_reach(host: str, r: DnsResult) -> str:
@@ -155,6 +175,11 @@ class Monitor:
         self._warned_orphans: set[str] = set()
         # Dedup for "can't validate DNS (no usable tool)" — re-armed if it later validates.
         self._warned_dns_unvalidated: set[str] = set()
+        # Per-dependent wedge escalation + retry backoff (#98). In-memory only:
+        # a restart mid-wedge re-detects within one attempt (the active
+        # `dependent-wedged:` alert persists in the alert sidecar and is picked
+        # up via alerts.is_active, so no re-announce and no false resolve).
+        self._wedges: dict[str, _WedgeTrack] = {}
 
     def _notify(self, tier: str, title: str, body: str, key: str) -> None:
         """Buffer a one-shot point event for this loop's rollup (ADR-0011)."""
@@ -518,6 +543,8 @@ class Monitor:
         # would imply it recovered (ADR-0012).
         for gone in self._managed_dependents - set(dependents):
             self._forget(f"dependent-unhealthy:{gone}")
+            self._forget(f"dependent-wedged:{gone}")
+            self._wedges.pop(gone, None)
         self._managed_dependents = set(dependents)
         if not dependents:
             return
@@ -590,6 +617,13 @@ class Monitor:
         else:
             self.log.info(f"dependents: {healthy}/{len(probes)} ok")
 
+        # A dependent that came back healthy WITHOUT our help (e.g. the operator
+        # cleared the wedge and it recovered) drops its failure bookkeeping; its
+        # wedged alert stops being reported, so the lifecycle resolves it.
+        failing = {dep for dep, _ in to_remediate}
+        for dep in [d for d in self._wedges if d not in failing]:
+            del self._wedges[dep]
+
         for dep, reason in to_remediate:
             if self.config.dry_run:
                 # Observe-only: report the decision + the action we'd take, but
@@ -599,11 +633,29 @@ class Monitor:
                 action = remediation_action(info, gluetun_id).name if info else "UNKNOWN"
                 self.log.warn(f"[DRY-RUN] would remediate {dep}: {reason} (action={action})")
                 continue
+            track = self._wedges.get(dep)
+            if track is not None and track.escalated and track.skip_remaining > 0:
+                # Wedged and backing off: the same attempt has failed identically
+                # every time — don't drive another doomed removal through the
+                # daemon this loop. Keep the alert active (the lifecycle resolves
+                # anything not re-reported) and keep probing every loop.
+                track.skip_remaining -= 1
+                self._problem(
+                    f"dependent-wedged:{dep}", "attention",
+                    f"dependent WEDGED: {dep}", track.body,
+                )
+                self.log.debug(
+                    f"{dep} is wedged; backing off — next remediation attempt in "
+                    f"{track.skip_remaining + 1} loop(s) (probes continue)"
+                )
+                continue
             self.log.warn(f"Remediating dependent {dep}: {reason}")
             self.stats.record_dependent_remediation()
-            if remediate_dependent(
+            outcome = remediate_dependent(
                 self.client, dep, gluetun_id, self.config, self.log, sleep=self._sleep
-            ):
+            )
+            if outcome:
+                self._wedges.pop(dep, None)
                 self.dependent_failures.reset(dep)
                 self._notify(
                     "recovery",
@@ -612,15 +664,99 @@ class Monitor:
                     key=f"dependent-remediated:{dep}",
                 )
             else:
-                # An ongoing problem → the lifecycle (edge-triggered, repeat, resolve),
-                # not a per-loop point event.
-                self._problem(
-                    f"dependent-unhealthy:{dep}",
-                    "attention",
-                    f"dependent unhealthy: {dep}",
-                    f"{dep} is still unhealthy after remediation ({reason}) — "
-                    f"manual intervention may be required.",
-                )
+                self._record_remediation_failure(dep, reason, outcome)
+
+    def _record_remediation_failure(
+        self, dep: str, reason: str, outcome: RemediationOutcome
+    ) -> None:
+        """Track consecutive identical remediation failures for ``dep``; escalate
+        to a distinct wedged alert + retry backoff once the same failure has
+        repeated WEDGE_ESCALATE_AFTER times (#98).
+
+        Below the threshold this is exactly the pre-#98 behavior (the generic
+        ``dependent-unhealthy`` lifecycle alert, retry next loop). A failure with
+        a DIFFERENT signature restarts the count — a new error is a new
+        situation, not a deeper wedge.
+        """
+        track = self._wedges.get(dep)
+        if track is None or track.signature != outcome.detail:
+            track = _WedgeTrack(signature=outcome.detail)
+            self._wedges[dep] = track
+        else:
+            track.consecutive += 1
+        # A wedged alert persisted from before a monitor restart means this
+        # dependent was already escalated — stay escalated rather than demoting
+        # to the generic alert (which would re-announce AND falsely resolve the
+        # wedged one). report() on an active key refreshes silently.
+        already = self.alerts.is_active(f"dependent-wedged:{dep}")
+        if track.consecutive < self.config.wedge_escalate_after and not already:
+            self._problem(
+                f"dependent-unhealthy:{dep}",
+                "attention",
+                f"dependent unhealthy: {dep}",
+                f"{dep} is still unhealthy after remediation ({reason}) — "
+                f"manual intervention may be required.",
+            )
+            return
+        first = not track.escalated
+        track.escalated = True
+        # Doubling backoff per failed attempt, in loops, capped. cap=0 disables
+        # the backoff (attempt every loop) but keeps the escalated alert.
+        cap_loops = self.config.wedge_backoff_cap // max(1, self.config.check_interval)
+        track.backoff_loops = (
+            min(max(2, track.backoff_loops * 2), cap_loops) if cap_loops > 0 else 0
+        )
+        track.skip_remaining = track.backoff_loops
+        track.body = self._wedged_body(dep, track, outcome)
+        if first:
+            # The wedged alert supersedes the generic one: silently retire it (no
+            # false "resolved" — the problem didn't clear, it got more specific).
+            self.alerts.supersede(f"dependent-unhealthy:{dep}")
+            self.log.warn(
+                f"{dep} is WEDGED: the same remediation failure has repeated "
+                f"{track.consecutive}x ({outcome.detail}) — operator action required; "
+                f"backing off to one attempt every {track.backoff_loops or 1} loop(s) "
+                f"(probes continue every loop)"
+            )
+        self._problem(
+            f"dependent-wedged:{dep}", "attention",
+            f"dependent WEDGED: {dep}", track.body,
+        )
+
+    def _wedged_body(self, dep: str, track: _WedgeTrack, outcome: RemediationOutcome) -> str:
+        """The wedged-alert body: what is stuck, the exact error, and — when the
+        blocker is an unremovable parked twin — the operator runbook, so the alert
+        itself is enough to act on (#98).
+        """
+        retry_s = track.backoff_loops * self.config.check_interval
+        cadence = (
+            f"retries remediation only every ~{retry_s}s"
+            if retry_s > 0
+            else "keeps retrying every loop"
+        )
+        lines = [
+            f"{dep} remediation has failed {track.consecutive} consecutive times with "
+            f"the same error and cannot succeed without operator action. The monitor "
+            f"keeps probing every loop but now {cadence}; it will finish the heal "
+            f"itself once the blocker is cleared.",
+            f"Error: {outcome.detail}",
+        ]
+        if outcome.wedge is not None:
+            w = outcome.wedge
+            lines += [
+                f"Parked twin: {w.parked_name} (state: {w.parked_status}) — an "
+                f"interrupted recreate's copy that Docker cannot remove; it shares "
+                f"every volume with {dep}, so remediation is refused while it exists. "
+                f"A 'dead' state with a busy-filesystem error usually means its "
+                f"process tree is still alive and pinning the mount.",
+                f"Runbook: 1) find the pinning processes — match the container's "
+                f"storage/dataset id in /proc/*/mountinfo to LOCATE holders, but kill "
+                f"only pids whose /proc/<pid>/cgroup contains this container's id "
+                f"(host-namespace processes match mountinfo innocently); "
+                f"2) docker rm -f {w.parked_name} (never remove the storage layer "
+                f"directly — Docker owns it); 3) done — no monitor action needed.",
+            ]
+        return "\n".join(lines)
 
     # ----- one full loop iteration (node 1 -> 22, minus the sleep) -----
 

--- a/gluetun_monitor/recovery.py
+++ b/gluetun_monitor/recovery.py
@@ -11,11 +11,12 @@ from __future__ import annotations
 
 import time
 from collections.abc import Callable
+from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 from .dependents import interface_check, remediation_action
 from .endpoint import get_endpoint_info
-from .recreate import gc_recreate_leftover, recreate_dependent
+from .recreate import Wedge, gc_recreate_leftover, recreate_dependent
 from .state import InterfaceStatus, RemediationAction
 
 if TYPE_CHECKING:
@@ -24,6 +25,26 @@ if TYPE_CHECKING:
     from .logging_setup import Logger
 
 Sleep = Callable[[float], None]
+
+
+@dataclass(frozen=True, slots=True)
+class RemediationOutcome:
+    """Result of one dependent remediation attempt.
+
+    Truthiness == success, so boolean call sites keep reading naturally.
+    ``detail`` is the failure signature: the monitor compares it across loops to
+    recognize *the same* failure repeating (the wedge-escalation trigger, #98).
+    ``wedge`` carries the unremovable-parked-twin specifics when that is the
+    blocker, so the escalation alert can ship the runbook.
+    """
+
+    ok: bool
+    detail: str = ""
+    wedge: Wedge | None = None
+
+    def __bool__(self) -> bool:
+        """Truthiness is success, so ``if outcome:`` reads like the old bool API."""
+        return self.ok
 
 
 def get_health(client: DockerClient, container: str) -> str:
@@ -137,14 +158,19 @@ def verify_dependent(client: DockerClient, dep_name: str) -> bool:
     return interface_check(client, dep_name) != InterfaceStatus.STRANDED
 
 
-def _do_restart(client: DockerClient, dep_name: str, logger: Logger, *, sleep: Sleep) -> bool:
+def _do_restart(
+    client: DockerClient, dep_name: str, logger: Logger, *, sleep: Sleep
+) -> str | None:
+    """Restart ``dep_name``. Returns None on success, the error detail on failure
+    (the caller feeds it into the failure signature — #98).
+    """
     try:
         client.restart(dep_name)
     except Exception as exc:
         logger.error(f"{dep_name} restart raised: {exc}")
-        return False
+        return f"restart failed: {exc}"
     sleep(2)  # brief settle before the verify, as v1.x did
-    return True
+    return None
 
 
 def _maybe_recreate(
@@ -153,14 +179,19 @@ def _maybe_recreate(
     gluetun_id: str,
     config: Config,
     logger: Logger,
-) -> bool:
+) -> str | None:
+    """Recreate ``dep_name`` if allowed. Returns None on success, else the
+    failure detail (#98 signature).
+    """
     if not config.auto_recreate:
         logger.error(
             f"{dep_name} needs recreate (gluetun id changed) but AUTO_RECREATE is "
             f"disabled — FAILED, manual intervention required"
         )
-        return False
-    return recreate_dependent(client, dep_name, gluetun_id, logger)
+        return "needs recreate but AUTO_RECREATE is disabled"
+    if not recreate_dependent(client, dep_name, gluetun_id, logger):
+        return "recreate failed (see log for the failing step)"
+    return None
 
 
 def remediate_dependent(
@@ -171,39 +202,50 @@ def remediate_dependent(
     logger: Logger,
     *,
     sleep: Sleep = time.sleep,
-) -> bool:
-    """Remediate a failing dependent and verify recovery. Returns success."""
+) -> RemediationOutcome:
+    """Remediate a failing dependent and verify recovery.
+
+    The outcome is truthy on success; on failure it carries the signature the
+    monitor uses to spot the same failure repeating loop after loop (#98).
+    """
     info = client.inspect(dep_name)
     if info is None:
         logger.error(f"Cannot remediate {dep_name}: container not found")
-        return False
+        return RemediationOutcome(False, "container not found")
 
     # A parked twin from an interrupted recreate shares every volume with this
     # container — restarting/recreating alongside it risks two writers on the
     # same data. Clear it first; refuse to act if it can't be cleared (#76).
-    if not gc_recreate_leftover(client, dep_name, logger):
-        return False
+    wedge = gc_recreate_leftover(client, dep_name, logger)
+    if wedge is not None:
+        return RemediationOutcome(
+            False,
+            f"unremovable parked twin {wedge.parked_name}: {wedge.error}",
+            wedge,
+        )
 
     action = remediation_action(info, gluetun_id)
 
     if action is RemediationAction.RESTART:
         logger.info(f"Restarting {dep_name} (same netns id)")
-        if not _do_restart(client, dep_name, logger, sleep=sleep):
-            return False
+        err = _do_restart(client, dep_name, logger, sleep=sleep)
+        if err is not None:
+            return RemediationOutcome(False, err)
     elif action is RemediationAction.TRY_RESTART:
         logger.info(f"Restarting {dep_name} (name-form netns)")
-        if not _do_restart(client, dep_name, logger, sleep=sleep):
+        if _do_restart(client, dep_name, logger, sleep=sleep) is not None:
             logger.warn(f"{dep_name} restart failed; escalating to recreate")
-            if not _maybe_recreate(client, dep_name, gluetun_id, config, logger):
-                return False
+            err = _maybe_recreate(client, dep_name, gluetun_id, config, logger)
+            if err is not None:
+                return RemediationOutcome(False, err)
     elif action is RemediationAction.RECREATE:
         logger.warn(f"{dep_name} netns moved (gluetun recreated) → recreate")
-        if not _maybe_recreate(client, dep_name, gluetun_id, config, logger):
-            return False
+        err = _maybe_recreate(client, dep_name, gluetun_id, config, logger)
+        if err is not None:
+            return RemediationOutcome(False, err)
 
-    ok = verify_dependent(client, dep_name)
-    if ok:
+    if verify_dependent(client, dep_name):
         logger.info(f"{dep_name} verified healthy after remediation")
-    else:
-        logger.error(f"{dep_name} still unhealthy after remediation — FAILED")
-    return ok
+        return RemediationOutcome(True)
+    logger.error(f"{dep_name} still unhealthy after remediation — FAILED")
+    return RemediationOutcome(False, "still unhealthy after remediation")

--- a/gluetun_monitor/recreate.py
+++ b/gluetun_monitor/recreate.py
@@ -25,6 +25,7 @@ import signal
 import threading
 from collections.abc import Iterator
 from contextlib import contextmanager
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
@@ -172,28 +173,49 @@ def _defer_stop_signals(logger: Logger) -> Iterator[None]:
             os.kill(os.getpid(), signum)  # re-deliver to the restored handler
 
 
-def gc_recreate_leftover(client: DockerClient, dep_name: str, logger: Logger) -> bool:
+@dataclass(frozen=True, slots=True)
+class Wedge:
+    """An unremovable parked twin blocking remediation of a dependent (#98).
+
+    Produced by :func:`gc_recreate_leftover` when the leftover exists but the
+    daemon refuses to remove it (observed live: ZFS "dataset is busy" — the
+    force-killed container's process tree survived and pinned the mount). The
+    fields feed the escalation alert: the exact driver error is the failure
+    signature, and ``parked_status`` ("dead") is the tell that points an
+    operator at the zombie-process cause.
+    """
+
+    parked_name: str
+    error: str
+    parked_status: str  # inspect State.Status at failure time
+
+
+def gc_recreate_leftover(client: DockerClient, dep_name: str, logger: Logger) -> Wedge | None:
     """Remove a parked ``<dep>.gm-recreate-old`` left by an interrupted recreate.
 
     Called before ANY remediation of ``dep_name``: if the leftover still exists
     alongside the (already-replaced or about-to-be-replaced) dependent, it holds
     the same volume mounts — starting/recreating the dependent with it still
-    around risks two instances writing the same data. Returns False when a
-    leftover exists but cannot be removed (the caller must NOT proceed).
+    around risks two instances writing the same data. Returns None when clear to
+    proceed; a :class:`Wedge` when a leftover exists but cannot be removed (the
+    caller must NOT proceed, and should escalate — #98).
     """
     leftover = f"{dep_name}{_OLD_SUFFIX}"
-    if client.inspect(leftover) is None:
-        return True
+    info = client.inspect(leftover)
+    if info is None:
+        return None
     try:
         client.remove(leftover, volumes=False)
     except Exception as exc:
+        state = info.raw.get("State", {}) or {}
+        status = str(state.get("Status") or ("running" if info.running else "exited"))
         logger.error(
             f"Cannot remove leftover {leftover} from an interrupted recreate: {exc} "
             f"— refusing to remediate {dep_name} while it exists (shared volumes)"
         )
-        return False
+        return Wedge(parked_name=leftover, error=str(exc), parked_status=status)
     logger.warn(f"Removed leftover {leftover} from a previously interrupted recreate")
-    return True
+    return None
 
 
 def sweep_recreate_leftovers(client: DockerClient, logger: Logger) -> None:

--- a/tests/test_branches.py
+++ b/tests/test_branches.py
@@ -113,7 +113,7 @@ def test_remediate_missing_container_returns_false() -> None:
     act on) rather than raising."""
     fake = FakeDockerClient()
     ok = remediate_dependent(fake, "ghost", GLUETUN_ID, Config(), _logger(), sleep=lambda _s: None)
-    assert ok is False
+    assert ok.ok is False
 
 
 def test_remediate_try_restart_success_without_escalation() -> None:
@@ -129,6 +129,6 @@ def test_remediate_try_restart_success_without_escalation() -> None:
 
     fake.on_exec = handler
     ok = remediate_dependent(fake, "dep", GLUETUN_ID, Config(), _logger(), sleep=lambda _s: None)
-    assert ok is True
+    assert ok.ok is True
     assert fake.restarted == ["dep"]
     assert fake.created == []  # restart worked, no escalation to recreate

--- a/tests/test_recovery.py
+++ b/tests/test_recovery.py
@@ -134,7 +134,7 @@ def test_remediate_restart_path() -> None:
     fake.add_container("dep", network_mode=f"container:{GLUETUN_ID}")
     fake.on_exec = _live_exec
     ok = remediate_dependent(fake, "dep", GLUETUN_ID, Config(), _logger(), sleep=lambda _s: None)
-    assert ok is True
+    assert ok.ok is True
     assert fake.restarted == ["dep"]
     assert fake.created == []  # restart, not recreate
 
@@ -146,7 +146,7 @@ def test_remediate_recreate_path() -> None:
     fake.add_container("dep", network_mode=f"container:{OLD_ID}")  # gluetun id moved
     fake.on_exec = _live_exec
     ok = remediate_dependent(fake, "dep", GLUETUN_ID, Config(), _logger(), sleep=lambda _s: None)
-    assert ok is True
+    assert ok.ok is True
     assert fake.removed == [("dep.gm-recreate-old", False)]  # parked old, volumes kept
     assert len(fake.created) == 1
     assert fake.restarted == []  # recreate, not restart
@@ -160,7 +160,7 @@ def test_remediate_recreate_disabled_is_failed() -> None:
     fake.on_exec = _live_exec
     cfg = Config(auto_recreate=False)
     ok = remediate_dependent(fake, "dep", GLUETUN_ID, cfg, _logger(), sleep=lambda _s: None)
-    assert ok is False
+    assert ok.ok is False
     assert fake.removed == []  # nothing destroyed when disabled
 
 
@@ -176,5 +176,5 @@ def test_remediate_try_restart_escalates_to_recreate() -> None:
 
     fake.restart = failing_restart  # type: ignore[method-assign]
     ok = remediate_dependent(fake, "dep", GLUETUN_ID, Config(), _logger(), sleep=lambda _s: None)
-    assert ok is True
+    assert ok.ok is True
     assert len(fake.created) == 1  # escalated to recreate

--- a/tests/test_recreate_window.py
+++ b/tests/test_recreate_window.py
@@ -106,7 +106,7 @@ def test_gc_removes_leftover_and_blocks_when_it_cannot() -> None:
     fake = FakeDockerClient()
     _stranded_dep(fake)
     fake.add_container("dep.gm-recreate-old", network_mode=f"container:{OLD_ID}")
-    assert gc_recreate_leftover(fake, "dep", _logger()) is True
+    assert gc_recreate_leftover(fake, "dep", _logger()) is None
     assert ("dep.gm-recreate-old", False) in fake.removed
 
     class _RemoveRaises(FakeDockerClient):
@@ -116,13 +116,13 @@ def test_gc_removes_leftover_and_blocks_when_it_cannot() -> None:
     blocked = _RemoveRaises()
     _stranded_dep(blocked)
     blocked.add_container("dep.gm-recreate-old", network_mode=f"container:{OLD_ID}")
-    assert gc_recreate_leftover(blocked, "dep", _logger()) is False  # caller must not act
+    assert gc_recreate_leftover(blocked, "dep", _logger()) is not None  # caller must not act
 
 
 def test_gc_noop_without_leftover() -> None:
     fake = FakeDockerClient()
     _stranded_dep(fake)
-    assert gc_recreate_leftover(fake, "dep", _logger()) is True
+    assert gc_recreate_leftover(fake, "dep", _logger()) is None
     assert fake.removed == []
 
 

--- a/tests/test_remediation_branches.py
+++ b/tests/test_remediation_branches.py
@@ -60,7 +60,7 @@ def test_remediate_restart_failure_returns_false() -> None:
     fake.add_container("dep", network_mode=f"container:{GLUETUN_ID}")  # same id -> RESTART
     fake.on_exec = lambda n, c: ExecResult(1, "")
     assert remediate_dependent(fake, "dep", GLUETUN_ID, _cfg(), _logger(),
-                               sleep=lambda _s: None) is False
+                               sleep=lambda _s: None).ok is False
 
 
 # ----- TRY_RESTART escalates, recreate disabled -> fails (recovery.py:188-189) -----
@@ -69,13 +69,13 @@ def test_remediate_nameform_restart_fail_escalates_to_disabled_recreate() -> Non
     fake = _RestartRaises()
     fake.add_container("dep", network_mode="container:gluetun")  # name form -> TRY_RESTART
     assert remediate_dependent(fake, "dep", GLUETUN_ID, _cfg(auto_recreate=False),
-                               _logger(), sleep=lambda _s: None) is False
+                               _logger(), sleep=lambda _s: None).ok is False
 
 
 def test_remediate_missing_container_returns_false() -> None:
     fake = FakeDockerClient()
     assert remediate_dependent(fake, "ghost", GLUETUN_ID, _cfg(), _logger(),
-                               sleep=lambda _s: None) is False
+                               sleep=lambda _s: None).ok is False
 
 
 # ----- recreate spec-build failure (recreate.py:135-137) -----

--- a/tests/test_wedge_escalation.py
+++ b/tests/test_wedge_escalation.py
@@ -1,0 +1,301 @@
+"""Wedge escalation + retry backoff (#98).
+
+Why: observed live, twice. (1) The #76 dogfood left an unremovable parked twin
+(ZFS "dataset is busy"); the guard correctly refused remediation — and then the
+monitor drove the same doomed removal through the daemon every 30s for ~14
+hours, surfacing only a generic dependent-unhealthy alert. (2) A dependent
+stuck in "marked for removal" got the same identical-failure restart loop for
+hours, across a host reboot. These tests pin the fix: N consecutive IDENTICAL
+failures escalate to a distinct ``dependent-wedged`` alert (runbook included
+when the blocker is the parked twin) and remediation attempts back off with a
+doubling, capped interval — while probing continues every loop, so a cleared
+wedge heals promptly and a changed failure starts the count over.
+"""
+
+from __future__ import annotations
+
+import io
+import random
+from pathlib import Path
+from typing import Any
+
+from gluetun_monitor.config import Config
+from gluetun_monitor.docker_client import ExecResult
+from gluetun_monitor.logging_setup import Logger
+from gluetun_monitor.monitor import Monitor
+from gluetun_monitor.monitor_state import MonitorState
+from gluetun_monitor.recovery import remediate_dependent
+
+from .fakes import FakeDockerClient, FakeNotifier
+
+GLUETUN_ID = "c" * 64
+PARKED = "dep.gm-recreate-old"
+WEDGED_KEY = "dependent-wedged:dep"
+UNHEALTHY_KEY = "dependent-unhealthy:dep"
+
+
+class _WedgedRemove(FakeDockerClient):
+    """Remove of the parked twin raises (the live ZFS wedge) while ``blocked``."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.blocked = True
+        self.blocked_attempts = 0
+
+    def remove(self, name_or_id: str, *, volumes: bool) -> None:
+        if self.blocked and name_or_id.endswith(".gm-recreate-old"):
+            self.blocked_attempts += 1
+            raise RuntimeError(
+                'driver "zfs" failed to remove root filesystem: dataset is busy'
+            )
+        super().remove(name_or_id, volumes=volumes)
+
+
+def _monitor(
+    fake: FakeDockerClient, tmp_path: Path, **cfg: Any
+) -> tuple[Monitor, FakeNotifier, io.StringIO]:
+    (tmp_path / "sites.conf").write_text("https://a.example\n")
+    cfg.setdefault("config_file", str(tmp_path / "sites.conf"))
+    cfg.setdefault("gluetun_container", "gluetun")
+    cfg.setdefault("monitor_state_file", str(tmp_path / "state.json"))
+    cfg.setdefault("stats_file", str(tmp_path / "stats.json"))
+    cfg.setdefault("notify_state_file", str(tmp_path / "notify.json"))
+    # Discovery matches RUNNING containers only; a wedged dependent is typically
+    # stopped (replacement created but never started). In production it stays
+    # visible via the durable dependent memory (#97) — seed it the same way.
+    seed = MonitorState(str(tmp_path / "state.json"))
+    seed.record_gluetun_id(GLUETUN_ID)
+    seed.set_known_dependents({"dep"})
+    seed.save()
+    stream = io.StringIO()
+    logger = Logger(log_file=None, level="DEBUG", stream=stream)
+    notifier = FakeNotifier()
+    mon = Monitor(
+        fake, Config(**cfg), logger, rng=random.Random(0), sleep=lambda _s: None,
+        notifier=notifier,
+    )
+
+    def running_aware(name: str, cmd: list[str]) -> ExecResult:
+        info = fake.inspect(name)
+        if info is None or not info.running:
+            return ExecResult(126, "container is not running")
+        return ExecResult(0, "eth0\nlo\ntun0\n")
+
+    fake.on_exec = running_aware
+    return mon, notifier, stream
+
+
+def _wedged_stack(fake: FakeDockerClient) -> None:
+    """gluetun + a stopped dependent with an (unremovable) parked twin alongside
+    — the exact post-'remove-old failed' state from the live incident."""
+    fake.add_container("gluetun", id=GLUETUN_ID)
+    fake.add_container("dep", network_mode=f"container:{GLUETUN_ID}", running=False)
+    parked = fake.add_container(
+        PARKED, network_mode=f"container:{GLUETUN_ID}", running=False, health=None
+    )
+    parked.raw["State"]["Status"] = "dead"  # the zombie tell from the field
+
+
+# ----- remediate_dependent: the wedge is reported, not just logged -----
+
+
+def test_outcome_carries_the_wedge(tmp_path: Path) -> None:
+    fake = _WedgedRemove()
+    _wedged_stack(fake)
+    out = remediate_dependent(
+        fake, "dep", GLUETUN_ID, Config(),
+        Logger(log_file=None, level="DEBUG", stream=io.StringIO()),
+        sleep=lambda _s: None,
+    )
+    assert bool(out) is False
+    assert out.wedge is not None
+    assert out.wedge.parked_name == PARKED
+    assert out.wedge.parked_status == "dead"
+    assert "dataset is busy" in out.wedge.error
+    assert "dataset is busy" in out.detail  # the signature the monitor compares
+
+
+# ----- escalation: N identical failures → distinct alert, generic superseded -----
+
+
+def test_escalates_after_n_identical_failures(tmp_path: Path) -> None:
+    fake = _WedgedRemove()
+    _wedged_stack(fake)
+    mon, notifier, stream = _monitor(fake, tmp_path, wedge_escalate_after=3)
+
+    mon.run_once()
+    mon.run_once()
+    assert UNHEALTHY_KEY in notifier.event_keys()  # pre-threshold: generic alert
+    assert WEDGED_KEY not in notifier.event_keys()
+
+    mon.run_once()  # third identical failure → escalate
+    assert WEDGED_KEY in notifier.event_keys()
+    assert "is WEDGED" in stream.getvalue()
+    # The generic alert was superseded, NOT resolved (the problem didn't clear).
+    assert f"resolve:{UNHEALTHY_KEY}" not in notifier.event_keys()
+
+
+def test_wedged_alert_carries_error_state_and_runbook(tmp_path: Path) -> None:
+    fake = _WedgedRemove()
+    _wedged_stack(fake)
+    mon, notifier, _ = _monitor(fake, tmp_path, wedge_escalate_after=3)
+    for _ in range(3):
+        mon.run_once()
+
+    wedged = [e for e in notifier.events if e.key == WEDGED_KEY]
+    assert wedged, "escalation alert was never emitted"
+    body = wedged[0].body
+    assert "dataset is busy" in body  # the exact driver error
+    assert PARKED in body and "state: dead" in body  # inspect state of the twin
+    # The runbook: locate via mountinfo, kill only cgroup-confirmed pids, rm -f.
+    assert "/proc/*/mountinfo" in body
+    assert "cgroup" in body
+    assert f"docker rm -f {PARKED}" in body
+
+
+# ----- backoff: doomed attempts are throttled, alert stays active -----
+
+
+def test_backoff_doubles_and_caps_attempts(tmp_path: Path) -> None:
+    fake = _WedgedRemove()
+    _wedged_stack(fake)
+    # interval 30s, cap 120s → backoff caps at 4 loops.
+    mon, notifier, _ = _monitor(
+        fake, tmp_path, wedge_escalate_after=3, check_interval=30, wedge_backoff_cap=120
+    )
+    attempts_by_loop = []
+    for _ in range(16):
+        mon.run_once()
+        attempts_by_loop.append(fake.blocked_attempts)
+
+    # Loops 1-3 attempt every loop (pre-threshold); escalation at loop 3 backs
+    # off 2 loops (skip 4,5 → attempt 6), then 4 loops (skip 7-10 → attempt 11),
+    # then caps at 4 (skip 12-15 → attempt 16).
+    expected = [1, 2, 3, 3, 3, 4, 4, 4, 4, 4, 5, 5, 5, 5, 5, 6]
+    assert attempts_by_loop == expected
+    # The wedged alert is reported every loop while backing off — exactly one
+    # announce (edge-triggered), and no resolve while it holds.
+    assert notifier.event_keys().count(WEDGED_KEY) == 1
+    assert f"resolve:{WEDGED_KEY}" not in notifier.event_keys()
+
+
+# ----- the full lifecycle from the issue: wedge → operator clears → heal -----
+
+
+def test_full_wedge_lifecycle_heals_via_restart_not_second_recreate(tmp_path: Path) -> None:
+    """remove-old fails → GC blocks for N loops (replacement exists, created but
+    not started, homed on the CURRENT gluetun id) → the twin becomes removable →
+    the next attempted loop GCs it and heals the dependent via RESTART — no
+    second recreate (the observed 14-hour arc, compressed)."""
+    fake = _WedgedRemove()
+    _wedged_stack(fake)
+    mon, notifier, _ = _monitor(fake, tmp_path, wedge_escalate_after=3)
+
+    for _ in range(4):  # 3 failures (escalate at 3rd), loop 4 skipped (backoff)
+        mon.run_once()
+    assert fake.inspect(PARKED) is not None
+    assert not fake.inspect("dep").running  # type: ignore[union-attr]
+
+    fake.blocked = False  # operator clears the ZFS pin (per the alert's runbook)
+    mon.run_once()  # loop 5: still in backoff — skipped
+    mon.run_once()  # loop 6: attempt → GC removes the twin, RESTART heals
+
+    assert fake.inspect(PARKED) is None  # twin finally GC'd
+    assert fake.inspect("dep").running  # type: ignore[union-attr]
+    assert fake.created == []  # healed via restart, never a second recreate
+    assert "dep" in fake.restarted
+    # The wedged alert resolves and the recovery event fires.
+    assert f"resolve:{WEDGED_KEY}" in notifier.event_keys()
+    assert "dependent-remediated:dep" in notifier.event_keys()
+
+
+def test_wedge_clears_when_dependent_recovers_without_us(tmp_path: Path) -> None:
+    """Operator fixes everything by hand mid-backoff (twin gone, dependent up):
+    the next loop sees it healthy, drops the bookkeeping, resolves the alert."""
+    fake = _WedgedRemove()
+    _wedged_stack(fake)
+    mon, notifier, _ = _monitor(fake, tmp_path, wedge_escalate_after=3)
+    for _ in range(3):
+        mon.run_once()
+
+    fake.blocked = False
+    fake.remove(PARKED, volumes=False)
+    fake.start("dep")
+    mon.run_once()
+
+    assert f"resolve:{WEDGED_KEY}" in notifier.event_keys()
+    assert not mon._wedges  # bookkeeping dropped
+
+
+# ----- a DIFFERENT failure is a new situation, not a deeper wedge -----
+
+
+def test_changed_failure_signature_restarts_the_count(tmp_path: Path) -> None:
+    fake = _WedgedRemove()
+    _wedged_stack(fake)
+    mon, notifier, _ = _monitor(fake, tmp_path, wedge_escalate_after=3)
+    mon.run_once()
+    mon.run_once()  # two identical failures — one short of escalation
+
+    # The wedge morphs: twin now removable, but the restart starts failing
+    # differently (e.g. "marked for removal").
+    fake.blocked = False
+
+    def failing_restart(_name: str) -> None:
+        raise RuntimeError("container is marked for removal and cannot be started")
+
+    fake.restart = failing_restart  # type: ignore[method-assign]
+    mon.run_once()  # 3rd failure overall — but a NEW signature: no escalation yet
+    assert WEDGED_KEY not in notifier.event_keys()
+    mon.run_once()
+    mon.run_once()  # 3rd IDENTICAL new-signature failure → now escalate
+    wedged = [e for e in notifier.events if e.key == WEDGED_KEY]
+    assert wedged and "marked for removal" in wedged[0].body
+
+
+# ----- generic identical failures (no parked twin) escalate too -----
+
+
+def test_restart_500_loop_escalates_without_a_parked_twin(tmp_path: Path) -> None:
+    """The prowlarr field case: restart fails identically every loop ('marked
+    for removal') with no parked twin involved — still escalates + backs off."""
+    fake = FakeDockerClient()
+    fake.add_container("gluetun", id=GLUETUN_ID)
+    fake.add_container("dep", network_mode=f"container:{GLUETUN_ID}", running=False)
+
+    def failing_restart(_name: str) -> None:
+        raise RuntimeError(
+            "500 Server Error: container is marked for removal and cannot be started"
+        )
+
+    fake.restart = failing_restart  # type: ignore[method-assign]
+    mon, notifier, _ = _monitor(fake, tmp_path, wedge_escalate_after=3)
+    for _ in range(4):
+        mon.run_once()
+
+    wedged = [e for e in notifier.events if e.key == WEDGED_KEY]
+    assert wedged and "marked for removal" in wedged[0].body
+    assert "Runbook" not in wedged[0].body  # twin runbook only when there IS a twin
+
+
+# ----- a monitor restart mid-wedge neither re-announces nor falsely resolves -----
+
+
+def test_monitor_restart_mid_wedge_stays_escalated(tmp_path: Path) -> None:
+    fake = _WedgedRemove()
+    _wedged_stack(fake)
+    # apprise_urls set → the alert lifecycle persists to the notify sidecar.
+    cfg: dict[str, Any] = {"apprise_urls": ("json://localhost",), "wedge_escalate_after": 3}
+    mon_a, notifier_a, _ = _monitor(fake, tmp_path, **cfg)
+    for _ in range(3):
+        mon_a.run_once()
+    assert WEDGED_KEY in notifier_a.event_keys()
+
+    # Fresh monitor instance, same sidecars (in-memory wedge bookkeeping lost).
+    mon_b, notifier_b, _ = _monitor(fake, tmp_path, **cfg)
+    mon_b.run_once()
+
+    # Still escalated: no re-announce, no false resolve, no demotion to generic.
+    assert WEDGED_KEY not in notifier_b.event_keys()
+    assert f"resolve:{WEDGED_KEY}" not in notifier_b.event_keys()
+    assert UNHEALTHY_KEY not in notifier_b.event_keys()


### PR DESCRIPTION
Closes #98.

## Problem

A remediation failure that **cannot** self-heal — canonically an unremovable parked twin (`dataset is busy`: the force-killed container's process tree survived and pinned the mount) — got exactly the same treatment as a transient one: a generic `dependent-unhealthy` alert and a fresh attempt every loop. Observed live twice: a doomed `zfs destroy` driven through the daemon every 30s for **~14 hours**, and an identical restart-500 loop (`marked for removal`) that persisted **across a host reboot** (the flag is in the on-disk container config; only the pin dies with the reboot).

```mermaid
stateDiagram-v2
    [*] --> Failing: probe fails
    Failing --> Attempt: every loop, forever
    Attempt --> Failing: identical error<br/>(generic dependent-unhealthy alert)
    Attempt --> Healed: blocker cleared by operator
    Healed --> [*]
    note right of Attempt
        1437 attempts / ~14h observed:
        indistinguishable from a transient,
        nothing escalates, nothing backs off
    end note
```

## Fix

Track the failure **signature** (the exact error) per dependent. The same failure repeating `WEDGE_ESCALATE_AFTER` consecutive times (default 3) means the state is operator-only — escalate and back off. A **different** failure restarts the count: a new error is a new situation, not a deeper wedge.

```mermaid
stateDiagram-v2
    [*] --> Failing: probe fails
    Failing --> Attempt: every loop
    Attempt --> Failing: error CHANGED → count restarts
    Attempt --> Wedged: same error × N (default 3)
    Wedged --> Backoff: dependent-WEDGED alert<br/>supersedes generic (no false resolve)<br/>runbook + twin inspect state in body
    Backoff --> Attempt2: retry after 2→4→…loops<br/>(cap WEDGE_BACKOFF_CAP, default 600s)
    Attempt2 --> Backoff: still the same error<br/>(alert stays active, delay doubles)
    Backoff --> Healed: probe turns healthy<br/>(operator fixed it directly)
    Attempt2 --> Healed: blocker cleared → GC + RESTART<br/>(no second recreate)
    Healed --> [*]: wedged alert resolves,<br/>recovery event fires
    note right of Backoff
        probing continues EVERY loop —
        only the doomed remediation
        attempt is throttled
    end note
```

- **Distinct, actionable alert.** `dependent WEDGED: <name>` (attention tier) carries the exact driver error, the parked twin's inspect state (`dead` = the zombie tell), and the runbook: locate pin holders via `/proc/*/mountinfo`, kill **only** pids whose `/proc/<pid>/cgroup` contains the container id (host-ns processes match mountinfo innocently), then `docker rm -f` — never raw storage removal. The alert alone is enough to act on; the monitor finishes the heal itself.
- **Supersede, don't lie.** The generic `dependent-unhealthy` alert is retired silently at escalation (new `AlertState.supersede`) — no false "resolved", no "no longer monitored".
- **Capped doubling backoff.** After escalation, attempts run every 2→4→8… loops, capped at `WEDGE_BACKOFF_CAP` seconds (default 600; `0` = escalate but keep retrying every loop). Probes never stop, so recovery-without-us is noticed the same loop and resolves the alert.
- **Restart-safe.** The wedged alert persists in the notify sidecar; a restarted monitor sees it via `AlertState.is_active` and stays escalated — no re-announce, no false resolve, no demotion to the generic alert.
- **Plumbing:** `remediate_dependent` returns a `RemediationOutcome` (truthiness == success) carrying the failure signature; `gc_recreate_leftover` returns the `Wedge` (parked name, driver error, inspect status) instead of a bare `False`.

## Tests (red-verified against pre-fix code)

All 9 new tests fail before the fix. Highlights:
- **The full observed arc, compressed** (issue ask 3): remove-old fails → GC blocks with the replacement created-not-started on the *current* gluetun id → twin becomes removable → next attempted loop GCs it and heals via **RESTART** (asserts no second recreate ever happens).
- Backoff schedule pinned attempt-by-attempt over 16 loops (1,2,3 then 6, 11, 16 with cap): exactly one announce, no resolve while wedged.
- Alert body carries the driver error, `state: dead`, and the mountinfo/cgroup/`docker rm -f` runbook.
- The prowlarr field case: identical restart-500s with **no parked twin** still escalate (runbook section only appears when there is a twin).
- Changed signature restarts the count; recovery-without-us resolves and drops bookkeeping; monitor restart mid-wedge stays escalated silently.

## Docs

README: new `WEDGE_ESCALATE_AFTER` / `WEDGE_BACKOFF_CAP` rows, a "Wedged dependents" section under Notifications, and the deployment note from the issue: in log-only mode every attention-tier alert is just a log line — if the monitor should summon you when it's stuck, configure `APPRISE_URLS`.

## Field evidence

See the issue comments: 4+ dataset-busy zombies in one day, the reboot-survival of `RemovalInProgress`, and the cgroup-scoped unpin runbook this alert now ships.
