### PR TITLE
feat(notify): dependent-flapping advisory — escalate a chronically-remediated dependent (#45)

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,8 @@ docker compose up -d
 | `ADVISORY_WINDOW` | `86400` | Window (seconds) for the flaky-site advisory |
 | `ADVISORY_MIN_RESTARTS` | `5` | Minimum gluetun restarts in the window before an advisory can fire |
 | `ADVISORY_DOMINANCE` | `0.5` | Fraction of those restarts one site must cause to be flagged flaky |
+| `DEPENDENT_ADVISORY_WINDOW` | `86400` | Window (seconds) for the dependent-flapping advisory |
+| `DEPENDENT_ADVISORY_MIN_REMEDIATIONS` | `5` | Remediations of one dependent in the window before it's flagged as flapping |
 | `AUTO_RECREATE` | `1` | Recreate a dependent stranded by a Gluetun recreate (id changed). Set `0` to disable → such a dependent is reported FAILED instead |
 | `DNS_WAIT_TIMEOUT` | `30` | Max seconds to wait for Gluetun DNS to stabilize after a restart |
 | `LOG_LEVEL` | `INFO` | `DEBUG` to include per-site/per-dependent detail lines |
@@ -697,6 +699,22 @@ That's the signal to prune that site from `sites.conf` (re-read each loop — se
 Tune with `ADVISORY_WINDOW`, `ADVISORY_MIN_RESTARTS`, and
 `ADVISORY_DOMINANCE`. See [ADR-0008](docs/adr/0008-persistent-site-stats-and-advisory.md).
 
+The **dependent-flapping advisory** is the same idea aimed at a *dependent* rather
+than a site: a container that keeps needing remediation but won't stay healthy
+self-heals every loop (a quiet `recovery` event) and would otherwise never reach a
+human. When one is remediated `DEPENDENT_ADVISORY_MIN_REMEDIATIONS` times within
+`DEPENDENT_ADVISORY_WINDOW`, it escalates to an `attention` alert:
+
+```
+[WARN] FLAPPING DEPENDENT: qbittorrent remediated 6 times in the last 24h
+— it won't stay healthy; investigate
+```
+
+It's **count-based, not dominance-based** (each dependent is independent — there's
+no shared gluetun to contend for), and the per-loop DEBUG logs already show *which*
+sites/DNS failed each time, so the alert just points you at the right container to
+investigate.
+
 > **By design, the monitor does not auto-suppress a flaky site** — it keeps
 > applying the cheap restart fix and escalates to you. (A future automatic
 > back-off is possible; it would be opt-in.)
@@ -756,7 +774,7 @@ line looks. Each level adds its own row to everything above it (ADR-0011):
 
 | `NOTIFY_LEVEL` | You get | Events |
 |---|---|---|
-| **`attention`** *(default)* | only when **you** must act/decide | recovery/remediation failed, refused to start, **flaky-site advisory** |
+| **`attention`** *(default)* | only when **you** must act/decide | recovery/remediation failed, refused to start, **flaky-site advisory**, **dependent-flapping advisory** |
 | `recovery` | + self-healed incidents | gluetun recovered, dependent remediated |
 | `activity` | + non-fault changes | `sites.conf` reloaded, **advisory site unreachable / recovered** |
 | `all` | + the firehose | per-loop checks, restart play-by-play |

--- a/docker-compose.yml.example
+++ b/docker-compose.yml.example
@@ -104,6 +104,11 @@ services:
       # - ADVISORY_WINDOW=86400      # seconds (24h)
       # - ADVISORY_MIN_RESTARTS=5
       # - ADVISORY_DOMINANCE=0.5     # one site causing >=50% of recent restarts -> flag it
+      # Dependent-flapping advisory: warns (attention) when a dependent keeps needing
+      # remediation but won't stay healthy — the dependent analogue of the flaky-site
+      # advisory. On by default; count-based (no dominance).
+      # - DEPENDENT_ADVISORY_WINDOW=86400          # seconds (24h)
+      # - DEPENDENT_ADVISORY_MIN_REMEDIATIONS=5    # >=N remediations of one dependent in the window -> flag it
       # --- Notifications (opt-in; unset = log-only, no outbound traffic) ---
       # Comma-separated Apprise URLs to push significant events (restart, recovery
       # failure, dependent remediation, flaky-site advisory, refusal to start).

--- a/gluetun_monitor/config.py
+++ b/gluetun_monitor/config.py
@@ -160,6 +160,12 @@ class Config:
     advisory_window: int = 86400
     advisory_min_restarts: int = 5
     advisory_dominance: float = 0.5
+    # #45: dependent-flapping advisory — a dependent remediated >= N times in the
+    # window keeps failing and being healed but won't stay healthy. Count-based
+    # (no dominance — each dependent is independent). On by default like the site
+    # advisory (it only emits an alert, never acts).
+    dependent_advisory_window: int = 86400
+    dependent_advisory_min_remediations: int = 5
 
     # --- Opt-in notification layer (issue #22, ADR-0010) ---
     # Comma-separated Apprise URLs (ntfy/Discord/Telegram/email/webhook/…).
@@ -269,6 +275,10 @@ class Config:
             advisory_min_restarts=_env_int("ADVISORY_MIN_RESTARTS", 5, errors, minimum=1),
             advisory_dominance=_env_float("ADVISORY_DOMINANCE", 0.5, errors,
                                           minimum=0.0, maximum=1.0),
+            dependent_advisory_window=_env_int("DEPENDENT_ADVISORY_WINDOW", 86400,
+                                               errors, minimum=1),
+            dependent_advisory_min_remediations=_env_int(
+                "DEPENDENT_ADVISORY_MIN_REMEDIATIONS", 5, errors, minimum=1),
             apprise_urls=tuple(
                 u.strip() for u in os.environ.get("APPRISE_URLS", "").split(",") if u.strip()
             ),

--- a/gluetun_monitor/monitor.py
+++ b/gluetun_monitor/monitor.py
@@ -147,6 +147,7 @@ class Monitor:
         # Persistent per-site stats (ADR-0008). Injectable for tests.
         self.stats = stats if stats is not None else SiteStatsStore(config.stats_file)
         self._advised_site: str | None = None  # dedup the flaky-site advisory
+        self._advised_deps: set[str] = set()  # dedup the dependent-flapping advisory (#45)
         # Sites that triggered an active gluetun-unrecovered alert (#106). Held so
         # the alert resolves only on OBSERVED recovery, not on the mechanical
         # post-restart counter reset that makes the next loop look sub-threshold.
@@ -822,7 +823,7 @@ class Monitor:
                 )
                 continue
             self.log.warn(f"Remediating dependent {dep}: {reason}")
-            self.stats.record_dependent_remediation()
+            self.stats.record_dependent_remediation(dep)
             outcome = remediate_dependent(
                 self.client, dep, gluetun_id, self.config, self.log, sleep=self._sleep
             )
@@ -837,6 +838,12 @@ class Monitor:
                 )
             else:
                 self._record_remediation_failure(dep, reason, outcome)
+
+        # Surface a dependent-flapping advisory (#45) for any dependent that keeps
+        # needing remediation. Evaluated every completed loop (like _emit_advisory) so
+        # the lifecycle edge-triggers the alert once and resolves it when the
+        # dependent settles back under the threshold.
+        self._emit_dependent_advisories()
 
     def _record_remediation_failure(
         self, dep: str, reason: str, outcome: RemediationOutcome
@@ -1213,6 +1220,44 @@ class Monitor:
             f"{format_window(adv.window_seconds)} — it may be flaky; consider "
             f"reviewing or removing it from sites.conf.{hint}"
         )
+
+    def _emit_dependent_advisories(self) -> None:
+        """Surface a dependent-flapping advisory for each dependent that keeps needing
+        remediation (#45) — the dependent analogue of :meth:`_emit_advisory`.
+
+        Reported every completed dependent phase so the lifecycle sees an ongoing
+        flapper continuously (edge-trigger once, resolve when it settles). A dependent
+        that drops back under the window threshold isn't re-reported, so the alert
+        resolves on its own. Log + stats fire once per episode per dependent
+        (``_advised_deps``); the failing-site *detail* is intentionally left to the
+        per-loop DEBUG logs (not pre-chewed into the alert).
+        """
+        flapping = self.stats.dependent_advisories(
+            self.config.dependent_advisory_window,
+            self.config.dependent_advisory_min_remediations,
+        )
+        current = {adv.dependent for adv in flapping}
+        for adv in flapping:
+            window = format_window(adv.window_seconds)
+            self._problem(
+                f"dependent-flapping:{adv.dependent}",
+                "attention",
+                f"flapping dependent: {adv.dependent}",
+                f"{adv.dependent} was remediated {adv.remediations} times in the last "
+                f"{window} — it keeps failing and being healed but won't stay healthy; "
+                f"investigate (check the container's own logs / config).",
+            )
+            if adv.dependent not in self._advised_deps:
+                self._advised_deps.add(adv.dependent)
+                self.stats.record_advisory()
+                self.log.warn(
+                    f"FLAPPING DEPENDENT: {adv.dependent} remediated {adv.remediations} "
+                    f"times in the last {window} — it won't stay healthy; investigate."
+                )
+        # Forget the episode-dedup for dependents that stopped flapping, so a later
+        # re-flap logs fresh (the notification alert itself resolves via the lifecycle
+        # once the dependent is no longer reported above).
+        self._advised_deps &= current
 
     def _advisory_hint(self, site: str) -> str:
         """A one-sentence per-URL tunable suggestion for ``site`` if the stats

--- a/gluetun_monitor/site_stats.py
+++ b/gluetun_monitor/site_stats.py
@@ -144,6 +144,15 @@ class Advisory:
     window_seconds: int
 
 
+@dataclass
+class DependentAdvisory:
+    """A chronically-flapping dependent worth surfacing to the operator (#45)."""
+
+    dependent: str
+    remediations: int
+    window_seconds: int
+
+
 class SiteStatsStore:
     """In-memory site stats with best-effort JSON persistence + advisory logic."""
 
@@ -161,6 +170,9 @@ class SiteStatsStore:
         self._latency_max = latency_ring_max
         self.sites: dict[str, SiteStat] = {}
         self.recent_restarts: list[dict[str, object]] = []  # {"ts": float, "site": str}
+        # #45: timestamped remediation events for the dependent-flapping advisory —
+        # the dependent analogue of recent_restarts.
+        self.recent_remediations: list[dict[str, object]] = []  # {"ts": float, "dependent": str}
         self.monitor = MonitorStats()
         self._load()
         # Stamp this process's start; first_started persists from the first ever run.
@@ -228,11 +240,18 @@ class SiteStatsStore:
         """
         self.monitor.total_gluetun_restarts += 1
 
-    def record_dependent_remediation(self) -> None:
-        """One dependent remediation initiated — restart/recreate (monitor-wide
-        count; counted when the action is taken, not gated on it succeeding).
+    def record_dependent_remediation(self, dependent: str) -> None:
+        """One dependent remediation initiated — restart/recreate. Bumps the
+        monitor-wide count AND records a timestamped event for ``dependent`` so the
+        dependent-flapping advisory can spot a chronic re-offender (#45, mirroring
+        :meth:`record_restart`). Counted when the action is taken, not gated on it
+        succeeding.
         """
+        now = self._clock()
         self.monitor.total_dependent_remediations += 1
+        self.recent_remediations.append({"ts": now, "dependent": dependent})
+        if self._recent_max and len(self.recent_remediations) > self._recent_max:
+            del self.recent_remediations[: -self._recent_max]
 
     def record_advisory(self) -> None:
         """One flaky-site advisory raised (monitor-wide count)."""
@@ -282,6 +301,28 @@ class SiteStatsStore:
             return Advisory(site, top, len(recent), window_seconds)
         return None
 
+    def dependent_advisories(
+        self, window_seconds: int, min_remediations: int
+    ) -> list[DependentAdvisory]:
+        """Dependents remediated >= ``min_remediations`` times within ``window_seconds``.
+
+        The dependent analogue of :meth:`advisory` (#45), but **count-based, not
+        dominance-based**: each dependent is remediated independently — there's no
+        shared resource (like the single gluetun) they contend for — so "kept needing
+        healing N times" is the whole signal, no dominance fraction. Returns one entry
+        per flapping dependent (several can flap at once).
+        """
+        cutoff = self._clock() - window_seconds
+        counts = Counter(
+            str(r["dependent"]) for r in self.recent_remediations
+            if isinstance(r.get("ts"), int | float) and float(r["ts"]) >= cutoff  # type: ignore[arg-type]
+        )
+        return [
+            DependentAdvisory(dep, n, window_seconds)
+            for dep, n in counts.items()
+            if n >= min_remediations
+        ]
+
     # ----- persistence (best-effort) -----
 
     def _load(self) -> None:
@@ -314,6 +355,11 @@ class SiteStatsStore:
             recent = data.get("recent_restarts", [])
             self.recent_restarts = [
                 r for r in recent if isinstance(r, dict) and "ts" in r and "site" in r
+            ]
+            recent_rem = data.get("recent_remediations", [])
+            self.recent_remediations = [
+                r for r in recent_rem
+                if isinstance(r, dict) and "ts" in r and "dependent" in r
             ]
             m = data.get("monitor") or {}
             # `version` and `last_started` are intentionally NOT reloaded: version
@@ -374,6 +420,7 @@ class SiteStatsStore:
             "monitor": monitor_out,
             "sites": sites_out,
             "recent_restarts": self.recent_restarts,
+            "recent_remediations": self.recent_remediations,
         }
         try:
             self._path.parent.mkdir(parents=True, exist_ok=True)

--- a/tests/test_dependent_flapping.py
+++ b/tests/test_dependent_flapping.py
@@ -1,0 +1,116 @@
+"""#45: the dependent-flapping advisory.
+
+A dependent that keeps needing remediation — N times within a window — escalates
+from the per-loop `recovery` events to an `attention` alert ("it won't stay
+healthy; investigate"), announced once and resolved by the lifecycle when it
+settles. Count-based (no dominance): the dependent analogue of the flaky-site
+advisory (#75), mirrored but simpler.
+"""
+
+from __future__ import annotations
+
+import io
+import random
+
+from gluetun_monitor.config import Config
+from gluetun_monitor.logging_setup import Logger
+from gluetun_monitor.monitor import Monitor
+from gluetun_monitor.site_stats import SiteStatsStore
+
+from .fakes import FakeDockerClient, FakeNotifier
+
+GLUETUN_ID = "a" * 64
+
+
+class _Clock:
+    def __init__(self, t: float = 1000.0) -> None:
+        self.t = t
+
+    def __call__(self) -> float:
+        return self.t
+
+
+def _monitor(notifier: FakeNotifier, clock: _Clock) -> tuple[Monitor, SiteStatsStore]:
+    fake = FakeDockerClient()
+    fake.add_container("gluetun", id=GLUETUN_ID, health="healthy")
+    stats = SiteStatsStore(None, clock=clock)
+    mon = Monitor(
+        fake,
+        Config(gluetun_container="gluetun",
+               dependent_advisory_min_remediations=3,
+               dependent_advisory_window=100),
+        Logger(log_file=None, stream=io.StringIO()),
+        rng=random.Random(0), sleep=lambda _s: None,
+        stats=stats, notifier=notifier,
+    )
+    return mon, stats
+
+
+def _cycle(mon: Monitor) -> None:
+    """One lifecycle cycle — exactly what run_once does around the advisory."""
+    mon.alerts.begin_loop()
+    mon._emit_dependent_advisories()
+    mon._flush_notifications()
+
+
+def test_flapping_dependent_escalates_to_attention_once() -> None:
+    """At >= threshold remediations in the window: one announce, no re-announce while
+    it keeps flapping, no false resolve."""
+    notifier = FakeNotifier()
+    stats_clock = _Clock(1000.0)
+    mon, stats = _monitor(notifier, stats_clock)
+    for _ in range(3):
+        stats.record_dependent_remediation("qbittorrent")
+
+    _cycle(mon)
+    _cycle(mon)  # still flapping -> stays active, no fresh announce
+
+    keys = notifier.event_keys()
+    assert keys.count("dependent-flapping:qbittorrent") == 1, keys
+    assert "resolve:dependent-flapping:qbittorrent" not in keys, keys
+
+
+def test_flapping_advisory_resolves_when_it_settles() -> None:
+    """Once the remediations age out of the window, the alert resolves exactly once."""
+    notifier = FakeNotifier()
+    stats_clock = _Clock(1000.0)
+    mon, stats = _monitor(notifier, stats_clock)
+    for _ in range(3):
+        stats.record_dependent_remediation("qbittorrent")
+
+    _cycle(mon)
+    assert "dependent-flapping:qbittorrent" in notifier.event_keys()
+
+    stats_clock.t += 200  # all three remediations now outside the 100s window
+    _cycle(mon)
+
+    keys = notifier.event_keys()
+    assert keys.count("resolve:dependent-flapping:qbittorrent") == 1, keys
+
+
+def test_below_threshold_dependent_is_silent() -> None:
+    notifier = FakeNotifier()
+    stats_clock = _Clock(1000.0)
+    mon, stats = _monitor(notifier, stats_clock)
+    for _ in range(2):  # below the min of 3
+        stats.record_dependent_remediation("prowlarr")
+
+    _cycle(mon)
+    assert notifier.events == []
+
+
+def test_two_dependents_flap_independently() -> None:
+    """No dominance — each dependent is judged on its own count, both can fire."""
+    notifier = FakeNotifier()
+    stats_clock = _Clock(1000.0)
+    mon, stats = _monitor(notifier, stats_clock)
+    for _ in range(3):
+        stats.record_dependent_remediation("qbittorrent")
+    for _ in range(4):
+        stats.record_dependent_remediation("prowlarr")
+
+    _cycle(mon)
+
+    keys = notifier.event_keys()
+    assert "dependent-flapping:qbittorrent" in keys
+    assert "dependent-flapping:prowlarr" in keys

--- a/tests/test_site_stats.py
+++ b/tests/test_site_stats.py
@@ -307,7 +307,7 @@ def test_monitor_level_counters() -> None:
         s.record_loop()
     s.record_gluetun_restart()
     s.record_gluetun_restart()
-    s.record_dependent_remediation()
+    s.record_dependent_remediation("dep")
     s.record_advisory()
     assert s.monitor.total_loops == 3
     assert s.monitor.total_gluetun_restarts == 2
@@ -365,3 +365,40 @@ def test_advisory_empty_window_is_none_even_if_min_restarts_zero() -> None:
     (review finding — the public method now guards `not recent`)."""
     store = SiteStatsStore(None)
     assert store.advisory(3600, 0, 0.5) is None
+
+
+# ----- #45 dependent-flapping advisory -----
+
+
+def test_dependent_advisories_counts_per_dependent() -> None:
+    """Count-based (no dominance): each dependent flagged independently once it hits
+    the threshold; a dependent below it isn't."""
+    clock = _Clock(1000.0)
+    s = SiteStatsStore(None, clock=clock)
+    for _ in range(3):
+        s.record_dependent_remediation("flappy")
+    for _ in range(2):
+        s.record_dependent_remediation("occasional")
+    advs = {a.dependent: a.remediations for a in s.dependent_advisories(100, 3)}
+    assert advs == {"flappy": 3}  # occasional (2) is below the min
+
+
+def test_dependent_advisories_respects_window() -> None:
+    clock = _Clock(1000.0)
+    s = SiteStatsStore(None, clock=clock)
+    for _ in range(5):
+        s.record_dependent_remediation("dep")
+    assert len(s.dependent_advisories(100, 5)) == 1
+    clock.t += 200  # all five remediations now fall outside the 100s window
+    assert s.dependent_advisories(100, 5) == []
+
+
+def test_recent_remediations_survive_persistence(tmp_path: Path) -> None:
+    clock = _Clock(1000.0)
+    p = tmp_path / "stats.json"
+    s = SiteStatsStore(str(p), clock=clock)
+    for _ in range(4):
+        s.record_dependent_remediation("dep")
+    assert s.save()
+    reloaded = SiteStatsStore(str(p), clock=clock)
+    assert len(reloaded.dependent_advisories(100, 4)) == 1  # counter survived a restart


### PR DESCRIPTION
Closes #45.

## Why
The flaky-site advisory (#75) escalates a **site** that keeps causing gluetun restarts to the `attention` tier. There was no equivalent for a **dependent** that keeps needing remediation — it self-heals every loop (a quiet `recovery` event) but never *stays* healthy, so it never reached a human. This closes that asymmetry.

## What
A faithful mirror of the site advisory, deliberately **simpler**:

- `SiteStatsStore` records a timestamped remediation per dependent (`recent_remediations`, mirroring `recent_restarts`; persisted in the sidecar) and exposes `dependent_advisories(window, min)` — **count-based, no dominance**. Each dependent is independent (no shared gluetun to contend for), so "healed N times in the window" is the whole signal — the site advisory's dominance knob simply isn't needed.
- `Monitor._emit_dependent_advisories()` reports `dependent-flapping:<dep>` (`attention`) each completed dependent phase; the ADR-0012 lifecycle edge-triggers it once and resolves it when the dependent settles. Log + stats fire once per episode per dependent.
- Knobs `DEPENDENT_ADVISORY_WINDOW=86400` / `DEPENDENT_ADVISORY_MIN_REMEDIATIONS=5`, **on by default** (it only emits an alert, never acts — like the site advisory, unlike #27 which we closed).

```
[WARN] FLAPPING DEPENDENT: qbittorrent remediated 6 times in the last 24h — it won't stay healthy; investigate
```

## Deliberately *not* included (design conversation)
- **No auto-backoff / demotion** (that was #27 — closed as a hidden third site-state, Tenet 9/ADR-0008 non-goal).
- **No failing-site attribution in the alert.** The per-loop DEBUG logs already show which sites/DNS failed, and confirm-before-strike (#61) means a remediation is *already* a genuine per-dependent fault (≥2 sites failed DNS), not site-outage noise. The alert points a human at the right container; the diagnosis lives in the logs (Tenets 1/8/9). Attribution would be over-sharpening.

No new ADR — extends the ADR-0008 advisory pattern.

## Tests
- `test_site_stats.py`: `dependent_advisories` count/window/persistence.
- `test_dependent_flapping.py`: escalates once, resolves when it settles, silent below threshold, two dependents flap independently.

Full suite + ruff + mypy green. This is the `feat` that turns the parked release PR into a real (2.6.0) release.