### PR TITLE
fix(monitor): hold gluetun-unrecovered until observed recovery (#106)

### DIFF
--- a/README.md
+++ b/README.md
@@ -704,6 +704,12 @@ retired, not recovered). This state persists to `NOTIFY_STATE_FILE`,
 so restarting the monitor neither re-spams still-broken problems nor misses a
 resolve (ADR-0012).
 
+A resolve means the condition was **observed** to clear, not that a counter
+momentarily dipped. In particular the "gluetun cannot recover" alert stays active
+until the sites that triggered it actually pass again — a site that is unreachable
+through an otherwise-healthy tunnel (e.g. geo-blocked from the current exit) keeps
+the alert firing once, without a false "recovered" every restart cycle.
+
 ### Wedged dependents — escalation with the runbook attached
 
 Most remediation failures are transient and the next loop's retry clears them. But

--- a/gluetun_monitor/monitor.py
+++ b/gluetun_monitor/monitor.py
@@ -144,6 +144,10 @@ class Monitor:
         # Persistent per-site stats (ADR-0008). Injectable for tests.
         self.stats = stats if stats is not None else SiteStatsStore(config.stats_file)
         self._advised_site: str | None = None  # dedup the flaky-site advisory
+        # Sites that triggered an active gluetun-unrecovered alert (#106). Held so
+        # the alert resolves only on OBSERVED recovery, not on the mechanical
+        # post-restart counter reset that makes the next loop look sub-threshold.
+        self._unrecovered_sites: set[str] = set()
         self.site_failures = Counter()
         self.dependent_failures = Counter()
         self._last_sites: set[str] | None = None
@@ -856,6 +860,13 @@ class Monitor:
             # fresh announce on the next one. Evaluated every loop, the alert
             # stays active until the dominance window genuinely clears.
             self._emit_advisory()
+            # #106: a failed recovery zeroes every site counter, so the very next
+            # loop is sub-threshold ("not breached") even while the triggering site
+            # is still down. That mechanical dip used to auto-resolve an active
+            # gluetun-unrecovered alert — a false "recovered". Hold it until the
+            # sites that triggered it have OBSERVABLY cleared this loop.
+            failing_now = {url for url in sites if self.site_failures.get(url) > 0}
+            self._reconcile_unrecovered(failing_now)
             # Gluetun is up — proceed straight to the dependent phase (the #20 fix:
             # dependents are checked every loop, not only after a gluetun failure).
             self.run_dependent_phase(gluetun.id, sites)
@@ -897,6 +908,7 @@ class Monitor:
                 f"Was failing on {', '.join(breached)}; restarted but it did not come back "
                 f"healthy — manual intervention may be required.",
             )
+            self._unrecovered_sites = set(breached)  # #106: hold until these clear
             self.alerts.mark_incomplete()  # dependents were never evaluated (#74)
             return
 
@@ -915,6 +927,7 @@ class Monitor:
                 f"Restarted {self.config.gluetun_container} but it's still failing: "
                 f"{', '.join(reverify_breached)} — manual intervention may be required.",
             )
+            self._unrecovered_sites = set(reverify_breached)  # #106: hold until these clear
             self.site_failures.reset_all()
             self.alerts.mark_incomplete()  # dependents left untouched = unevaluated (#74)
             return
@@ -926,11 +939,47 @@ class Monitor:
             f"Was failing on {', '.join(breached)}; restarted and connectivity is healthy again.",
             key="gluetun-recovered",
         )
+        self._unrecovered_sites = set()  # #106: observed recovery — let the alert resolve
         self.site_failures.reset_all()
         # Re-inspect: a restart keeps the same id, but be robust if it was recreated.
         gluetun = self.client.inspect(self.config.gluetun_container) or gluetun
         self.run_dependent_phase(gluetun.id, sites)
         self._save_stats()
+
+    def _reconcile_unrecovered(self, failing_now: set[str]) -> None:
+        """Hold or resolve the ``gluetun-unrecovered`` alert from OBSERVED recovery
+        rather than the mechanical post-restart counter reset (#106).
+
+        The failed-recovery path zeroes every site counter, so the loop right after
+        it is always sub-threshold — which let :class:`AlertState` auto-resolve the
+        alert (a false "recovered") while the triggering site was still failing.
+        Called on every "not breached" loop: re-report the alert while its
+        triggering sites are still failing so it stays active, and let it resolve
+        only when they have genuinely cleared. Symmetric with ``_emit_advisory``,
+        which #75 hardened the same way.
+        """
+        if not self.alerts.is_active("gluetun-unrecovered"):
+            self._unrecovered_sites = set()
+            return
+        # Restart-safe: the alert can outlive the process (persisted sidecar), but
+        # the in-RAM triggering set does not. If it survived a monitor restart,
+        # adopt whatever is failing right now as the condition to hold on — a
+        # genuinely clean loop still resolves it below.
+        if not self._unrecovered_sites:
+            self._unrecovered_sites = set(failing_now)
+        remaining = self._unrecovered_sites & failing_now
+        if remaining:
+            self._problem(
+                "gluetun-unrecovered",
+                "attention",
+                f"gluetun cannot recover ({self.config.gluetun_container})",
+                f"Restarted {self.config.gluetun_container} but it's still failing: "
+                f"{', '.join(sorted(remaining))} — manual intervention may be required.",
+            )
+        else:
+            # The sites that triggered it are passing again → observed recovery.
+            # Not re-reporting lets the lifecycle emit the (true) resolve.
+            self._unrecovered_sites = set()
 
     def _emit_advisory(self) -> None:
         """Surface a flaky-site advisory when one site dominates recent restarts.

--- a/tests/test_unrecovered_flap.py
+++ b/tests/test_unrecovered_flap.py
@@ -1,0 +1,138 @@
+"""#106: the gluetun-unrecovered alert must not false-resolve every restart cycle.
+
+A site that is unreachable through an otherwise-healthy tunnel (e.g. a geo-blocked
+endpoint) fails every loop. With FAIL_THRESHOLD>1 the sequence is:
+
+    breach (N/N) -> restart -> re-verify still fails -> report "unrecovered" and
+    reset_all() -> next loop the site is back at 1/N (sub-threshold) -> "not breached"
+
+Pre-fix, that mechanical sub-threshold loop let AlertState auto-resolve the active
+alert — a false "recovered" — then the next breach re-announced it, storming the
+operator with new -> resolved -> new every couple of loops. The alert must instead
+stay active until the sites that triggered it OBSERVABLY clear (mirrors the #75
+advisory hardening).
+"""
+
+from __future__ import annotations
+
+import io
+import random
+from pathlib import Path
+
+from gluetun_monitor.config import Config
+from gluetun_monitor.docker_client import ExecResult
+from gluetun_monitor.logging_setup import Logger
+from gluetun_monitor.monitor import Monitor
+from gluetun_monitor.site_stats import SiteStatsStore
+
+from .fakes import FakeDockerClient, FakeNotifier
+
+GLUETUN_ID = "a" * 64
+BLOCKED = "https://blocked.example"
+GOOD = "https://1.1.1.1"
+
+
+def _monitor(tmp_path: Path, notifier: FakeNotifier, state: dict, **cfg_over):
+    """A monitor over one persistently-blocked site + one healthy site.
+
+    ``state["block"]`` toggles whether the blocked site fails this loop.
+    """
+    conf = tmp_path / "sites.conf"
+    conf.write_text(f"{GOOD}\n{BLOCKED}\n")
+
+    fake = FakeDockerClient()
+    fake.add_container("gluetun", id=GLUETUN_ID, health="healthy")
+
+    def handler(name: str, cmd: list[str]) -> ExecResult:
+        if cmd and cmd[0] == "nslookup":
+            return ExecResult(0, "")  # DNS-stability probe passes
+        if BLOCKED in cmd and state["block"]:
+            return ExecResult(4, "")  # blocked site times out
+        return ExecResult(0, "")
+
+    fake.on_exec = handler
+
+    cfg = Config(
+        config_file=str(conf),
+        gluetun_container="gluetun",
+        fail_threshold=2,             # so the post-restart reset yields a sub-threshold loop
+        dns_wait_timeout=2,
+        advisory_min_restarts=1000,   # keep the advisory out of these assertions
+        **cfg_over,
+    )
+    return Monitor(
+        fake, cfg, Logger(log_file=None, stream=io.StringIO()),
+        rng=random.Random(0), sleep=lambda _s: None,
+        stats=SiteStatsStore(None), notifier=notifier,
+    )
+
+
+def test_unrecovered_does_not_false_resolve_while_site_still_down(tmp_path: Path) -> None:
+    """The core #106 regression (RED pre-fix): one announce, never a false resolve."""
+    notifier = FakeNotifier()
+    state = {"block": True}
+    mon = _monitor(tmp_path, notifier, state)
+
+    # Six loops of the blocked site failing: breach/restart cycles interleaved with
+    # the sub-threshold "not breached" loops that used to trigger the false resolve.
+    for _ in range(6):
+        mon.run_once()
+
+    keys = notifier.event_keys()
+    # Announced exactly once, and never (falsely) resolved while the site is down.
+    assert keys.count("gluetun-unrecovered") == 1, keys
+    assert "resolve:gluetun-unrecovered" not in keys, keys
+
+
+def test_unrecovered_resolves_once_on_genuine_recovery(tmp_path: Path) -> None:
+    """The fix must not swallow a TRUE resolve: once the site clears, resolve once."""
+    notifier = FakeNotifier()
+    state = {"block": True}
+    mon = _monitor(tmp_path, notifier, state)
+
+    for _ in range(4):
+        mon.run_once()
+    assert notifier.event_keys().count("gluetun-unrecovered") == 1
+
+    # The blocked site starts responding again — genuine recovery.
+    state["block"] = False
+    mon.run_once()  # not breached, blocked site now passes -> observed recovery
+    mon.run_once()  # stays resolved, no re-flap
+
+    keys = notifier.event_keys()
+    assert keys.count("resolve:gluetun-unrecovered") == 1, keys
+    assert keys.count("gluetun-unrecovered") == 1, keys  # one episode, one announce
+
+
+def test_unrecovered_hold_survives_monitor_restart(tmp_path: Path) -> None:
+    """#106 restart-safety: a monitor restart loses the in-RAM triggering set, but
+    the alert survives in the persisted sidecar. The next sub-threshold loop must
+    still HOLD it (adopt the currently-failing sites), not false-resolve it."""
+    state = {"block": True}
+    notify_file = str(tmp_path / "notify-state.json")
+
+    # Monitor A establishes the active unrecovered alert and persists it.
+    mon_a = _monitor(
+        tmp_path, FakeNotifier(), state,
+        apprise_urls=("json://localhost",),  # enables AlertState persistence
+        notify_state_file=notify_file,
+    )
+    mon_a.run_once()  # blocked at 1/2
+    mon_a.run_once()  # blocked at 2/2 -> restart -> re-verify fails -> unrecovered
+    assert mon_a.alerts.is_active("gluetun-unrecovered")
+
+    # Monitor B is a fresh process sharing the sidecar: it reloads the active alert
+    # but starts with an empty _unrecovered_sites (the RAM set didn't persist).
+    notifier_b = FakeNotifier()
+    mon_b = _monitor(
+        tmp_path, notifier_b, state,
+        apprise_urls=("json://localhost",),
+        notify_state_file=notify_file,
+    )
+    assert mon_b.alerts.is_active("gluetun-unrecovered")
+    assert mon_b._unrecovered_sites == set()  # memory lost across the "restart"
+
+    mon_b.run_once()  # blocked at 1/2 -> not breached -> must HOLD, not resolve
+
+    assert "resolve:gluetun-unrecovered" not in notifier_b.event_keys()
+    assert mon_b.alerts.is_active("gluetun-unrecovered")


### PR DESCRIPTION
Fixes #106.

## Problem

The `gluetun-unrecovered` attention-tier alert false-resolves on every restart
cycle when a site is unreachable through an otherwise-healthy tunnel (e.g. an
endpoint geo-blocked from the current exit). The operator gets a
`new → resolved → new → resolved …` storm every ~2 loops, and each "resolved" is a
false "recovered" — the condition never cleared.

Root cause: the failed-recovery path reports the alert and then `reset_all()`s every
site counter, so the loop immediately after is always sub-threshold ("not breached").
`AlertState` auto-resolves any active alert not re-reported that loop, so the alert
resolves on the mechanical counter dip — while the triggering site is still failing.

The flaky-site advisory dodges this because #75 made it re-evaluate every loop; the
`gluetun-unrecovered` alert never got the same treatment. Same bug class, different
alert.

### Before

```mermaid
stateDiagram-v2
    [*] --> Healthy
    Healthy --> Breach: blocked site hits FAIL_THRESHOLD
    Breach --> ReVerifyFail: restart, re-check still fails
    ReVerifyFail --> ResetCounters: report alert + site_failures.reset_all()
    ResetCounters --> SubThreshold: next loop, site at 1/N (below threshold)
    SubThreshold --> FalseResolve: not breached, alert not re-reported → AlertState resolves
    FalseResolve --> Breach: site climbs back to N/N → re-announce
    note right of FalseResolve
      FALSE "recovered" page —
      condition never cleared
    end note
```

### After

```mermaid
stateDiagram-v2
    [*] --> Healthy
    Healthy --> Breach: blocked site hits FAIL_THRESHOLD
    Breach --> ReVerifyFail: restart, re-check still fails
    ReVerifyFail --> Held: report alert, remember triggering sites
    Held --> SubThreshold: next loop, site at 1/N (below threshold)
    SubThreshold --> Reconcile: triggering site still failing?
    Reconcile --> Held: yes → re-report, alert stays active (no event)
    Reconcile --> TrueResolve: no → sites cleared → resolve once
    Held --> Breach: site climbs back to N/N (already active, no re-announce)
```

## Fix

Hold `gluetun-unrecovered` from **observed** recovery instead of the mechanical
counter reset:

- Record the sites that triggered the alert (`_unrecovered_sites`).
- On every "not breached" loop, `_reconcile_unrecovered()` re-reports the alert
  while any of those sites is still failing this loop, so `AlertState` keeps it
  active; it resolves only when they have genuinely cleared.
- **Restart-safe**: the alert can outlive the process in the persisted sidecar
  while the in-RAM triggering set does not. If it survived a restart (still
  `is_active`) but the set is empty, adopt the currently-failing sites — a
  genuinely clean loop still resolves it.

This mirrors the #75 advisory hardening, and aligns the alert lifecycle with what
the stats layer already knows (the restart-outcome / dominance history that
correctly stays "chronic" the whole time).

## Tests

`tests/test_unrecovered_flap.py` — all three **red pre-fix**, green post-fix:

1. **The flap** — a persistently-blocked site over 6 loops: announced exactly
   once, never a `resolve:gluetun-unrecovered`.
2. **True resolve preserved** — when the site genuinely clears, resolve fires
   exactly once (the fix doesn't swallow real recoveries).
3. **Restart-safe hold** — a second monitor sharing the persisted sidecar reloads
   the active alert with an empty in-RAM set; the next sub-threshold loop holds it
   rather than false-resolving.

Full suite + ruff + mypy green.

## Note

The deeper trigger — a permanently-unreachable site being treated as a tunnel-health
signal at all — is tracked separately (advisory-only per-site flag). This PR fixes
the alert-lifecycle false-resolve independently. Broader notification state-machine
test coverage is #107.
