### PR TITLE
chore(ci): pin actions to SHAs, scope workflow permissions (#79, #80)

### DIFF
--- a/.github/workflows/auto-assign.yml
+++ b/.github/workflows/auto-assign.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     types: [opened, reopened]
 
+# Deny by default; the one job that needs write grants itself exactly what it uses.
+permissions: {}
+
 jobs:
   assign:
     name: Assign csmarshall
@@ -16,7 +19,7 @@ jobs:
       issues: write
     steps:
       - name: Add csmarshall as assignee
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         with:
           script: |
             const assignee = 'csmarshall';

--- a/.github/workflows/base-drift.yml
+++ b/.github/workflows/base-drift.yml
@@ -20,7 +20,7 @@ jobs:
   drift:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           # Push via the PAT so the resulting commit triggers release-please (a
           # GITHUB_TOKEN push would not).

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [main]
 
+# CI only reads the repo (lint, test, build-without-push). No job needs write.
+permissions:
+  contents: read
+
 jobs:
   python:
     name: Python (lint, types, tests)
@@ -18,7 +22,7 @@ jobs:
       matrix:
         python-version: ["3.14"]
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
       - name: requirements.lock direct pins match pyproject
         # The image installs runtime deps from the hashed requirements.lock, so a
@@ -38,7 +42,7 @@ jobs:
           echo "requirements.lock direct pins in sync"
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -62,8 +66,9 @@ jobs:
         # (docker + transitives) gates the build. If a toolchain advisory ever lands
         # with no fix yet, add a scoped `--ignore-vuln <ID>` here with a removal note.
         run: |
+          # pip-audit itself is pinned in requirements-dev.txt (installed above,
+          # Dependabot-tracked) — no ad-hoc install here.
           python -m pip install --upgrade pip setuptools wheel
-          pip install pip-audit
           pip-audit
 
       - name: Pytest (incl. differential vs. legacy bash)
@@ -76,10 +81,10 @@ jobs:
     name: Integration (real daemon, pytest)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
           python-version: "3.14"
 
@@ -97,9 +102,9 @@ jobs:
     name: Shellcheck (legacy script)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: Run ShellCheck
-        uses: ludeeus/action-shellcheck@master
+        uses: ludeeus/action-shellcheck@00cae500b08a931fb5698e11e79bfbd38e612a38 # v2.0.0
         with:
           scandir: '.'
           format: tty
@@ -108,7 +113,7 @@ jobs:
     name: Bats (legacy regression)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
       - name: Install bats
         run: |
@@ -122,13 +127,13 @@ jobs:
     name: Build Docker Image
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
 
       - name: Build image
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
         with:
           context: .
           push: false
@@ -141,7 +146,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: build
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
       - name: Build image
         run: docker build -t gluetun-monitor:test .
@@ -173,12 +178,16 @@ jobs:
           # Create an isolated network for the proxy
           docker network create test-docker-proxy
 
-          # Start socket proxy with required permissions
+          # Start socket proxy with required permissions.
+          # Digest-pinned (was :latest on 2026-07-06). Neither this test fixture nor
+          # the example ships in our image, so it's not Dependabot- or drift-tracked;
+          # refresh manually with:
+          #   docker buildx imagetools inspect tecnativa/docker-socket-proxy:latest
           docker run -d --name test-socket-proxy \
             -v /var/run/docker.sock:/var/run/docker.sock:ro \
             -e CONTAINERS=1 -e POST=1 -e EXEC=1 \
             --network test-docker-proxy \
-            tecnativa/docker-socket-proxy
+            tecnativa/docker-socket-proxy@sha256:1f3a6f303320723d199d2316a3e82b2e2685d86c275d5e3deeaf182573b47476
 
           # Wait for proxy to be ready
           sleep 3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -179,10 +179,9 @@ jobs:
           docker network create test-docker-proxy
 
           # Start socket proxy with required permissions.
-          # Digest-pinned (was :latest on 2026-07-06). Neither this test fixture nor
-          # the example ships in our image, so it's not Dependabot- or drift-tracked;
-          # refresh manually with:
-          #   docker buildx imagetools inspect tecnativa/docker-socket-proxy:latest
+          # Digest-pinned; kept current by .github/workflows/socket-proxy-drift.yml
+          # (opens a refresh PR on upstream re-publish — this image doesn't ship in
+          # ours, so it's tracked via PR, not a release like the python base).
           docker run -d --name test-socket-proxy \
             -v /var/run/docker.sock:/var/run/docker.sock:ro \
             -e CONTAINERS=1 -e POST=1 -e EXEC=1 \

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -39,7 +39,7 @@ jobs:
     steps:
       - name: Fetch Dependabot metadata
         id: meta
-        uses: dependabot/fetch-metadata@v3
+        uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3
 
       - name: Enable auto-merge (squash) for in-scope updates
         if: >

--- a/.github/workflows/dependabot-rebase.yml
+++ b/.github/workflows/dependabot-rebase.yml
@@ -6,6 +6,9 @@ on:
     - cron: "0 9 * * 1"
   workflow_dispatch:
 
+# Deny by default; the rebase job grants itself exactly what it uses.
+permissions: {}
+
 jobs:
   rebase:
     name: Rebase Dependabot PRs
@@ -15,7 +18,7 @@ jobs:
       contents: write
     steps:
       - name: Rebase open Dependabot PRs
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         with:
           script: |
             const pulls = await github.rest.pulls.list({

--- a/.github/workflows/edge.yml
+++ b/.github/workflows/edge.yml
@@ -14,6 +14,9 @@ concurrency:
   group: edge-${{ github.ref }}
   cancel-in-progress: true
 
+# Deny by default; the build job grants itself exactly what it uses.
+permissions: {}
+
 env:
   IMAGE_NAME: gluetun-monitor
 
@@ -26,23 +29,23 @@ jobs:
       packages: write
 
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v4
+        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
 
       - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v4
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Log in to Docker Hub
-        uses: docker/login-action@v4
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4
         with:
           registry: docker.io
           username: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -50,7 +53,7 @@ jobs:
 
       - name: Extract metadata
         id: meta
-        uses: docker/metadata-action@v6
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6
         with:
           images: |
             ghcr.io/${{ github.repository }}
@@ -63,7 +66,7 @@ jobs:
             type=sha,prefix=edge-,format=short
 
       - name: Build and push
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
         with:
           context: .
           platforms: linux/amd64,linux/arm64,linux/arm/v7

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -21,6 +21,6 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
-      - uses: googleapis/release-please-action@v5
+      - uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5
         with:
           token: ${{ secrets.RELEASE_PLEASE_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,9 @@ on:
 env:
   IMAGE_NAME: gluetun-monitor
 
+# Deny by default; the release job grants itself exactly what it uses.
+permissions: {}
+
 jobs:
   release:
     name: Build and Push
@@ -17,23 +20,23 @@ jobs:
       packages: write
 
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v4
+        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
 
       - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v4
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Log in to Docker Hub
-        uses: docker/login-action@v4
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4
         with:
           registry: docker.io
           username: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -41,7 +44,7 @@ jobs:
 
       - name: Extract metadata
         id: meta
-        uses: docker/metadata-action@v6
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6
         with:
           images: |
             ghcr.io/${{ github.repository }}
@@ -56,7 +59,7 @@ jobs:
             type=semver,pattern={{major}}
 
       - name: Build and push
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
         with:
           context: .
           platforms: linux/amd64,linux/arm64,linux/arm/v7

--- a/.github/workflows/socket-proxy-drift.yml
+++ b/.github/workflows/socket-proxy-drift.yml
@@ -1,0 +1,75 @@
+name: socket-proxy-drift
+
+# Weekly check that the digest-pinned tecnativa/docker-socket-proxy hasn't drifted.
+# Unlike base-drift.yml, this image does NOT ship in our published artifact — it's
+# only the CI test fixture and the docker-compose.yml.example users copy to deploy.
+# The example is a security boundary (it mediates Docker-socket access), so letting
+# its pin rot is the real risk; but a bump must NOT cut a release of our image
+# (immutable semvers — our artifact didn't change). So instead of committing to main
+# like base-drift, this opens a PR (auto-merged on green) that refreshes the pin in
+# both spots. Manual `workflow_dispatch` for testing.
+
+on:
+  schedule:
+    - cron: "0 6 * * 2"  # Tuesdays 06:00 UTC (base-drift runs Mondays — stagger them)
+  workflow_dispatch: {}
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  drift:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          # PAT so the PR branch's push triggers CI (a GITHUB_TOKEN push would not,
+          # and auto-merge would then wait forever for checks that never start).
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
+
+      - name: Open a PR if the socket-proxy digest moved
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN }}
+          REPO: tecnativa/docker-socket-proxy
+          TAG: "latest"
+        run: |
+          set -euo pipefail
+          token=$(curl -s "https://auth.docker.io/token?service=registry.docker.io&scope=repository:${REPO}:pull" | jq -r .token)
+          current=$(curl -sI \
+            -H "Authorization: Bearer ${token}" \
+            -H "Accept: application/vnd.oci.image.index.v1+json" \
+            -H "Accept: application/vnd.docker.distribution.manifest.list.v2+json" \
+            "https://registry-1.docker.io/v2/${REPO}/manifests/${TAG}" \
+            | grep -i '^docker-content-digest:' | awk '{print $2}' | tr -d '\r')
+          pinned=$(grep -oP 'docker-socket-proxy@\Ksha256:[0-9a-f]+' docker-compose.yml.example | head -1)
+          echo "pinned:  ${pinned}"
+          echo "current: ${current:-<none>}"
+          if [ -z "${current}" ]; then
+            echo "::warning::could not resolve current digest — skipping this run"; exit 0
+          fi
+          if [ "${current}" = "${pinned}" ]; then
+            echo "socket-proxy unchanged — nothing to do."; exit 0
+          fi
+          branch="chore/socket-proxy-${current#sha256:}"
+          branch="${branch:0:52}"
+          # Idempotent: if we already opened this PR on a previous run, do nothing.
+          if git ls-remote --exit-code --heads origin "${branch}" >/dev/null 2>&1; then
+            echo "PR branch ${branch} already exists — nothing to do."; exit 0
+          fi
+          echo "socket-proxy :latest re-published → opening a refresh PR."
+          sed -i "s|docker-socket-proxy@${pinned}|docker-socket-proxy@${current}|g" \
+            docker-compose.yml.example .github/workflows/ci.yml
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git checkout -b "${branch}"
+          git add docker-compose.yml.example .github/workflows/ci.yml
+          git commit -m "chore(ci): bump tecnativa/docker-socket-proxy digest (${current})"
+          git push origin "${branch}"
+          gh pr create \
+            --title "chore(ci): bump socket-proxy digest" \
+            --body "Automated by socket-proxy-drift: \`tecnativa/docker-socket-proxy:latest\` was re-published. Refreshes the digest pin in the CI test fixture and \`docker-compose.yml.example\`. No release — the image is not part of our published artifact. Merges automatically once CI is green." \
+            --label dependencies \
+            --assignee csmarshall
+          # Self-merge on green (CI is the guard); harmless no-op if auto-merge is off.
+          gh pr merge --auto --squash || echo "auto-merge unavailable — left for manual merge"

--- a/docker-compose.yml.example
+++ b/docker-compose.yml.example
@@ -3,7 +3,11 @@
 # See: https://github.com/Tecnativa/docker-socket-proxy
 services:
   docker-socket-proxy:
-    image: tecnativa/docker-socket-proxy
+    # Pinned by digest (supply-chain: an immutable reference can't be re-tagged
+    # under you). This digest was `:latest` on 2026-07-06. To refresh:
+    #   docker buildx imagetools inspect tecnativa/docker-socket-proxy:latest
+    # and replace the sha256 below with the reported digest.
+    image: tecnativa/docker-socket-proxy@sha256:1f3a6f303320723d199d2316a3e82b2e2685d86c275d5e3deeaf182573b47476
     container_name: gluetun-monitor-socket-proxy
     restart: unless-stopped
     # On hardened hosts with restricted seccomp profiles, you may need:

--- a/docker-compose.yml.example
+++ b/docker-compose.yml.example
@@ -4,9 +4,9 @@
 services:
   docker-socket-proxy:
     # Pinned by digest (supply-chain: an immutable reference can't be re-tagged
-    # under you). This digest was `:latest` on 2026-07-06. To refresh:
+    # under you). Kept current automatically by .github/workflows/socket-proxy-drift.yml,
+    # which opens a refresh PR when upstream re-publishes `:latest`. Manual refresh:
     #   docker buildx imagetools inspect tecnativa/docker-socket-proxy:latest
-    # and replace the sha256 below with the reported digest.
     image: tecnativa/docker-socket-proxy@sha256:1f3a6f303320723d199d2316a3e82b2e2685d86c275d5e3deeaf182573b47476
     container_name: gluetun-monitor-socket-proxy
     restart: unless-stopped

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -9,3 +9,4 @@ ruff==0.15.20
 mypy==2.1.0
 pytest==9.1.1
 pytest-cov==7.1.0
+pip-audit==2.10.1


### PR DESCRIPTION
Supply-chain hardening for the CI/CD workflows. Closes #80 and #79.

## What
- **SHA-pin every third-party action.** All 11 `uses:` refs now point at a full commit SHA with a trailing `# vX` comment. A tag (`@v7`) is mutable — the maintainer (or an attacker who compromises them) can re-point it at new code; a SHA can't be re-pointed. The `# vX` comment is what lets Dependabot keep them current (see "How these stay fresh"). `ludeeus/action-shellcheck@master` (worst case — a moving branch) is now pinned to the `2.0.0` release SHA.
- **Least-privilege `permissions:`.** `GITHUB_TOKEN` defaults to broad write on older repos; an unscoped workflow hands that to every action it runs. CI is now `contents: read` (it only lints/tests/builds — never pushes). The four workflows whose jobs already declare their own scoped tokens (auto-assign, dependabot-rebase, edge, release) get a top-level `permissions: {}` deny-default, so a future job added without its own block inherits *nothing*.
- **Digest-pin the socket-proxy image** in the CI test fixture and `docker-compose.yml.example`.
- **Pin pip-audit** via `requirements-dev.txt` (Dependabot-tracked) instead of an ad-hoc `pip install`.
- **`socket-proxy-drift.yml`** — a weekly drift check that keeps the socket-proxy digest current (see below).

## How these stay fresh
Every pin is wired to an updater — a pin nothing tracks just rots into a stale, insecure pin:

| Pinned thing | Update mechanism |
|---|---|
| **11 GitHub Actions** | Dependabot `github-actions` (weekly) reads the `# vX` comment, opens a PR bumping SHA + comment. Auto-merged on green. |
| **pip-audit** | Now in `requirements-dev.txt` → Dependabot `pip`, like ruff/mypy/pytest. |
| **python:3.14-slim base** | Dependabot `docker` + weekly `base-drift.yml` (digest re-resolve → patch release). |
| **socket-proxy digest** | New `socket-proxy-drift.yml`: weekly digest re-resolve → opens an auto-merged **PR** (not a release — this image isn't part of our published artifact). |

The socket-proxy pin lives in the `docker-compose.yml.example` users copy to deploy, and the proxy is the boundary mediating their Docker-socket access — so keeping it current is a real security concern, not cosmetic. It's tracked by PR rather than release because a bump changes only the example and the CI fixture, never our shipped image (immutable semvers — no artifact change, no release).

## Guardrail
CI itself validates every pin and permission on this PR — a wrong SHA or a too-tight scope fails here, not in production.