### PR TITLE
feat(notify): opt-in advisory-site reachability alert (activity tier)

### DIFF
--- a/README.md
+++ b/README.md
@@ -419,7 +419,12 @@ https://slow-and-flaky.example|role=advisory|timeout=25
   stats, but its failure **never** triggers a gluetun restart, and it's excluded
   from the flaky-site advisory (you've already acknowledged it). Startup logs it
   under `Per-URL probe overrides: … role=advisory`, and a failing advisory site
-  shows in the heartbeat as `failing: host (advisory)`.
+  shows in the heartbeat as `failing: host (advisory)`. If you want to *hear* when
+  an advisory site goes unreachable, it emits an opt-in, edge-triggered alert at the
+  **`activity`** notification tier (silent at the default `attention`) — announced
+  once it's been unreachable `FAIL_THRESHOLD` checks, resolved when it's back. So
+  you can watch a geo-blocked endpoint's reachability without it ever restarting the
+  tunnel or paging you.
 
 Use `advisory` for a site you want to **watch** but that can't be reached through
 the VPN regardless of tunnel health — a geo-blocked/anti-VPN endpoint (a torrent
@@ -731,7 +736,7 @@ line looks. Each level adds its own row to everything above it (ADR-0011):
 |---|---|---|
 | **`attention`** *(default)* | only when **you** must act/decide | recovery/remediation failed, refused to start, **flaky-site advisory** |
 | `recovery` | + self-healed incidents | gluetun recovered, dependent remediated |
-| `activity` | + non-fault changes | `sites.conf` reloaded |
+| `activity` | + non-fault changes | `sites.conf` reloaded, **advisory site unreachable / recovered** |
 | `all` | + the firehose | per-loop checks, restart play-by-play |
 
 So enabling notifications gets you **`attention` only** — the monitor stays silent

--- a/gluetun_monitor/monitor.py
+++ b/gluetun_monitor/monitor.py
@@ -363,6 +363,7 @@ class Monitor:
                 for url in removed:
                     self.site_failures.discard(url)
                     self._forget(f"advisory:{url}")
+                    self._forget(f"advisory-down:{url}")  # its reachability alert too
                 # On ANY role change, discard the live failure counter so the new role
                 # starts clean (#110): an advisory site accumulates fails without
                 # gating, so flipping it to critical must NOT inherit that count and
@@ -372,7 +373,9 @@ class Monitor:
                     if current[url].role != prev[url].role:
                         self.site_failures.discard(url)
                         if current[url].role == "advisory":
-                            self._forget(f"advisory:{url}")
+                            self._forget(f"advisory:{url}")       # no longer a restart driver
+                        else:
+                            self._forget(f"advisory-down:{url}")  # no longer an advisory site
             self._last_specs = current
 
         results = self._fan_out(
@@ -401,6 +404,21 @@ class Monitor:
                 # #110: an advisory site is probed and recorded (reachability), but
                 # its failure NEVER gates a restart — a site blocked through every
                 # exit can't be rolled to health, so it must not roll the tunnel.
+                # Still surface its reachability as an OPT-IN, edge-triggered alert
+                # at the `activity` tier (silent at the default `attention`): announce
+                # once it's been unreachable FAIL_THRESHOLD checks, resolve when it's
+                # back. Only on the primary poll (record); flap-free because the
+                # counter climbs while failing and resets to 0 only on a pass — which
+                # is exactly the resolve condition (not re-reported → lifecycle clears).
+                if record and count >= threshold:
+                    host = hostname_of(result.url)
+                    self._problem(
+                        f"advisory-down:{result.url}", "activity",
+                        f"advisory site unreachable: {host}",
+                        f"{result.url} (role=advisory) failed {count} consecutive checks "
+                        f"({result.reason}) — reachability watch only; the tunnel is not "
+                        f"restarted.",
+                    )
                 self.log.debug(
                     f"[{gw}] reach fail: {result.url} ({result.reason}) "
                     f"[{count} · advisory — not gating]"

--- a/tests/test_site_roles.py
+++ b/tests/test_site_roles.py
@@ -257,3 +257,47 @@ def test_role_switch_advisory_to_critical_resets_failure_grace(tmp_path: Path) -
     assert fake.restarted == []
     mon.run_once()  # now 2/2 -> restart
     assert "gluetun" in fake.restarted
+
+
+def test_advisory_down_alert_is_opt_in_activity_edge_triggered(tmp_path: Path) -> None:
+    """An advisory site's unreachability surfaces as an opt-in `activity`-tier alert:
+    announced once after FAIL_THRESHOLD, not re-announced while it persists, and
+    resolved when it recovers. Never gates a restart."""
+    from .fakes import FakeNotifier
+
+    badurl = "https://blocked.example"
+    conf = tmp_path / "sites.conf"
+    conf.write_text(f"{GOOD}\n{badurl}|role=advisory\n")
+    state = {"block": True}
+    fake = FakeDockerClient()
+    fake.add_container("gluetun", id=GLUETUN_ID, health="healthy")
+
+    def handler(name: str, cmd: list[str]) -> ExecResult:
+        if cmd and cmd[0] == "nslookup":
+            return ExecResult(0, "")
+        if badurl in cmd and state["block"]:
+            return ExecResult(4, "")
+        return ExecResult(0, "")
+
+    fake.on_exec = handler
+    notifier = FakeNotifier()
+    cfg = Config(config_file=str(conf), gluetun_container="gluetun", fail_threshold=2,
+                 dns_wait_timeout=2, advisory_min_restarts=1000)
+    mon = Monitor(fake, cfg, Logger(log_file=None, stream=io.StringIO()),
+                  rng=random.Random(0), sleep=lambda _s: None,
+                  stats=SiteStatsStore(None), notifier=notifier)
+    key = f"advisory-down:{badurl}"
+
+    mon.run_once()  # count 1/2 -> not yet announced
+    assert key not in notifier.event_keys()
+    mon.run_once()  # count 2/2 -> announce
+    assert key in notifier.event_keys()
+    ev = next(e for e in notifier.events if e.key == key)
+    assert ev.tier == "activity"                       # opt-in, silent at default attention
+    mon.run_once()  # still down -> edge-triggered, no re-announce
+    assert notifier.event_keys().count(key) == 1
+    assert fake.restarted == []                         # advisory NEVER restarts
+
+    state["block"] = False
+    mon.run_once()  # recovered -> resolve
+    assert f"resolve:{key}" in notifier.event_keys()


### PR DESCRIPTION
Completes the `role=advisory` story (#110): an advisory site never restarts the tunnel and stays silent at the default `attention` level — but if you *want* to know when it goes unreachable, it now emits an **opt-in, edge-triggered** alert at the **`activity`** tier.

## Behavior
- Announced **once** after the site has been unreachable `FAIL_THRESHOLD` checks; **resolved** when it recovers; not re-announced while it persists (edge-triggered, honors `NOTIFY_REPEAT_INTERVAL`, persists across restarts) — all free from the existing alert lifecycle (ADR-0012).
- **Never** gates a restart; silent unless `NOTIFY_LEVEL >= activity`.
- **Flap-free** by construction: the fail counter climbs monotonically while failing and resets to 0 only on a pass — which is exactly the resolve condition, so no false new→resolve churn (the class of bug #106 fixed).
- Retired (`_forget`) when the site is removed from `sites.conf` or switched off `advisory`.

## Why
Closes the 'advisory means give up on it' gap noted during #110: you can *watch* a geo-blocked/anti-VPN endpoint's reachability (e.g. a torrent indexer) without it ever rolling the tunnel or paging you at `attention`.

## Tests / docs
1 test — announce-at-threshold, edge-trigger (no re-announce), resolve-on-recovery, never-restarts. Full suite + ruff + mypy + coverage (96.9%) green. README: the Site-roles section + the `NOTIFY_LEVEL` `activity` row updated.

Bundles with #115 (dir-mount docs) for the next release. Being a `feat`, release-please will cut **2.4.0**.