### PR TITLE
feat(monitor): stream probe results as they land, with (n/total) progress (#123)

### DIFF
--- a/gluetun_monitor/monitor.py
+++ b/gluetun_monitor/monitor.py
@@ -12,13 +12,13 @@ from __future__ import annotations
 import random
 import threading
 import time
-from collections.abc import Callable
-from concurrent.futures import ThreadPoolExecutor
+from collections.abc import Callable, Iterator
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 from .alert_state import AlertState
-from .connectivity import probe_site
+from .connectivity import SiteResult, probe_site
 from .dependents import (
     classify_interfaces,
     discover_dependents,
@@ -378,24 +378,32 @@ class Monitor:
                             self._forget(f"advisory-down:{url}")  # no longer an advisory site
             self._last_specs = current
 
-        results = self._fan_out(
-            sites, lambda url: probe_site(self.client, self.config.gluetun_container, url,
-                                          *self._probe_knobs(url))
-        )
-
         # Site tests run *inside the gluetun container* (the VPN gateway, through
         # the tunnel). Tag each line with the role + container — "[gateway:<name>]"
         # — so it's unambiguous what kind of container and which one (cf.
         # "[dependent:<name>]" below). Greppable: `grep gateway:` / `grep dependent:`.
+        # Results stream in as each probe lands (completion order) with an (n/total)
+        # progress marker, so a slow site is visibly the one still outstanding rather
+        # than hiding the fast results behind one batched burst at gather-end.
         gw = f"gateway:{self.config.gluetun_container}"
+        total = len(sites)
+        results: list[SiteResult] = []
         failed: list[str] = []
-        for result in results:
+        for done, result in enumerate(
+            self._fan_out(
+                sites, lambda url: probe_site(self.client, self.config.gluetun_container,
+                                              url, *self._probe_knobs(url))
+            ),
+            start=1,
+        ):
+            results.append(result)
             if record:
                 self.stats.record_poll(result.url, result.ok, result.duration_ms, result.reason)
             if result.ok:
                 self.site_failures.reset(result.url)
                 self.log.debug(
-                    f"[{gw}] reach ok: {result.url} ({result.reason}, {result.duration_ms}ms)"
+                    f"[{gw}] ({done}/{total}) reach ok: {result.url} "
+                    f"({result.reason}, {result.duration_ms}ms)"
                 )
                 continue
             count = self.site_failures.fail(result.url)
@@ -420,19 +428,20 @@ class Monitor:
                         f"restarted.",
                     )
                 self.log.debug(
-                    f"[{gw}] reach fail: {result.url} ({result.reason}) "
+                    f"[{gw}] ({done}/{total}) reach fail: {result.url} ({result.reason}) "
                     f"[{count} · advisory — not gating]"
                 )
                 continue
             if count >= threshold:
                 failed.append(result.url)
                 self.log.warn(
-                    f"[{gw}] reach fail: {result.url} ({result.reason}) "
+                    f"[{gw}] ({done}/{total}) reach fail: {result.url} ({result.reason}) "
                     f"[{count}/{threshold} → restart]"
                 )
             else:
                 self.log.debug(
-                    f"[{gw}] reach fail: {result.url} ({result.reason}) [{count}/{threshold}]"
+                    f"[{gw}] ({done}/{total}) reach fail: {result.url} ({result.reason}) "
+                    f"[{count}/{threshold}]"
                 )
 
         if failed:
@@ -700,23 +709,29 @@ class Monitor:
                 "testing connectivity only against IP literals"
             )
 
-        probes = self._fan_out(
-            dependents, lambda d: self._probe_dependent(d, gluetun_id, resolvable, ips)
-        )
-
         # State mutation + remediation decisions are single-threaded. Each
         # dependent logs two ordered DEBUG lines: first the L3 network-path check
         # (which interfaces / can it route out), THEN the L7 viability result —
         # so the logs show the path was validated before the DNS/connect test.
+        # Probes stream in as each lands (completion order); the (n/total) marker
+        # rides the leading link line so mid-phase progress is visible.
+        dep_total = len(dependents)
+        probes: list[DependentProbe] = []
         to_remediate: list[tuple[str, str]] = []
         # Dependents the loop could NOT evaluate this cycle (link/DNS couldn't tell):
         # an active alert for them must be HELD, not resolved, and their wedge kept.
         unevaluated: set[str] = set()
-        for probe in probes:
+        for done, probe in enumerate(
+            self._fan_out(
+                dependents, lambda d: self._probe_dependent(d, gluetun_id, resolvable, ips)
+            ),
+            start=1,
+        ):
+            probes.append(probe)
             dep = probe.name
             tag = f"dependent:{dep}"  # role + name, mirrors "[gateway:<name>]"
             link = _link_line(probe.status.name.lower(), probe.interfaces)
-            self.log.debug(f"[{tag}] link {link}")
+            self.log.debug(f"[{tag}] ({done}/{dep_total}) link {link}")
             if probe.status is InterfaceStatus.STRANDED:
                 to_remediate.append((dep, probe.reason))
                 continue
@@ -1347,10 +1362,24 @@ class Monitor:
 
     # ----- helpers -----
 
-    def _fan_out[T, R](self, items: list[T], fn: Callable[[T], R]) -> list[R]:
-        """Run ``fn`` over ``items`` with a bounded thread pool, preserving order."""
+    def _fan_out[T, R](self, items: list[T], fn: Callable[[T], R]) -> Iterator[R]:
+        """Run ``fn`` over ``items`` with a bounded thread pool, yielding each result
+        the moment it lands — in **completion order**, not input order.
+
+        Streaming (vs. the old ``pool.map`` that returned the whole list only once the
+        slowest item finished) is what lets the caller log/interpret each probe as it
+        comes back: a slow site no longer hides the fast ones behind a single batched
+        burst at gather-end. Only ``fn`` runs in the worker threads; the caller drains
+        this generator single-threaded, so result interpretation (stats, failure
+        counters, alerting) stays serial and thread-safe — the concurrency is confined
+        to the probe itself.
+        """
         workers = max(1, min(self.config.max_parallel_checks, len(items)))
         if workers == 1:
-            return [fn(item) for item in items]
+            for item in items:
+                yield fn(item)
+            return
         with ThreadPoolExecutor(max_workers=workers) as pool:
-            return list(pool.map(fn, items))
+            futures = [pool.submit(fn, item) for item in items]
+            for future in as_completed(futures):
+                yield future.result()

--- a/tests/test_gateway_interface_log.py
+++ b/tests/test_gateway_interface_log.py
@@ -45,5 +45,5 @@ def test_gateway_interface_logged_before_site_tests(tmp_path: Path) -> None:
     assert "[gateway:gluetun] link live: eth0,lo,tun0" in out
     # ...and it comes before the first site curl line.
     gw_at = out.index("[gateway:gluetun] link ")
-    site_at = out.index("[gateway:gluetun] reach ok: https://www.google.com")
+    site_at = out.index("[gateway:gluetun] (1/1) reach ok: https://www.google.com")
     assert gw_at < site_at

--- a/tests/test_interface_logging.py
+++ b/tests/test_interface_logging.py
@@ -74,9 +74,9 @@ def test_live_dependent_logs_its_interfaces(tmp_path: Path) -> None:
     mon.run_once()
     out = stream.getvalue()
     # Two ordered lines: the L3 link check first, then the reach (DNS/connect) test.
-    assert "[dependent:dep] link live: eth0,lo,tun0" in out
+    assert "[dependent:dep] (1/1) link live: eth0,lo,tun0" in out
     assert "[dependent:dep] reach " in out
-    iface_at = out.index("[dependent:dep] link ")
+    iface_at = out.index("[dependent:dep] (1/1) link ")
     reach_at = out.index("[dependent:dep] reach ")
     assert iface_at < reach_at  # path validated BEFORE the DNS/connect test
 
@@ -90,4 +90,4 @@ def test_stranded_dependent_logs_loopback_only(tmp_path: Path) -> None:
     )
     mon, stream = _mon(fake, tmp_path)
     mon.run_once()
-    assert "[dependent:dep] link stranded: lo" in stream.getvalue()
+    assert "[dependent:dep] (1/1) link stranded: lo" in stream.getvalue()

--- a/tests/test_log_heartbeat.py
+++ b/tests/test_log_heartbeat.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import io
 import random
+import re
 
 from gluetun_monitor.config import Config
 from gluetun_monitor.docker_client import ExecResult
@@ -53,15 +54,17 @@ def test_info_shows_heartbeat_not_per_item() -> None:
     assert "[gateway:gluetun] sites: 3/3 ok" in out
     assert "dependents: 2/2 ok" in out
     # ...but the per-item detail is NOT (that's DEBUG-only).
-    assert "reach ok: https://google.com" not in out
+    assert "reach ok:" not in out
     assert "link live:" not in out
 
 
 def test_debug_shows_heartbeat_and_per_item() -> None:
     out = _run_loop("DEBUG")
     assert "[gateway:gluetun] sites: 3/3 ok" in out        # heartbeat
-    assert "reach ok: https://google.com" in out           # per-site detail
-    assert "[dependent:qbittorrent] link live:" in out     # per-dependent detail
+    # per-site + per-dependent detail — the (n/total) counter is completion-order,
+    # so match any index rather than a fixed position.
+    assert re.search(r"\(\d/3\) reach ok: https://google\.com", out)
+    assert re.search(r"\[dependent:qbittorrent\] \(\d/2\) link live:", out)
 
 
 def test_heartbeat_reports_failing_site() -> None:

--- a/tests/test_probe_streaming.py
+++ b/tests/test_probe_streaming.py
@@ -1,0 +1,78 @@
+"""Streaming probe logs with an (n/total) progress marker.
+
+The gateway and dependent phases fan probes out concurrently and now consume the
+results as a *stream* (completion order), logging each the moment it lands with an
+``(n/total)`` counter — so a slow site is visibly the one still outstanding instead
+of hiding the fast results behind one batched burst at gather-end. These tests lock
+that every probe is logged exactly once and the counter covers the full ``1..total``.
+"""
+
+from __future__ import annotations
+
+import io
+import random
+import re
+from pathlib import Path
+
+from gluetun_monitor.config import Config
+from gluetun_monitor.docker_client import ExecResult
+from gluetun_monitor.logging_setup import Logger
+from gluetun_monitor.monitor import Monitor
+from gluetun_monitor.site_stats import SiteStatsStore
+
+from .fakes import FakeDockerClient
+
+GLUETUN_ID = "a" * 64
+SITES = [f"https://site{i}.example" for i in range(5)]
+
+
+def _mon(tmp_path: Path, fake: FakeDockerClient) -> tuple[Monitor, io.StringIO]:
+    conf = tmp_path / "sites.conf"
+    conf.write_text("\n".join(SITES) + "\n")
+    stream = io.StringIO()
+    mon = Monitor(
+        fake, Config(config_file=str(conf), gluetun_container="gluetun"),
+        Logger(log_file=None, level="DEBUG", stream=stream),
+        rng=random.Random(0), sleep=lambda _s: None, stats=SiteStatsStore(None),
+    )
+    return mon, stream
+
+
+def test_every_gateway_probe_is_logged_with_a_counter(tmp_path: Path) -> None:
+    fake = FakeDockerClient()
+    fake.add_container("gluetun", id=GLUETUN_ID)
+    fake.on_exec = lambda n, c: (
+        ExecResult(0, "eth0\nlo\ntun0\n") if c[:2] == ["ls", "/sys/class/net"]
+        else ExecResult(0, "  HTTP/1.1 200 OK\n")
+    )
+    mon, stream = _mon(tmp_path, fake)
+    mon.run_once()
+    out = stream.getvalue()
+
+    total = len(SITES)
+    # Every gateway probe line carries "(n/total)"; the indices seen must be exactly 1..total.
+    indices = {int(m) for m in re.findall(rf"\[gateway:gluetun\] \((\d+)/{total}\) reach ", out)}
+    assert indices == set(range(1, total + 1)), out
+    # ...and one line per site (no probe dropped or double-logged).
+    assert len(re.findall(rf"\[gateway:gluetun\] \(\d+/{total}\) reach ", out)) == total, out
+
+
+def test_single_site_uses_worker_free_path_and_still_counts(tmp_path: Path) -> None:
+    """With one site the pool short-circuits to the in-line path — the counter
+    ((1/1)) must still be emitted so the format is uniform regardless of pool size."""
+    conf = tmp_path / "sites.conf"
+    conf.write_text("https://only.example\n")
+    fake = FakeDockerClient()
+    fake.add_container("gluetun", id=GLUETUN_ID)
+    fake.on_exec = lambda n, c: (
+        ExecResult(0, "eth0\nlo\ntun0\n") if c[:2] == ["ls", "/sys/class/net"]
+        else ExecResult(0, "  HTTP/1.1 200 OK\n")
+    )
+    stream = io.StringIO()
+    mon = Monitor(
+        fake, Config(config_file=str(conf), gluetun_container="gluetun"),
+        Logger(log_file=None, level="DEBUG", stream=stream),
+        rng=random.Random(0), sleep=lambda _s: None, stats=SiteStatsStore(None),
+    )
+    mon.run_once()
+    assert "[gateway:gluetun] (1/1) reach ok: https://only.example" in stream.getvalue()


### PR DESCRIPTION
Closes #123.

## Problem
Probe fan-out was already parallel, but the results were logged in one batch at gather-end — so a live loop showed nine `reach ok` lines sharing a single timestamp, and a 15s-slow site (`thepiratebay.org`, `role=advisory`) made the whole gateway phase look like a 16s stall with nothing shown as outstanding.

Two root causes:
1. `_fan_out` used `pool.map`, which only returns once the **slowest** future finishes; the per-result interpretation loop then ran serially after that gather.
2. No `(n/total)` marker, so you couldn't watch the batch drain.

## Change
- `_fan_out` now yields in **completion order** (`as_completed`) — each result is logged the instant it lands. Only the probe runs in worker threads; a single consumer drains the generator, so stats/counter/alert mutation stays serial and thread-safe (unchanged).
- Every gateway and dependent result line gets an `(n/total)` marker right after the tag:
  - `[gateway:gluetun] (3/9) reach ok: https://… (HTTP 200, 636ms)`
  - `[dependent:qbittorrent] (2/4) link live: eth0,lo,tun0`

Fast sites log immediately; a slow site is visibly the one still outstanding. The verb tokens (`reach ok:`, `link live:`) stay intact for grepping — the counter sits between the tag and the verb.

## Behavior notes
- **Log order is now completion order, not config order.** Intentional (it's what surfaces the slow probe), and nothing depends on input order — the breach decision and summary aggregate all results after the drain.
- Single-item phases keep the worker-free inline path and still emit `(1/1)`, so the format is uniform regardless of pool size.

## Tests
- New `tests/test_probe_streaming.py`: asserts every probe is logged exactly once and the counter covers the full `1..total`, plus the single-site inline path still emits `(1/1)`.
- Updated the three existing log-format assertions (`test_log_heartbeat`, `test_gateway_interface_log`, `test_interface_logging`) to the `(n/total)` format; the multi-item ones use a regex since the counter is completion-order.

Full suite + ruff + mypy green locally.