### PR TITLE
fix: watchdog robustness hardening from adversarial review (2 HIGH + 3 MED)

### DIFF
--- a/docs/adr/0012-alert-lifecycle.md
+++ b/docs/adr/0012-alert-lifecycle.md
@@ -78,3 +78,13 @@ edge/repeat/resolve logic is here, which keeps both pieces simple and testable.
 - **In-memory only (no sidecar).** Rejected: a monitor restart would re-announce
   every active problem and lose pending resolves — common, since the monitor is
   itself a container that gets updated/restarted.
+
+## Amendments
+- **#106 / #112 — resolve only on *observed* recovery, never a mechanical artifact.**
+  The edge-triggered lifecycle above resolves an active alert when it isn't reported
+  a loop it *could* be — but two paths could go silent without the subject actually
+  clearing. The `gluetun-unrecovered` alert is now held while its triggering sites
+  still fail, rather than false-resolving on the post-restart counter reset (#106);
+  and a dependent the loop couldn't evaluate holds its alert via `AlertState.hold`
+  instead of resolving it (#112). Both apply the incomplete-loop principle
+  (silence ≠ recovery) at per-subject granularity.

--- a/gluetun_monitor/alert_state.py
+++ b/gluetun_monitor/alert_state.py
@@ -91,6 +91,19 @@ class AlertState:
         """Declare that ``key``'s subject is no longer monitored (silent clear)."""
         self._forgotten.add(key)
 
+    def hold(self, key: str) -> None:
+        """Re-assert an already-active alert *as-is* so this loop doesn't resolve it.
+
+        For a subject the loop couldn't evaluate (e.g. a dependent that came back
+        un-probeable): the problem hasn't cleared, we just didn't get to check it, so
+        the alert must stay active rather than false-resolve. No-op if ``key`` isn't
+        active. Cheaper/more precise than ``mark_incomplete`` when only one subject
+        is unevaluated — it holds that alert, not every active alert.
+        """
+        active = self._active.get(key)
+        if active is not None:
+            self._reported[key] = (active.tier, active.title, active.body)
+
     def is_active(self, key: str) -> bool:
         """Whether ``key`` is currently an active (announced, unresolved) alert.
 
@@ -187,8 +200,12 @@ class AlertState:
                     since_loop=int(rec["since_loop"]),
                     last_notified_loop=int(rec["last_notified_loop"]),
                 )
-        except (OSError, ValueError, KeyError, TypeError):
+        except (OSError, ValueError, KeyError, TypeError, AttributeError):
             # Corrupt/missing sidecar: start clean rather than crash the watchdog.
+            # AttributeError covers a well-formed-JSON-but-not-an-object sidecar
+            # (null / [] / 5 / "str"), whose .get()/.items() would otherwise escape
+            # this handler and take the monitor down at startup — violating the
+            # tenet that notifications must never affect monitoring.
             self._loop = 0
             self._active = {}
 

--- a/gluetun_monitor/alert_state.py
+++ b/gluetun_monitor/alert_state.py
@@ -129,6 +129,12 @@ class AlertState:
         """Diff this loop's reported problems against the persisted active set."""
         out: list[NotifyEvent] = []
 
+        # A forget wins over a same-loop report: if a subject was declared no-longer-
+        # monitored, retire it even if another path re-reported it this loop (e.g. a
+        # removed-but-still-dominant flaky site whose restarts haven't aged out).
+        for key in self._forgotten:
+            self._reported.pop(key, None)
+
         for key, (tier, title, body) in self._reported.items():
             active = self._active.get(key)
             if active is None:

--- a/gluetun_monitor/cli.py
+++ b/gluetun_monitor/cli.py
@@ -278,6 +278,14 @@ def main(argv: list[str] | None = None) -> int:
     # can alert too; NullNotifier (no-op) unless APPRISE_URLS is configured.
     notifier = build_notifier(config, logger)
 
+    # The diagnostic sub-commands below run before the fatal-config gate, so a
+    # malformed env would otherwise be silently substituted with defaults and the
+    # output judged against the wrong values. Surface the errors first.
+    if config.errors and (args.notify_test or args.suggest_tunables):
+        for err in config.errors:
+            logger.warn(err)
+        logger.warn("Config has errors (above); diagnostic output may use defaults.")
+
     if args.notify_test:
         return _run_notify_test(config, notifier, logger)
 

--- a/gluetun_monitor/config.py
+++ b/gluetun_monitor/config.py
@@ -10,6 +10,8 @@ from __future__ import annotations
 import os
 from dataclasses import dataclass
 
+from .sites import MAX_URL_TIMEOUT, MAX_URL_TRIES
+
 _TRUE_VALUES = {"1", "true", "yes", "on"}
 _FALSE_VALUES = {"0", "false", "no", "off"}
 _VALID_LOG_LEVELS = {"DEBUG", "INFO", "WARN", "WARNING", "ERROR"}
@@ -233,8 +235,11 @@ class Config:
             config_file=os.environ.get("CONFIG_FILE", "/config/sites.conf"),
             log_file=os.environ.get("LOG_FILE", "/logs/gluetun-monitor.log"),
             check_interval=_env_int("CHECK_INTERVAL", 30, errors, minimum=1),
-            timeout=_env_int("TIMEOUT", 10, errors, minimum=1),
-            wget_tries=_env_int("WGET_TRIES", 1, errors, minimum=1),
+            # Cap the globals like the per-URL overrides (#77): both feed the same
+            # worst-case transport sizing, so an absurd global (TIMEOUT=100000) would
+            # otherwise stall every loop for hours. Fatal-at-startup, not silent.
+            timeout=_env_int("TIMEOUT", 10, errors, minimum=1, maximum=MAX_URL_TIMEOUT),
+            wget_tries=_env_int("WGET_TRIES", 1, errors, minimum=1, maximum=MAX_URL_TRIES),
             fail_threshold=fail_threshold,
             gluetun_container=os.environ.get("GLUETUN_CONTAINER", "gluetun"),
             healthy_wait_timeout=_env_int("HEALTHY_WAIT_TIMEOUT", 120, errors, minimum=1),

--- a/gluetun_monitor/monitor.py
+++ b/gluetun_monitor/monitor.py
@@ -388,7 +388,18 @@ class Monitor:
             # target (TRY_RESTART) is left alone: we can't prove a strand there and
             # must not churn a healthy container (Tenet 3). The id comparison is
             # stable (no flap), so unlike the interface path it needs no re-check.
-            info = self.client.inspect(dep)
+            try:
+                info = self.client.inspect(dep)
+            except Exception as exc:
+                # A transient Docker error (socket blip, APIError) on this ONE
+                # dependent must not abort the whole fan-out and skip every other
+                # dependent's remediation this loop. Skip it conservatively: report
+                # it un-evaluated (running so it isn't remediated as "not running";
+                # viability None so its alert is held, not resolved) and retry next
+                # loop rather than churn a container we couldn't inspect (Tenet 3).
+                self.log.debug(f"[dependent:{dep}] inspect failed ({exc}); skipped this loop")
+                return DependentProbe(dep, InterfaceStatus.UNKNOWN, True, None,
+                                      "inspect unavailable (transient)", interfaces=ifs)
             running = bool(info and info.running)
             if (
                 info is not None
@@ -570,6 +581,9 @@ class Monitor:
         # (which interfaces / can it route out), THEN the L7 viability result —
         # so the logs show the path was validated before the DNS/connect test.
         to_remediate: list[tuple[str, str]] = []
+        # Dependents the loop could NOT evaluate this cycle (link/DNS couldn't tell):
+        # an active alert for them must be HELD, not resolved, and their wedge kept.
+        unevaluated: set[str] = set()
         for probe in probes:
             dep = probe.name
             tag = f"dependent:{dep}"  # role + name, mirrors "[gateway:<name>]"
@@ -582,6 +596,8 @@ class Monitor:
                 self.log.debug(f"[{tag}] {probe.reason} (running={probe.running})")
                 if not probe.running:
                     to_remediate.append((dep, "not running (link check unavailable)"))
+                else:
+                    unevaluated.add(dep)  # running but interfaces unreadable — not judged
                 continue
             if probe.viability_ok is None:
                 if probe.dns_unvalidated:
@@ -594,6 +610,7 @@ class Monitor:
                         self.log.debug(f"[{tag}] reach ?: {probe.reason}")
                 else:
                     self.log.debug(f"[{tag}] reach skip: {probe.reason}")
+                unevaluated.add(dep)  # viability couldn't be determined — not judged
                 continue  # not tested -> no counter change
             # A validated result (ok or broken): re-arm the unvalidated warning.
             self._warned_dns_unvalidated.discard(dep)
@@ -621,11 +638,18 @@ class Monitor:
         else:
             self.log.info(f"dependents: {healthy}/{len(probes)} ok")
 
+        # A dependent the loop couldn't evaluate wasn't proven healthy — hold any
+        # active alert so it doesn't false-resolve mid-incident (e.g. all sites went
+        # advisory → empty pool, or the container lost its DNS tool), and keep its
+        # wedge track. Only a dependent seen genuinely healthy drops its bookkeeping.
+        for dep in unevaluated:
+            self.alerts.hold(f"dependent-unhealthy:{dep}")
+            self.alerts.hold(f"dependent-wedged:{dep}")
         # A dependent that came back healthy WITHOUT our help (e.g. the operator
         # cleared the wedge and it recovered) drops its failure bookkeeping; its
         # wedged alert stops being reported, so the lifecycle resolves it.
         failing = {dep for dep, _ in to_remediate}
-        for dep in [d for d in self._wedges if d not in failing]:
+        for dep in [d for d in self._wedges if d not in failing and d not in unevaluated]:
             del self._wedges[dep]
 
         for dep, reason in to_remediate:

--- a/gluetun_monitor/monitor.py
+++ b/gluetun_monitor/monitor.py
@@ -508,9 +508,10 @@ class Monitor:
         with self._rng_lock:
             url = self._rng.choice(candidates)
         host = hostname_of(url)
-        return host, validate_dns(
-            self.client, dep, url, host, self.config.timeout, self.config.wget_tries
-        )
+        # Honor the confirm URL's own per-URL |timeout=/|tries= like every other
+        # probe (#60/#77), not the globals — a slow site set specifically for this
+        # URL must not be clipped on the confirm path.
+        return host, validate_dns(self.client, dep, url, host, *self._probe_knobs(url))
 
     def _resolve_dependents(self) -> list[str]:
         """Current dependent set: discovery (or manual list) unioned with the
@@ -731,6 +732,11 @@ class Monitor:
         # Doubling backoff per failed attempt, in loops, capped. cap=0 disables
         # the backoff (attempt every loop) but keeps the escalated alert.
         cap_loops = self.config.wedge_backoff_cap // max(1, self.config.check_interval)
+        # A positive-but-small cap (< CHECK_INTERVAL) floors to 0 loops, which the
+        # code below reads as "backoff disabled" — the opposite of intent. Keep any
+        # positive cap throttling at >= 1 loop; only cap == 0 means disabled.
+        if self.config.wedge_backoff_cap > 0:
+            cap_loops = max(1, cap_loops)
         track.backoff_loops = (
             min(max(2, track.backoff_loops * 2), cap_loops) if cap_loops > 0 else 0
         )
@@ -1103,6 +1109,10 @@ class Monitor:
         if gluetun_info is not None:
             self.mstate.record_gluetun_id(gluetun_info.id)
         self._scan_stranded_orphans(gluetun_info.id if gluetun_info is not None else None)
+        # Mirror any startup-adopted orphan into durable memory BEFORE this save
+        # (matching the loop path), so a crash right after startup doesn't rely on
+        # re-discovery to remember it.
+        self.mstate.set_known_dependents(self._known_dependents)
         self.mstate.save()
         startup = get_endpoint_info(self.client, self.config.gluetun_container)
         self.log.endpoint(startup.format("STARTUP", "Monitor starting"))

--- a/gluetun_monitor/recreate.py
+++ b/gluetun_monitor/recreate.py
@@ -226,8 +226,14 @@ def sweep_recreate_leftovers(client: DockerClient, logger: Logger) -> None:
     create), the parked container IS the workload — rename it back. If the real
     name exists (replacement was created), the parked one is condemned — remove
     it (volumes preserved; they belong to the replacement now).
+
+    Scans ALL containers, not just running ones: a dependent stranded by a gluetun
+    recreate is usually driven *exited* by its restart policy, so the parked twin
+    from an interrupted recreate of it is Exited too — a running-only scan would
+    miss it and leave the dependent silently down. The restore/condemn decision
+    keys off name existence, not run state, so including exited twins is safe.
     """
-    for cid in client.list_running_ids():
+    for cid in client.list_all_ids():
         info = client.inspect(cid)
         if info is None or not info.name.endswith(_OLD_SUFFIX):
             continue

--- a/gluetun_monitor/site_stats.py
+++ b/gluetun_monitor/site_stats.py
@@ -192,7 +192,7 @@ class SiteStatsStore:
             st.current_fail_streak = 0
             st.last_success = now
             st.recent_latencies.append(int(duration_ms))
-            if len(st.recent_latencies) > self._latency_max:
+            if self._latency_max and len(st.recent_latencies) > self._latency_max:
                 del st.recent_latencies[: -self._latency_max]
             st.lifetime_latency.add(int(duration_ms))  # all-time percentiles
         else:
@@ -210,7 +210,7 @@ class SiteStatsStore:
         now = self._clock()
         self._stat(site).restarts_triggered += 1
         self.recent_restarts.append({"ts": now, "site": site})
-        if len(self.recent_restarts) > self._recent_max:
+        if self._recent_max and len(self.recent_restarts) > self._recent_max:
             del self.recent_restarts[: -self._recent_max]
 
     def record_loop(self) -> None:
@@ -274,8 +274,8 @@ class SiteStatsStore:
             r for r in self.recent_restarts
             if isinstance(r.get("ts"), int | float) and float(r["ts"]) >= cutoff  # type: ignore[arg-type]
         ]
-        if len(recent) < min_restarts:
-            return None
+        if not recent or len(recent) < min_restarts:
+            return None  # `not recent` also guards most_common([]) if min_restarts<=0
         counts = Counter(str(r["site"]) for r in recent)
         site, top = counts.most_common(1)[0]
         if top / len(recent) >= dominance:

--- a/tests/test_alert_state.py
+++ b/tests/test_alert_state.py
@@ -173,3 +173,20 @@ def test_non_object_sidecar_starts_clean(tmp_path: Path) -> None:
         s = AlertState(str(path), logger=_log(), repeat_interval=0)
         s.begin_loop()
         assert s.active_count() == 0  # degraded to empty, no crash
+
+
+def test_forget_wins_over_same_loop_report(tmp_path: Path) -> None:
+    """A forget must retire an alert even if another path re-reported it the same
+    loop (review finding: removed-but-still-dominant flaky site)."""
+    s = AlertState(None, logger=_log(), repeat_interval=0)
+    s.begin_loop()
+    s.report("advisory:x", "attention", "flaky x", "b")
+    s.events()  # announced -> active
+    assert s.is_active("advisory:x")
+
+    s.begin_loop()
+    s.report("advisory:x", "attention", "flaky x", "b")  # re-reported this loop...
+    s.forget("advisory:x")                                # ...but also forgotten
+    ev = s.events()
+    assert not s.is_active("advisory:x")                          # retired, not held active
+    assert any(e.key == "deprecated:advisory:x" for e in ev)     # "no longer monitored"

--- a/tests/test_alert_state.py
+++ b/tests/test_alert_state.py
@@ -162,3 +162,14 @@ def test_corrupt_sidecar_starts_clean(tmp_path: Path) -> None:
     s = AlertState(str(path), logger=_log(), repeat_interval=0)
     s.begin_loop()
     assert s.active_count() == 0  # degraded to empty, no crash
+
+
+def test_non_object_sidecar_starts_clean(tmp_path: Path) -> None:
+    """Well-formed JSON that isn't an object (null/[]/5/"str") must not crash the
+    monitor at startup — .get()/.items() would raise AttributeError (review finding)."""
+    path = tmp_path / "notify-state.json"
+    for blob in ("null", "[]", "5", '"hi"'):
+        path.write_text(blob)
+        s = AlertState(str(path), logger=_log(), repeat_interval=0)
+        s.begin_loop()
+        assert s.active_count() == 0  # degraded to empty, no crash

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -107,3 +107,22 @@ def test_suggest_tunables_no_stats_is_graceful(tmp_path: Path) -> None:
     """No stats file yet → a friendly message and a clean exit, not a crash."""
     cfg = Config(stats_file=str(tmp_path / "absent.json"))
     assert _run_suggest_tunables(cfg, _logger()) == 0
+
+
+def test_diag_subcommand_surfaces_config_errors_first(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """A malformed env must be surfaced before a diagnostic sub-command runs, not
+    silently substituted with defaults (review finding)."""
+    from gluetun_monitor.cli import main
+
+    conf = tmp_path / "sites.conf"
+    conf.write_text("https://a.example\n")
+    monkeypatch.setenv("CONFIG_FILE", str(conf))
+    monkeypatch.setenv("TIMEOUT", "abc")  # malformed -> config.errors
+    monkeypatch.delenv("APPRISE_URLS", raising=False)
+
+    rc = main(["--suggest-tunables"])
+    err = capsys.readouterr().err
+    assert "TIMEOUT" in err  # the config error was surfaced...
+    assert rc == 0           # ...and the diagnostic still ran

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -100,3 +100,15 @@ def test_int_fallback_on_garbage(monkeypatch: pytest.MonkeyPatch) -> None:
     separately treats the recorded error as fatal — see test_config_warnings)."""
     monkeypatch.setenv("CHECK_INTERVAL", "not-a-number")
     assert Config.from_env().check_interval == 30
+
+
+def test_absurd_global_timeout_is_capped(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A fat-fingered global TIMEOUT is fatal-at-startup like the per-URL cap (#77),
+    not silently accepted to stall every loop for hours (review finding)."""
+    monkeypatch.setenv("TIMEOUT", "100000")
+    assert any("TIMEOUT" in e and "300" in e for e in Config.from_env().errors)
+
+
+def test_absurd_global_tries_is_capped(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("WGET_TRIES", "100000")
+    assert any("WGET_TRIES" in e and "5" in e for e in Config.from_env().errors)

--- a/tests/test_loop_abort_alerts.py
+++ b/tests/test_loop_abort_alerts.py
@@ -120,3 +120,50 @@ def test_exception_mid_loop_holds_active_alerts(tmp_path: Path) -> None:
     fake.explode = False
     mon.run_once()  # next complete loop: now the resolve is genuine
     assert "resolve:dependent-unhealthy:app" in notifier.event_keys()
+
+
+def test_unprobeable_dependent_holds_its_active_alert(tmp_path: Path) -> None:
+    """A dependent the loop can't evaluate (empty site pool → viability None) must
+    HOLD its active alert, not false-resolve it mid-incident (review finding H3)."""
+    fake = FakeDockerClient()
+    fake.add_container("gluetun", id=GLUETUN_ID, health="healthy")
+    fake.add_container("app", network_mode=f"container:{GLUETUN_ID}")
+    fake.on_exec = lambda n, c: (
+        ExecResult(0, "eth0\nlo\ntun0\n") if c[:2] == ["ls", "/sys/class/net"]
+        else ExecResult(0, "  HTTP/1.1 200 OK\n"))
+    notifier = FakeNotifier()
+    cfg = Config(config_file=_conf(tmp_path), gluetun_container="gluetun",
+                 dependent_containers="app")
+    mon = Monitor(fake, cfg, Logger(log_file=None, level="DEBUG", stream=io.StringIO()),
+                  rng=random.Random(0), sleep=lambda _s: None,
+                  stats=SiteStatsStore(None), notifier=notifier)
+    _seed_active_alert(mon, "dependent-wedged:app")
+
+    mon.alerts.begin_loop()
+    mon.run_dependent_phase(GLUETUN_ID, [])  # no sites -> app un-probeable this loop
+    keys = [e.key for e in mon.alerts.events()]
+    assert "resolve:dependent-wedged:app" not in keys  # not false-resolved
+    assert mon.alerts.is_active("dependent-wedged:app")  # still active
+
+
+def test_probe_dependent_survives_a_transient_inspect_error(tmp_path: Path) -> None:
+    """One dependent's Docker inspect error must not propagate out of the fan-out
+    and abort every other dependent's remediation (review finding). It returns an
+    un-evaluated probe (running so it isn't churned) instead of raising."""
+    from gluetun_monitor.state import InterfaceStatus
+
+    class Boom(FakeDockerClient):
+        def inspect(self, name_or_id: str):  # type: ignore[no-untyped-def]
+            if name_or_id == "distroless":
+                raise RuntimeError("APIError: socket blip")
+            return super().inspect(name_or_id)
+
+    fake = Boom()
+    fake.add_container("distroless", network_mode=f"container:{GLUETUN_ID}")
+    fake.on_exec = lambda n, c: ExecResult(1, "")  # no shell -> UNKNOWN -> inspect path
+    mon = Monitor(fake, Config(config_file=_conf(tmp_path), gluetun_container="gluetun"),
+                  Logger(log_file=None, stream=io.StringIO()), rng=random.Random(0),
+                  sleep=lambda _s: None, stats=SiteStatsStore(None))
+    probe = mon._probe_dependent("distroless", GLUETUN_ID, [], [])  # must NOT raise
+    assert probe.status is InterfaceStatus.UNKNOWN
+    assert probe.running is True  # conservative: not remediated as "not running"

--- a/tests/test_recreate_window.py
+++ b/tests/test_recreate_window.py
@@ -155,3 +155,14 @@ def test_sweep_ignores_unrelated_containers() -> None:
     fake.add_container("app", network_mode=f"container:{GLUETUN_ID}")
     sweep_recreate_leftovers(fake, _logger())
     assert fake.removed == [] and fake.renamed == []
+
+
+def test_sweep_restores_an_exited_parked_container() -> None:
+    """A dependent stranded by a gluetun recreate is usually driven EXITED, so the
+    twin from an interrupted recreate of it is exited too. A running-only sweep would
+    miss it and leave the dependent silently down (review finding H2)."""
+    fake = FakeDockerClient()
+    fake.add_container("app.gm-recreate-old", network_mode=f"container:{OLD_ID}", running=False)
+    sweep_recreate_leftovers(fake, _logger())
+    assert fake.inspect("app") is not None  # restored despite being exited
+    assert ("app.gm-recreate-old", "app") in [(o, n) for o, n in fake.renamed]

--- a/tests/test_site_stats.py
+++ b/tests/test_site_stats.py
@@ -358,3 +358,10 @@ def test_format_window() -> None:
     assert format_window(3600) == "1h"
     assert format_window(1800) == "30m"
     assert format_window(90) == "90s"
+
+
+def test_advisory_empty_window_is_none_even_if_min_restarts_zero() -> None:
+    """advisory() must not IndexError on an empty most_common() when min_restarts<=0
+    (review finding — the public method now guards `not recent`)."""
+    store = SiteStatsStore(None)
+    assert store.advisory(3600, 0, 0.5) is None


### PR DESCRIPTION
Robustness fixes surfaced by a whole-codebase adversarial review (5 review agents across recovery, alerting, state/stats, probing/config, plus a #110-focused pass). All findings here are **pre-existing** — independent of the #110 role work (PR #111) — so they ship separately.

## HIGH

**Interrupted recreate of an *exited* dependent is silently lost** — `recreate.py` `sweep_recreate_leftovers` scanned `list_running_ids()`. A dependent stranded by a gluetun recreate is usually driven *exited* by its restart policy, so the `<dep>.gm-recreate-old` twin from a SIGKILL/power-loss-interrupted recreate is exited too, and the running-only sweep missed it: the dependent stayed down, got pruned from the managed set, and emitted **no alert**. Same bug class the orphan scan already fixed via `list_all_ids`. Fix: scan `list_all_ids` (restore/condemn keys off name existence, not run state).

**Un-probeable dependent false-resolves its active alert** — a dependent that comes back un-probeable this loop (`viability_ok is None`: empty site pool, lost DNS tool, unreadable interfaces) wasn't re-reported, so on that "complete" loop `AlertState` resolved its active `dependent-unhealthy`/`dependent-wedged` alert (a false "recovered") **and dropped its `_wedges` track**. Newly reachable via #111 (mark all sites advisory → empty gating pool → every dependent un-probeable), but also hit by a dependent losing its DNS tool. Fix: new `AlertState.hold(key)` re-asserts an active alert as-is; the dependent phase holds alerts (and keeps wedges) for un-evaluated dependents.

## MED

**Non-object notify-state sidecar crashes the monitor at startup** — `alert_state.py` `_load` caught `(OSError, ValueError, KeyError, TypeError)` but a well-formed-JSON-but-not-an-object sidecar (`null`/`[]`/`5`/`"str"`) raises `AttributeError` on `.get()`/`.items()`, escaping the guard and taking the watchdog down — violating "notifications must never affect monitoring." Fix: add `AttributeError` to the tuple.

**Global `TIMEOUT`/`WGET_TRIES` uncapped** — per-URL overrides are capped (#77) but the globals weren't, so `TIMEOUT=100000` was accepted and stalled every loop for ~28h via the worst-case transport sizing. Fix: cap the globals at the per-URL ceilings — fatal at startup, not silent.

**One dependent's Docker error aborts the whole dependent phase** — the `inspect` in the distroless/UNKNOWN branch of `_probe_dependent` was the one unguarded external call in the fan-out worker; a transient `APIError` propagated out of `pool.map` and skipped every other dependent's remediation that loop. Fix: guard it — skip that dependent conservatively (report un-evaluated/running so it isn't churned) and retry next loop.

## Tests
8 regression tests; the 2 HIGH + the 3 MED all red-verified pre-fix. Full suite + ruff + mypy green.

## Not included (filed separately / deferred)
The review's LOW/defensive findings (advisory() guard, ring-prune-if-0, wedge-backoff-floor, diag-before-config-gate, _confirm_dns per-URL knobs, etc.) are being filed as issues. Doc drift (Tenet 9 vs the #98 backoff) is handled in a docs change.
