### PR TITLE
perf(dependents): discover from the list payload, not an inspect per container (#91)

### DIFF
--- a/gluetun_monitor/dependents.py
+++ b/gluetun_monitor/dependents.py
@@ -52,10 +52,11 @@ def discover_dependents(client: DockerClient, gluetun_container: str) -> list[st
     id_form = f"container:{gluetun_id}"
     short_prefix = f"container:{short_id}"
 
+    # One list call carries every running container's name + network_mode, so we no
+    # longer inspect() each container individually (was an N+1 per loop).
     found: list[str] = []
-    for cid in client.list_running_ids():
-        info = client.inspect(cid)
-        if info is None or info.name == gluetun_container:
+    for info in client.list_running():
+        if info.name == gluetun_container:
             continue
         nm = info.network_mode
         if nm in (name_form, id_form) or nm.startswith(short_prefix):

--- a/gluetun_monitor/docker_client.py
+++ b/gluetun_monitor/docker_client.py
@@ -51,6 +51,28 @@ class ContainerInfo:
             raw=raw,
         )
 
+    @classmethod
+    def from_list_entry(cls, entry: dict[str, Any]) -> ContainerInfo:
+        """Build a ContainerInfo from a ``GET /containers/json`` **list** entry.
+
+        The list payload's ``HostConfig`` carries only ``NetworkMode`` and its state is
+        the string ``"running"`` (vs. inspect's ``State.Running`` bool and nested
+        ``Health``) — enough for dependent discovery (id / name / network_mode) without
+        an inspect per container. ``health`` is left ``"unknown"`` and ``raw`` is the
+        list entry (NOT a full inspect), so any caller needing ``Config``/``Mounts``
+        must still ``inspect()``.
+        """
+        names = entry.get("Names") or []
+        host_config = entry.get("HostConfig", {}) or {}
+        return cls(
+            id=entry.get("Id", ""),
+            name=str(names[0]).lstrip("/") if names else "",
+            network_mode=str(host_config.get("NetworkMode", "")),
+            running=str(entry.get("State", "")).lower() == "running",
+            health="unknown",
+            raw=entry,
+        )
+
 
 class DockerClient(Protocol):
     """The minimal Docker surface the monitor depends on."""
@@ -66,6 +88,13 @@ class DockerClient(Protocol):
 
     def list_running_ids(self) -> list[str]:
         """IDs of currently running containers."""
+        ...
+
+    def list_running(self) -> list[ContainerInfo]:
+        """Running containers as ContainerInfo, from a single list call — so callers
+        that only need id/name/network_mode (dependent discovery) avoid an inspect
+        per container. ``raw`` is the list entry, not a full inspect.
+        """
         ...
 
     def list_all_ids(self) -> list[str]:
@@ -151,6 +180,12 @@ class DockerPyClient:
     def list_running_ids(self) -> list[str]:
         """``GET /containers/json`` (running only) → their ids."""
         return [c["Id"] for c in self._api.containers(all=False)]
+
+    def list_running(self) -> list[ContainerInfo]:
+        """``GET /containers/json`` (running only) → ContainerInfo from each list
+        entry — one API call for the whole set, no per-container inspect.
+        """
+        return [ContainerInfo.from_list_entry(c) for c in self._api.containers(all=False)]
 
     def list_all_ids(self) -> list[str]:
         """``GET /containers/json?all=1`` (every container) → their ids."""

--- a/tests/fakes.py
+++ b/tests/fakes.py
@@ -81,6 +81,7 @@ class FakeDockerClient:
         self.renamed: list[tuple[str, str]] = []  # (name_or_id, new_name)
         self.ensured_timeouts: list[int] = []  # every ensure_timeout() call (#77)
         self.logs_tails: list[int] = []  # tail= of every logs() call (#78)
+        self.inspect_count = 0  # total inspect() calls (assert no per-container N+1)
         self._id_seq = 1000
 
     # ----- test setup helpers -----
@@ -120,10 +121,21 @@ class FakeDockerClient:
             if raw.get("State", {}).get("Running", False)
         ]
 
+    def list_running(self) -> list[ContainerInfo]:
+        # The fake stores inspect-shaped dicts, so from_inspect yields the correct
+        # name/network_mode a caller reads — regardless of the real client parsing
+        # the (leaner) list payload via from_list_entry.
+        return [
+            ContainerInfo.from_inspect(raw)
+            for raw in self._store.values()
+            if raw.get("State", {}).get("Running", False)
+        ]
+
     def list_all_ids(self) -> list[str]:
         return list(self._store.keys())
 
     def inspect(self, name_or_id: str) -> ContainerInfo | None:
+        self.inspect_count += 1  # so tests can assert discover_dependents isn't N+1
         raw = self._resolve(name_or_id)
         return ContainerInfo.from_inspect(raw) if raw is not None else None
 

--- a/tests/test_dependents.py
+++ b/tests/test_dependents.py
@@ -158,3 +158,23 @@ class _NullLogger:
     def debug(self, m: str) -> None: ...
     def check(self, m: str) -> None: ...
     def endpoint(self, m: str) -> None: ...
+
+
+def test_discover_dependents_is_not_n_plus_one() -> None:
+    """discover_dependents reads name+network_mode from the single list_running()
+    payload, so its inspect() count is O(1) (just the gluetun lookup) — not one per
+    running container. Guards against a regression back to the per-container inspect.
+    """
+    fake = FakeDockerClient()
+    fake.add_container("gluetun", id=GLUETUN_ID)
+    for i in range(8):
+        fake.add_container(f"dep{i}", network_mode=f"container:{GLUETUN_ID}")
+    # A few unrelated running containers that must NOT be picked up (or inspected).
+    for i in range(4):
+        fake.add_container(f"other{i}", network_mode="bridge")
+
+    fake.inspect_count = 0
+    found = discover_dependents(fake, "gluetun")
+
+    assert sorted(found) == [f"dep{i}" for i in range(8)]
+    assert fake.inspect_count == 1  # only the gluetun inspect; no per-container N+1


### PR DESCRIPTION
The last remaining code item on the #91 checklist.

## Problem
`discover_dependents` ran `list_running_ids()` and then `inspect()` on **every running container** each loop, just to read its `NetworkMode` and decide if it shares gluetun's netns. On a busy host that's dozens of inspect round-trips through the socket proxy every `CHECK_INTERVAL` — a classic N+1.

## Fix
The `GET /containers/json` list payload already includes each container's `Names` and `HostConfig.NetworkMode` — everything discovery needs. So:
- `ContainerInfo.from_list_entry()` builds a `ContainerInfo` from a list entry (id / name / network_mode; health defaults to `unknown`, `raw` is the list entry, not a full inspect).
- `DockerClient.list_running()` returns those from one API call.
- `discover_dependents` consumes `list_running()` instead of inspecting each container.

Per-loop API calls for discovery drop from **1 + N** to **1** (gluetun lookup) **+ 1** (the list). Anything needing `Config`/`Mounts` still `inspect()`s — only discovery changed.

## Tests
- New `test_discover_dependents_is_not_n_plus_one`: 8 dependents + 4 unrelated containers → exactly **one** `inspect()` (the gluetun lookup), so a regression back to per-container inspect fails the test.
- The fake's `list_running()` builds from its stored inspect dicts (so names/modes are correct in tests), while the real client parses the leaner list payload — the real-daemon integration job exercises that path.

Closes the #91 checklist (the `getent --` item was intentionally left as-is — it's a tested arg-injection guard; see #128 for that rationale).

Full suite + ruff + mypy green.