### PR TITLE
ci: single-source the Python version from the Dockerfile (#82 follow-up)

### DIFF
--- a/.github/workflows/base-drift.yml
+++ b/.github/workflows/base-drift.yml
@@ -29,9 +29,15 @@ jobs:
       - name: Bump the base-image pin if upstream moved
         env:
           REPO: library/python
-          TAG: "3.14-slim"
         run: |
           set -euo pipefail
+          # Derive the base tag from the Dockerfile (single source of truth), so a
+          # version bump (python:3.14-slim → 3.15-slim) needs no edit here — this keeps
+          # tracking whatever base the image actually declares.
+          TAG="$(grep -oP 'FROM python:\K[0-9.]+-slim' Dockerfile | head -1)"
+          if [ -z "${TAG}" ]; then
+            echo "::error::could not read the base tag from the Dockerfile FROM line"; exit 1
+          fi
           token=$(curl -s "https://auth.docker.io/token?service=registry.docker.io&scope=repository:${REPO}:pull" | jq -r .token)
           current=$(curl -sI \
             -H "Authorization: Bearer ${token}" \
@@ -39,7 +45,7 @@ jobs:
             -H "Accept: application/vnd.docker.distribution.manifest.list.v2+json" \
             "https://registry-1.docker.io/v2/${REPO}/manifests/${TAG}" \
             | grep -i '^docker-content-digest:' | awk '{print $2}' | tr -d '\r')
-          pinned=$(grep -oP 'FROM python:3\.14-slim@\K\S+' Dockerfile)
+          pinned=$(grep -oP "FROM python:${TAG}@\K\S+" Dockerfile)
           echo "pinned:  ${pinned}"
           echo "current: ${current:-<none>}"
           if [ -z "${current}" ]; then
@@ -56,5 +62,5 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add Dockerfile
-          git commit -m "fix(deps): rebuild on updated python:3.14-slim base (${current})"
+          git commit -m "fix(deps): rebuild on updated python:${TAG} base (${current})"
           git push

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,16 +11,44 @@ permissions:
   contents: read
 
 jobs:
+  runtime-python:
+    name: Resolve runtime Python from the Dockerfile
+    runs-on: ubuntu-latest
+    outputs:
+      runtime: ${{ steps.read.outputs.runtime }}
+      versions: ${{ steps.read.outputs.versions }}
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      - id: read
+        # SINGLE SOURCE OF TRUTH for the Python version: the base image
+        # (FROM python:X.Y-slim in the Dockerfile). Every setup-python job below
+        # derives from this, so a base bump (3.14 → 3.15 → …) is a one-line Dockerfile
+        # change with no other edits — nothing can test/resolve against a version the
+        # image doesn't ship.
+        #
+        # `runtime` = that one version (lint/type/test coverage floor, lock-audit, and
+        # the real-daemon integration all use it). `versions` = the test matrix,
+        # normally just [runtime]. During a base bump, widen `versions` HERE to
+        # validate the candidate alongside the current (e.g. ["3.14","3.15"]) before
+        # switching the Dockerfile FROM, then drop the old.
+        run: |
+          runtime="$(grep -oP 'FROM python:\K[0-9]+\.[0-9]+' Dockerfile | head -1)"
+          if [ -z "${runtime}" ]; then
+            echo "::error::could not read 'FROM python:X.Y' from the Dockerfile"; exit 1
+          fi
+          echo "runtime=${runtime}" >> "$GITHUB_OUTPUT"
+          echo "versions=[\"${runtime}\"]" >> "$GITHUB_OUTPUT"
+
   python:
     name: Python (lint, types, tests)
+    needs: runtime-python
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
-      # 3.14-only: the product is a single python:3.14-slim image, so that's the only
-      # runtime worth testing. (A future base bump temporarily adds the candidate
-      # here — e.g. 3.14 + 3.15 — validates, switches the base, then drops the old.)
+      # Matrix comes from the Dockerfile via runtime-python (single source of truth) —
+      # to test a candidate during a base bump, widen `versions` there, not here.
       matrix:
-        python-version: ["3.14"]
+        python-version: ${{ fromJSON(needs.runtime-python.outputs.versions) }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
@@ -29,7 +57,7 @@ jobs:
         # bump in pyproject that didn't regenerate the lock would silently NOT reach
         # the image (and silently break the docker-py/apprise auto-merge promotion).
         # Fail closed: assert the lock's direct pins equal pyproject's. (The deeper
-        # "lock is faithful to 3.14" check is the lock-audit job below.) Regenerate
+        # "lock is faithful to the runtime" check is the lock-audit job below.) Regenerate
         # in the runtime interpreter, NOT a host python — see scripts/regen-lock.sh.
         run: |
           for pkg in docker apprise; do
@@ -80,23 +108,17 @@ jobs:
 
   lock-audit:
     name: requirements.lock faithful to the runtime Python
+    needs: runtime-python
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
-      - name: Read the runtime Python version from the Dockerfile
-        # Single source of truth: the base image (FROM python:X.Y-slim) decides the
-        # runtime, so the lock must be resolved under X.Y. Deriving it here means a
-        # base bump (3.14 → 3.15 → …) is a one-line Dockerfile change and this audit
-        # follows automatically — it can never validate the lock against a different
-        # interpreter than the image actually ships (which would silently defeat #82).
-        id: pyver
-        run: echo "version=$(grep -oP 'FROM python:\K[0-9]+\.[0-9]+' Dockerfile | head -1)" >> "$GITHUB_OUTPUT"
-
-      - name: Set up Python ${{ steps.pyver.outputs.version }}
+      - name: Set up Python ${{ needs.runtime-python.outputs.runtime }}
+        # Resolved from the Dockerfile by runtime-python, so this can never validate
+        # the lock against a different interpreter than the image ships (#82).
         uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
-          python-version: ${{ steps.pyver.outputs.version }}
+          python-version: ${{ needs.runtime-python.outputs.runtime }}
 
       - name: Assert the committed lock == a fresh pip-compile under that version
         # #82: exercises requirements.lock (nothing did before) and pins it to the
@@ -113,18 +135,19 @@ jobs:
             echo "::error::requirements.lock is stale for the runtime Python. Regenerate with ./scripts/regen-lock.sh"
             exit 1
           fi
-          echo "requirements.lock matches pyproject.toml resolved under Python ${{ steps.pyver.outputs.version }}"
+          echo "requirements.lock matches pyproject.toml resolved under Python ${{ needs.runtime-python.outputs.runtime }}"
 
   pytest-integration:
     name: Integration (real daemon, pytest)
+    needs: runtime-python
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
-      - name: Set up Python
+      - name: Set up Python ${{ needs.runtime-python.outputs.runtime }}
         uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
-          python-version: "3.14"
+          python-version: ${{ needs.runtime-python.outputs.runtime }}
 
       - name: Install package + pinned dev tooling
         run: pip install -e . -r requirements-dev.txt

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,7 +19,7 @@ retained only as a differential test oracle (see below).
    ```
 4. Make your change with tests, run the gate (below), open a PR.
 
-Python **3.14** is the target (`requires-python`/`target-version`).
+The runtime Python is whatever the **Dockerfile**'s `FROM python:X.Y-slim` declares (currently **3.14**) — the single source of truth that CI derives its test matrix, lock audit, and integration job from. `pyproject.toml` (`requires-python` / ruff `target-version`) sets the supported floor.
 
 ## The gate — run this before every PR
 


### PR DESCRIPTION
Follow-up to #82/#131: eliminate the hardcoded Python version scattered across CI.

## Problem
The runtime version was hardcoded in **five** places — the Dockerfile `FROM`, the CI test matrix, `pytest-integration`, `lock-audit`, and `base-drift.yml`'s digest grep. A base bump could leave CI testing or validating a version the image doesn't actually ship (e.g. lock-audit resolving under 3.14 while the image moved to 3.15) — silently defeating the guard.

## Change — the Dockerfile is the single source of truth
- New **`runtime-python`** CI job reads `FROM python:X.Y-slim` once and outputs `runtime` (the version) + `versions` (the matrix, normally `[runtime]`). The `python`, `lock-audit`, and `pytest-integration` jobs derive from it (matrix via `fromJSON`; the rest via `needs.runtime-python.outputs.runtime`) — no more hardcoded `"3.14"`.
- **`base-drift.yml`** derives its base tag from the Dockerfile too, so it tracks whatever base the image declares (a version bump needs no edit there).
- **CONTRIBUTING** points at the Dockerfile as the source of truth.

Verified: no hardcoded `python-version` strings remain in ci.yml; all derivation greps resolve correctly against the current Dockerfile (`runtime=3.14`, `TAG=3.14-slim`, digest matches).

## Result
A base bump (3.14 → 3.15 → …) is a one-line Dockerfile change; to validate a candidate first, widen `versions` in the `runtime-python` job. The full recurring process is documented in **#133** (the periodic-bump runbook you asked for — "a fact of life every X years").

## What's intentionally NOT derived
`pyproject.toml`'s `requires-python` / ruff `target-version` — those are the *supported floor* (a policy choice), not the runtime, so they stay explicit.

No release (CI-only).