### PR TITLE
fix(nits): #91 remainder — drift digest validation, formatter/fsync/histogram hardening

### DIFF
--- a/.github/workflows/base-drift.yml
+++ b/.github/workflows/base-drift.yml
@@ -45,6 +45,9 @@ jobs:
           if [ -z "${current}" ]; then
             echo "::warning::could not resolve current digest — skipping this run"; exit 0
           fi
+          if ! printf '%s' "${current}" | grep -Eq '^sha256:[0-9a-f]{64}$'; then
+            echo "::warning::resolved digest '${current}' is malformed — refusing to pin"; exit 0
+          fi
           if [ "${current}" = "${pinned}" ]; then
             echo "Base image unchanged — nothing to do."; exit 0
           fi

--- a/.github/workflows/socket-proxy-drift.yml
+++ b/.github/workflows/socket-proxy-drift.yml
@@ -48,6 +48,9 @@ jobs:
           if [ -z "${current}" ]; then
             echo "::warning::could not resolve current digest — skipping this run"; exit 0
           fi
+          if ! printf '%s' "${current}" | grep -Eq '^sha256:[0-9a-f]{64}$'; then
+            echo "::warning::resolved digest '${current}' is malformed — refusing to open a PR"; exit 0
+          fi
           if [ "${current}" = "${pinned}" ]; then
             echo "socket-proxy unchanged — nothing to do."; exit 0
           fi

--- a/gluetun_monitor/alert_state.py
+++ b/gluetun_monitor/alert_state.py
@@ -31,6 +31,7 @@ happened while it was down.
 from __future__ import annotations
 
 import json
+import os
 from dataclasses import asdict, dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -224,10 +225,26 @@ class AlertState:
             "active": {key: asdict(a) for key, a in self._active.items()},
         }
         try:
-            Path(self._path).parent.mkdir(parents=True, exist_ok=True)
+            target = Path(self._path)
+            target.parent.mkdir(parents=True, exist_ok=True)
             tmp = Path(f"{self._path}.tmp")
             with tmp.open("w", encoding="utf-8") as fh:
                 json.dump(payload, fh, indent=2, sort_keys=True)
-            tmp.replace(self._path)
+                fh.flush()
+                os.fsync(fh.fileno())  # data on disk before the rename
+            tmp.replace(self._path)  # atomic rename
+            self._fsync_dir(target.parent)  # persist the rename itself (mirror SiteStatsStore)
         except OSError as exc:
             self._log.debug(f"notify: could not persist alert state: {exc}")
+
+    @staticmethod
+    def _fsync_dir(directory: Path) -> None:
+        """Best-effort fsync of a directory so the rename survives power loss."""
+        try:
+            fd = os.open(str(directory), os.O_RDONLY)
+            try:
+                os.fsync(fd)
+            finally:
+                os.close(fd)
+        except OSError:
+            pass

--- a/gluetun_monitor/histogram.py
+++ b/gluetun_monitor/histogram.py
@@ -75,7 +75,10 @@ class LatencyHistogram:
             cumulative += self.buckets[key]
             if cumulative >= rank:
                 return _bucket_value(key)
-        return _bucket_value(max(self.buckets))  # unreachable; defensive
+        # Defensive: with a consistent sketch (count == sum of bucket counts, which
+        # from_dict now enforces) this is unreachable. Guard the empty case anyway so
+        # a future inconsistency can't turn max({}) into a ValueError crash.
+        return _bucket_value(max(self.buckets)) if self.buckets else 0
 
     def summary(self) -> dict[str, int]:
         """Samples + exact avg/min/max + approximate p50/p90/p99 (ms)."""
@@ -92,7 +95,12 @@ class LatencyHistogram:
         }
 
     def merge(self, other: LatencyHistogram) -> None:
-        """Fold ``other`` into this one (the mergeable property — counts add)."""
+        """Fold ``other`` into this one (the mergeable property — counts add).
+
+        Retained deliberately (no production caller yet): merging is the defining
+        operation of this DDSketch-style sketch, and the recency-weighted all-time
+        view (#25) folds per-period histograms through it.
+        """
         if other.count == 0:
             return
         for key, cnt in other.buckets.items():
@@ -126,8 +134,16 @@ class LatencyHistogram:
                 for k, v in raw_buckets.items()
                 if isinstance(v, int | float)
             }
+            count = int(data.get("count", 0))
+            # A valid sketch always has count == sum of bucket counts (observe() bumps
+            # both together). A corrupt-but-parseable sidecar that breaks this invariant
+            # — e.g. count=100 with empty buckets — would make quantile() seek a rank the
+            # buckets can't satisfy. Reject to empty rather than load an inconsistent one
+            # (honors the "malformed → empty, never crash" contract above).
+            if count < 0 or count != sum(buckets.values()):
+                return cls()
             return cls(
-                count=int(data.get("count", 0)),
+                count=count,
                 sum_ms=int(data.get("sum_ms", 0)),
                 min_ms=int(data.get("min_ms", 0)),
                 max_ms=int(data.get("max_ms", 0)),

--- a/gluetun_monitor/logging_setup.py
+++ b/gluetun_monitor/logging_setup.py
@@ -44,10 +44,19 @@ class _BashFormatter(logging.Formatter):
     """Render ``[ts] [LEVEL] msg``, displaying WARNING as WARN (v1.x parity)."""
 
     def format(self, record: logging.LogRecord) -> str:
-        """Format a record, displaying WARNING as WARN for v1.x parity."""
-        if record.levelname == "WARNING":
+        """Format a record, displaying WARNING as WARN for v1.x parity.
+
+        The rename is restored before returning: ``LogRecord`` is shared across all
+        handlers on the logger, so mutating ``levelname`` in place would leak "WARN"
+        into any other handler (or a future second one) that formats the same record.
+        """
+        original = record.levelname
+        if original == "WARNING":
             record.levelname = "WARN"
-        return super().format(record)
+        try:
+            return super().format(record)
+        finally:
+            record.levelname = original
 
 
 def install_bash_format_on_root(level: str = "WARNING") -> None:

--- a/gluetun_monitor/notify.py
+++ b/gluetun_monitor/notify.py
@@ -116,6 +116,13 @@ class AppriseNotifier:
         self._level = tier_rank(level)
         self._timeout = timeout_seconds
         self._log = logger
+        # An unrecognized NOTIFY_LEVEL silently ranks 0 (the loudest floor) — say so
+        # once at startup rather than leave the operator wondering why everything sends.
+        if level.lower() not in _TIER_RANK:
+            self._log.warn(
+                f"NOTIFY_LEVEL '{level}' is not a recognized tier {TIERS}; "
+                f"treating it as the loudest floor ('attention')"
+            )
         self._apprise = self._build(urls, apprise_factory)
         # At most ONE send in flight: a backend that ignores its own socket timeout
         # would otherwise leak one abandoned daemon thread per loop, unbounded (#85).
@@ -180,7 +187,7 @@ class AppriseNotifier:
 
     def _compose(self, events: list[NotifyEvent]) -> tuple[str, str, str]:
         """Render survivors into one (title, body, notify_type). Worst tier wins the type."""
-        ordered = sorted(events, key=lambda e: tier_rank(e.tier))  # action first
+        ordered = sorted(events, key=lambda e: tier_rank(e.tier))  # attention first
         ntype = _TIER_NOTIFY_TYPE.get(ordered[0].tier, "info")
         if len(ordered) == 1:
             return ordered[0].title, ordered[0].body, ntype

--- a/tests/test_histogram.py
+++ b/tests/test_histogram.py
@@ -112,3 +112,21 @@ def test_from_dict_tolerates_garbage() -> None:
     assert LatencyHistogram.from_dict({"buckets": "nope"}).count == 0
     # partial / wrong-typed values degrade to empty, never raise
     assert LatencyHistogram.from_dict({"count": "x", "buckets": {}}).count == 0
+
+
+def test_from_dict_rejects_count_bucket_mismatch() -> None:
+    """#91: a corrupt-but-parseable sidecar whose count disagrees with its buckets
+    (e.g. count=100, empty buckets) is rejected to empty rather than loaded — an
+    inconsistent sketch would make quantile() seek a rank the buckets can't satisfy."""
+    h = LatencyHistogram.from_dict(
+        {"count": 100, "sum_ms": 5000, "min_ms": 1, "max_ms": 99, "buckets": {}}
+    )
+    assert h.count == 0
+    assert h.summary()["samples"] == 0
+
+
+def test_quantile_never_crashes_on_inconsistent_instance() -> None:
+    """Defense-in-depth: even a hand-built inconsistent histogram (count>0, no
+    buckets) must not turn the quantile fallback's max({}) into a ValueError."""
+    broken = LatencyHistogram(count=5, sum_ms=0, min_ms=0, max_ms=0, buckets={})
+    assert broken.quantile(0.5) == 0

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -140,3 +140,18 @@ def test_install_bash_format_on_root_formats_third_party() -> None:
     line = fmt.format(rec)
     assert _LINE_RE.match(line), line   # [ts] [WARN] pool full
     assert "[WARN]" in line
+
+
+def test_bash_formatter_does_not_mutate_record_levelname() -> None:
+    """#91: WARNING renders as WARN, but the shared LogRecord must be restored —
+    mutating levelname in place would leak "WARN" into any other handler formatting
+    the same record."""
+    import logging
+
+    from gluetun_monitor.logging_setup import _BashFormatter
+
+    fmt = _BashFormatter("[%(levelname)s] %(message)s")
+    record = logging.LogRecord("t", logging.WARNING, "f", 1, "hi", None, None)
+    rendered = fmt.format(record)
+    assert "[WARN]" in rendered            # display parity preserved
+    assert record.levelname == "WARNING"   # ...without corrupting the record

--- a/tests/test_notify.py
+++ b/tests/test_notify.py
@@ -180,3 +180,15 @@ def test_hung_backend_does_not_leak_a_thread_per_dispatch() -> None:
         assert threading.active_count() - before <= 1  # one in-flight worker, not five
     finally:
         release.set()
+
+
+def test_unknown_notify_level_warns() -> None:
+    """#91: an unrecognized NOTIFY_LEVEL silently ranks 0 (loudest); warn once at
+    construction so the operator isn't left guessing why everything sends."""
+    stream = io.StringIO()
+    logger = Logger(log_file=None, level="DEBUG", stream=stream)
+    AppriseNotifier(
+        ("memory://",), level="bogus", logger=logger,
+        apprise_factory=lambda _urls: _FakeApprise(),
+    )
+    assert "not a recognized tier" in stream.getvalue()


### PR DESCRIPTION
Works down the remaining actionable items on the #91 review-nit checklist. (The CLI-ordering, Dockerfile HEALTHCHECK/PYTHONUNBUFFERED, compose seccomp, and notify docstring items were already resolved in #119.)

## Fixes
- **Drift-workflow digest validation** — `base-drift.yml` and `socket-proxy-drift.yml` now validate the registry-scraped digest against `^sha256:[0-9a-f]{64}$` **before** any `sed`/commit/PR. A malformed manifest header could otherwise auto-commit a garbage pin to main. (This also hardens the `socket-proxy-drift.yml` I added last session — it inherited base-drift's unvalidated pattern.)
- **`logging_setup`** — `_BashFormatter` was mutating the shared `LogRecord.levelname` to "WARN" in place; now restored after formatting, so it can't leak into another handler formatting the same record.
- **`alert_state.save()`** — now fsyncs the temp file + directory, matching `SiteStatsStore.save`, so the alert sidecar survives power loss like its sibling.
- **`histogram`** — `from_dict` rejects a corrupt-but-parseable sidecar whose `count` disagrees with its bucket totals (which would make `quantile()` seek an unsatisfiable rank), and the `quantile()` fallback now guards the empty-bucket case so it can never turn `max({})` into a `ValueError`.
- **`notify`** — warns once at construction when `NOTIFY_LEVEL` isn't a recognized tier (it silently ranked 0 = loudest); fixed a stale "action first" comment.

## Decisions
- **`histogram.merge()` — kept**, not dropped. It's the defining operation of the mergeable sketch and the natural consumer is #25 (recency-weighted all-time view). Documented in-code so the "no caller yet" isn't mistaken for dead code.

## Deferred (own follow-ups, tracked on #91)
- **`discover_dependents` N+1 inspects** — the fix (read `NetworkMode` from the `/containers/json` list payload instead of inspecting each container) needs a `DockerClient` protocol change + both impls + fakes, so it's a separate focused PR. Doing it next.
- **`getent hosts --` → drop `--`** — reverted. It's a tested arg-injection guard (`test_arg_injection.py`), and the "musl treats `--` as a key" claim in the checklist was explicitly unverified. Removing a security guard on an unverified claim isn't worth it; needs real per-libc testing first.

## Tests
New behavior tests: formatter doesn't mutate the record, `from_dict` count/bucket-mismatch rejection + quantile safety, unknown-`NOTIFY_LEVEL` warning. Full suite + ruff + mypy green.