### PR TITLE
fix(monitor): never restart the tunnel over a probe that could not run (#137)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1181,6 +1181,8 @@ All three are required. `POST=1` in particular is unavoidable: tecnativa's `POST
 
 **If the monitor cannot probe, it does nothing.** Should `EXEC` be missing, the proxy become unreachable, or Gluetun stop shipping a usable `wget`, the site probes cannot *run* — which says nothing about the tunnel. Rather than mistake that for a connectivity failure and restart Gluetun (a restart cannot restore an EXEC permission), the monitor raises a distinct `attention` alert — *"cannot probe `<gluetun>`"* — holds its existing alerts, touches nothing, and never claims recovery it could not verify ([#137](https://github.com/csmarshall/gluetun-monitor/issues/137)).
 
+On `wget` specifically: Gluetun installs GNU `wget` deliberately (it's an explicit `apk add` in its Dockerfile), but that is an *implementation detail* rather than a documented guarantee — whether its presence is part of Gluetun's supported surface is [an open question upstream](https://github.com/passteque/gluetun/discussions/3387). The monitor is built not to care: probes are classified on the **HTTP response**, not on `wget`'s exit code, so GNU and BusyBox `wget` behave identically — and if it ever disappears entirely, the paragraph above applies. We report; we do not restart.
+
 The proxy and gluetun-monitor communicate over an isolated Docker network (`docker-proxy`). Only the proxy container has access to the Docker socket.
 
 ## Security Considerations

--- a/README.md
+++ b/README.md
@@ -774,7 +774,7 @@ line looks. Each level adds its own row to everything above it (ADR-0011):
 
 | `NOTIFY_LEVEL` | You get | Events |
 |---|---|---|
-| **`attention`** *(default)* | only when **you** must act/decide | recovery/remediation failed, refused to start, **flaky-site advisory**, **dependent-flapping advisory** |
+| **`attention`** *(default)* | only when **you** must act/decide | recovery/remediation failed, refused to start, **cannot probe the gateway**, **flaky-site advisory**, **dependent-flapping advisory** |
 | `recovery` | + self-healed incidents | gluetun recovered, dependent remediated |
 | `activity` | + non-fault changes | `sites.conf` reloaded, **advisory site unreachable / recovered** |
 | `all` | + the firehose | per-loop checks, restart play-by-play |
@@ -1176,6 +1176,10 @@ The recommended deployment uses a [Docker socket proxy](https://github.com/Tecna
 | `CONTAINERS=1` | Listing, inspecting, and reading logs of containers; creating the replacement when recreating a stranded dependent |
 | `POST=1` | Restarting, removing, and starting containers (the recreate path rides on the same `POST` flag — no new permission) |
 | `EXEC=1` | Running connectivity/interface probes inside Gluetun and the dependents |
+
+All three are required. `POST=1` in particular is unavoidable: tecnativa's `POST` is a *binary* switch for the container API — with `POST=0`, the `EXEC` and `ALLOW_RESTARTS` carve-outs are inert, so neither probing nor restarting works (verified; see [#29](https://github.com/csmarshall/gluetun-monitor/issues/29)).
+
+**If the monitor cannot probe, it does nothing.** Should `EXEC` be missing, the proxy become unreachable, or Gluetun stop shipping a usable `wget`, the site probes cannot *run* — which says nothing about the tunnel. Rather than mistake that for a connectivity failure and restart Gluetun (a restart cannot restore an EXEC permission), the monitor raises a distinct `attention` alert — *"cannot probe `<gluetun>`"* — holds its existing alerts, touches nothing, and never claims recovery it could not verify ([#137](https://github.com/csmarshall/gluetun-monitor/issues/137)).
 
 The proxy and gluetun-monitor communicate over an isolated Docker network (`docker-proxy`). Only the proxy container has access to the Docker socket.
 

--- a/gluetun_monitor/connectivity.py
+++ b/gluetun_monitor/connectivity.py
@@ -105,6 +105,12 @@ class SiteResult:
     signal used by dependent viability (the only per-container fault — see module
     docstring). They are distinct on purpose: a connect-refused/timeout makes
     ``ok`` False but ``dns_failed`` False (the dependent's DNS still worked).
+
+    ``exec_failed`` is a third, categorically different thing: the probe **never ran**
+    (no EXEC permission on the socket proxy, the proxy is down, the container is gone,
+    or it ships no ``wget``). That says nothing about the tunnel — it's a fault on *our*
+    side of the exec — so it must never be counted as a connectivity failure. Doing so
+    would restart the tunnel over a tool we couldn't invoke (#137, Tenets 1 and 7).
     """
 
     url: str
@@ -114,6 +120,7 @@ class SiteResult:
     reason: str
     exit_code: int
     dns_failed: bool = False
+    exec_failed: bool = False
 
 
 def probe_site(
@@ -142,7 +149,10 @@ def probe_site(
         exit_code, output = result.exit_code, result.output
     except Exception as exc:  # exec itself failed (container gone, daemon error)
         duration_ms = int((time.monotonic() - start) * 1000)
-        return SiteResult(url, False, duration_ms, "N/A", f"exec failed: {exc}", -1)
+        # The probe never ran — we learned NOTHING about the tunnel. Flag it so the
+        # caller treats it as unevaluated, not as a site failure (#137).
+        return SiteResult(url, False, duration_ms, "N/A", f"exec failed: {exc}", -1,
+                          exec_failed=True)
 
     duration_ms = int((time.monotonic() - start) * 1000)
     http_code = _parse_http_code(output)

--- a/gluetun_monitor/monitor.py
+++ b/gluetun_monitor/monitor.py
@@ -59,6 +59,23 @@ Sleep = Callable[[float], None]
 
 
 @dataclass(frozen=True, slots=True)
+class GatewayCheck:
+    """Outcome of one pass over gluetun's site set.
+
+    ``breached`` are the critical sites that hit FAIL_THRESHOLD and therefore justify a
+    restart. ``unprobeable`` means **no probe even ran** (no EXEC on the socket proxy,
+    the proxy is down, the container is gone, no ``wget`` inside it) — so the loop
+    learned nothing about the tunnel. The two are deliberately distinct: an empty
+    ``breached`` with ``unprobeable=True`` must never be read as "healthy" or as
+    "recovered", or the watchdog either restarts the tunnel over its own missing tool or
+    reports a fake-green (#137; Tenets 1 and 7).
+    """
+
+    breached: list[str]
+    unprobeable: bool = False
+
+
+@dataclass(frozen=True, slots=True)
 class DependentProbe:
     """Read-only outcome of probing one dependent (no state mutation)."""
 
@@ -307,7 +324,7 @@ class Monitor:
             diffs.append(f"tries {on}→{nn}")
         return ", ".join(diffs)
 
-    def check_gluetun_sites(self, sites: list[str], *, record: bool = True) -> list[str]:
+    def check_gluetun_sites(self, sites: list[str], *, record: bool = True) -> GatewayCheck:
         """Test the full URL set from inside gluetun. Return the sites that have
         breached FAIL_THRESHOLD (empty = healthy).
 
@@ -317,7 +334,7 @@ class Monitor:
         """
         if not sites:
             self.log.warn("No sites configured to test")
-            return []
+            return GatewayCheck(breached=[], unprobeable=False)
 
         # Track the full *spec* per URL (not just its presence) so a runtime
         # sites.conf edit is logged for ANY change: an added/removed site, a
@@ -391,6 +408,7 @@ class Monitor:
         total = len(sites)
         results: list[SiteResult] = []
         failed: list[str] = []
+        unprobeable: list[str] = []  # probes that never ran (#137) — evaluated nothing
         for done, result in enumerate(
             self._fan_out(
                 sites, lambda url: probe_site(self.client, self.config.gluetun_container,
@@ -399,6 +417,17 @@ class Monitor:
             start=1,
         ):
             results.append(result)
+            if result.exec_failed:
+                # The probe never RAN (no EXEC on the proxy, proxy down, container gone,
+                # no wget in the gateway). That says nothing about the tunnel — it's a
+                # fault on our side of the exec. Don't record a poll, don't touch the
+                # failure counter, never let it gate a restart (#137, Tenets 1 and 7).
+                unprobeable.append(result.url)
+                self.log.warn(
+                    f"[{gw}] ({done}/{total}) reach ?: {result.url} — probe could not run "
+                    f"({result.reason}); not counted as a failure"
+                )
+                continue
             if record:
                 self.stats.record_poll(result.url, result.ok, result.duration_ms, result.reason)
             if result.ok:
@@ -446,6 +475,19 @@ class Monitor:
                     f"[{count}/{threshold}]"
                 )
 
+        # EVERY probe failed to run: this loop evaluated nothing about the tunnel. Never
+        # restart on a signal we cannot attribute to it (Tenet 1) — a restart cannot
+        # restore an EXEC permission or a missing wget, so it would only churn the
+        # tunnel and every dependent behind it, forever (#137).
+        if results and len(unprobeable) == len(results):
+            self.log.error(
+                f"[{gw}] cannot probe: all {len(results)} probes failed to run "
+                f"({results[0].reason}) — NOT restarting. Check the socket proxy's EXEC "
+                f"permission and reachability, and that {self.config.gluetun_container} "
+                f"still has a usable wget."
+            )
+            return GatewayCheck(breached=[], unprobeable=True)
+
         if failed:
             self.log.error(f"[{gw}] restart triggered by: {' '.join(failed)}")
 
@@ -453,25 +495,29 @@ class Monitor:
         # without the per-site DEBUG detail. Only on the primary poll (not the
         # post-restart re-verify, which has its own "verified" line).
         if record:
-            ok_results = [r for r in results if r.ok]
+            # Sites whose probe never ran are neither ok nor failing — they are simply
+            # unevaluated, so they must not skew the heartbeat's N/M (#137).
+            evaluated = [r for r in results if not r.exec_failed]
+            ok_results = [r for r in evaluated if r.ok]
+            unprobed = f" — {len(unprobeable)} unprobeable" if unprobeable else ""
             # Mark advisory failures so the heartbeat makes clear they are NOT the
             # reason for any restart (#110) — "failing: x (advisory)".
             failing = [
                 hostname_of(r.url) + (" (advisory)" if self._role_of(r.url) == "advisory" else "")
-                for r in results if not r.ok
+                for r in evaluated if not r.ok
             ]
             if failing:
                 self.log.info(
-                    f"[{gw}] sites: {len(ok_results)}/{len(results)} ok — "
-                    f"failing: {', '.join(failing)}"
+                    f"[{gw}] sites: {len(ok_results)}/{len(evaluated)} ok — "
+                    f"failing: {', '.join(failing)}{unprobed}"
                 )
             else:
-                slowest = max(results, key=lambda r: r.duration_ms)
+                slowest = max(evaluated, key=lambda r: r.duration_ms)
                 self.log.info(
-                    f"[{gw}] sites: {len(ok_results)}/{len(results)} ok "
+                    f"[{gw}] sites: {len(ok_results)}/{len(evaluated)} ok{unprobed} "
                     f"(slowest {slowest.duration_ms}ms: {hostname_of(slowest.url)})"
                 )
-        return failed
+        return GatewayCheck(breached=failed, unprobeable=False)
 
     # ----- dependent phase (nodes 6-19) -----
 
@@ -1038,7 +1084,26 @@ class Monitor:
         worst = worst_case_probe_seconds(specs, self.config.timeout, self.config.wget_tries)
         self.client.ensure_timeout(max(worst * 2, 60))
 
-        breached = self.check_gluetun_sites(sites)
+        check = self.check_gluetun_sites(sites)
+        if check.unprobeable:
+            # Every probe failed to RUN: this loop learned nothing about the tunnel.
+            # Raise a distinct, actionable alert and HOLD every other active alert —
+            # silence here is absence of evidence, not recovery (#74). Restart nothing:
+            # a restart cannot restore an EXEC permission or a missing wget, so acting
+            # would churn the tunnel and every dependent behind it, forever (#137).
+            self._problem(
+                "gluetun-unprobeable",
+                "attention",
+                f"cannot probe {self.config.gluetun_container}",
+                f"Every site probe failed to run, so the tunnel's health is unknown and "
+                f"nothing was restarted. Check the socket proxy's EXEC permission and its "
+                f"reachability, and that {self.config.gluetun_container} still has a "
+                f"usable wget.",
+            )
+            self.alerts.mark_incomplete()
+            self._save_stats()
+            return
+        breached = check.breached
         if not breached:
             # Keep the flaky-site advisory current on HEALTHY loops too (#75):
             # the lifecycle resolves any alert not re-reported each loop, so
@@ -1103,7 +1168,29 @@ class Monitor:
             return
 
         # Re-verify without recording (so the loop counts one poll per site, not two).
-        reverify_breached = self.check_gluetun_sites(sites, record=False)
+        reverify = self.check_gluetun_sites(sites, record=False)
+        if reverify.unprobeable:
+            # We restarted, but now nothing can be probed — we do NOT know whether it
+            # recovered. An empty breach list here is absence of evidence, not proof of
+            # health: claiming "recovered" would be exactly the fake-green Tenet 7
+            # forbids (#137). Hold the triggering sites and say so.
+            self.log.error(
+                f"[{self.config.gluetun_container}] restarted, but no probe could run — "
+                f"recovery is UNVERIFIED; not claiming it recovered"
+            )
+            self._problem(
+                "gluetun-unprobeable",
+                "attention",
+                f"cannot probe {self.config.gluetun_container}",
+                f"{self.config.gluetun_container} was restarted but no site probe could "
+                f"run, so recovery is unverified. Check the socket proxy's EXEC permission "
+                f"and its reachability, and that the container still has a usable wget.",
+            )
+            self._unrecovered_sites = set(breached)  # #106: hold; we can't prove they cleared
+            self.alerts.mark_incomplete()  # dependents were never evaluated (#74)
+            self._save_stats()
+            return
+        reverify_breached = reverify.breached
         # Restart effectiveness: did each site that triggered this restart recover?
         still = set(reverify_breached)
         for site in breached:

--- a/tests/test_gateway_unprobeable.py
+++ b/tests/test_gateway_unprobeable.py
@@ -1,0 +1,159 @@
+"""#137: a gateway probe that never RAN must never be read as a connectivity failure.
+
+When `docker exec` into gluetun fails — no EXEC permission on the socket proxy, the
+proxy is down, the container is gone, or it ships no `wget` — the probe tells us
+*nothing* about the tunnel. Counting it as a site failure made the monitor restart
+gluetun every ~2 loops over a tool it could not invoke, churning every dependent
+behind it, forever. Restarting cannot restore an EXEC permission (Tenets 1 and 7).
+
+The dependent path always got this right (`InterfaceStatus.UNKNOWN` → unevaluated →
+left alone); these tests pin the same discipline onto the gateway path, including the
+subtler trap: an unprobeable *post-restart re-verify* must not be reported as
+"recovered" — an empty breach list there is absence of evidence, not proof of health.
+"""
+
+from __future__ import annotations
+
+import io
+import random
+from pathlib import Path
+
+from gluetun_monitor.config import Config
+from gluetun_monitor.docker_client import ExecResult
+from gluetun_monitor.logging_setup import Logger
+from gluetun_monitor.monitor import Monitor
+from gluetun_monitor.site_stats import SiteStatsStore
+
+from .fakes import FakeDockerClient, FakeNotifier
+
+GLUETUN_ID = "a" * 64
+A = "https://a.example"
+B = "https://b.example"
+
+
+def _denied(*_a: object, **_k: object) -> ExecResult:
+    raise RuntimeError("403 Client Error: Forbidden (socket proxy EXEC=0)")
+
+
+def _monitor(tmp_path: Path, notifier: FakeNotifier) -> tuple[Monitor, FakeDockerClient]:
+    conf = tmp_path / "sites.conf"
+    conf.write_text(f"{A}\n{B}\n")
+    fake = FakeDockerClient()
+    fake.add_container("gluetun", id=GLUETUN_ID, health="healthy")
+    fake.add_container("qbittorrent", network_mode=f"container:{GLUETUN_ID}")
+    mon = Monitor(
+        fake,
+        Config(config_file=str(conf), gluetun_container="gluetun",
+               fail_threshold=2, dns_wait_timeout=0, advisory_min_restarts=999),
+        Logger(log_file=None, stream=io.StringIO()),
+        rng=random.Random(0), sleep=lambda _s: None,
+        stats=SiteStatsStore(None), notifier=notifier,
+    )
+    return mon, fake
+
+
+def test_probe_site_flags_exec_failure() -> None:
+    """The signal itself: an exec that never ran is marked, not disguised as a failure."""
+    from gluetun_monitor.connectivity import probe_site
+
+    fake = FakeDockerClient()
+    fake.add_container("gluetun", id=GLUETUN_ID)
+    fake.on_exec = _denied
+    result = probe_site(fake, "gluetun", A, timeout=1, tries=1)
+    assert result.exec_failed is True
+    assert result.ok is False
+    assert result.exit_code == -1
+
+
+def test_unprobeable_gateway_never_restarts_gluetun(tmp_path: Path) -> None:
+    """The core #137 regression (RED pre-fix): exec denied every loop → the monitor
+    restarted gluetun every ~2 loops. It must now restart NOTHING and say why."""
+    notifier = FakeNotifier()
+    mon, fake = _monitor(tmp_path, notifier)
+    fake.on_exec = _denied
+
+    for _ in range(4):
+        mon.run_once()
+
+    keys = notifier.event_keys()
+    assert fake.restarted == [], "must never restart the tunnel over a probe that can't run"
+    assert (fake.removed, fake.created) == ([], []), "dependents must be left alone"
+    assert "gluetun-unprobeable" in keys, keys
+    assert "gluetun-recovered" not in keys, keys
+    assert keys.count("gluetun-unprobeable") == 1, "edge-triggered: announced once"
+
+
+def test_unprobeable_reverify_does_not_claim_recovery(tmp_path: Path) -> None:
+    """The subtler trap: a REAL breach restarts gluetun, but the post-restart re-verify
+    can't run. An empty breach list there is absence of evidence — claiming
+    'recovered' would be exactly the fake-green Tenet 7 forbids."""
+    notifier = FakeNotifier()
+    mon, fake = _monitor(tmp_path, notifier)
+
+    def handler(name: str, cmd: list[str]) -> ExecResult:
+        if cmd and cmd[0] == "nslookup":
+            return ExecResult(0, "")
+        if fake.restarted:  # after the restart, exec stops working
+            raise RuntimeError("403 Forbidden (proxy died mid-loop)")
+        return ExecResult(4, "")  # genuine site failure -> breach
+
+    fake.on_exec = handler
+
+    mon.run_once()  # 1/2
+    mon.run_once()  # 2/2 -> breach -> restart -> re-verify cannot run
+
+    keys = notifier.event_keys()
+    assert fake.restarted == ["gluetun"], "the breach was real; one restart is correct"
+    assert "gluetun-recovered" not in keys, f"fake-green! {keys}"
+    assert "gluetun-unprobeable" in keys, keys
+    assert mon._unrecovered_sites, "triggering sites must be held, not presumed cleared"
+
+
+def test_partial_exec_failure_does_not_gate_a_restart(tmp_path: Path) -> None:
+    """One site unprobeable, one healthy: the unprobeable one is simply unevaluated —
+    it never accrues a failure counter, so it can never breach."""
+    notifier = FakeNotifier()
+    mon, fake = _monitor(tmp_path, notifier)
+
+    def handler(name: str, cmd: list[str]) -> ExecResult:
+        if cmd and cmd[0] == "nslookup":
+            return ExecResult(0, "")
+        if cmd and A in cmd:
+            raise RuntimeError("403 Forbidden (this one probe can't run)")
+        return ExecResult(0, "  HTTP/1.1 200 OK\n")
+
+    fake.on_exec = handler
+
+    for _ in range(6):
+        mon.run_once()
+
+    assert fake.restarted == [], "an unprobeable site must never gate a restart"
+    # Not ALL probes failed, so this isn't the whole-gateway alert.
+    assert "gluetun-unprobeable" not in notifier.event_keys()
+
+
+def test_unprobeable_resolves_once_probing_works_again(tmp_path: Path) -> None:
+    """Lifecycle: the alert clears itself when exec starts working, exactly once."""
+    notifier = FakeNotifier()
+    mon, fake = _monitor(tmp_path, notifier)
+    state = {"denied": True}
+
+    def handler(name: str, cmd: list[str]) -> ExecResult:
+        if state["denied"]:
+            raise RuntimeError("403 Forbidden")
+        if cmd and cmd[0] == "nslookup":
+            return ExecResult(0, "")
+        return ExecResult(0, "  HTTP/1.1 200 OK\n")
+
+    fake.on_exec = handler
+
+    mon.run_once()
+    mon.run_once()
+    assert "gluetun-unprobeable" in notifier.event_keys()
+
+    state["denied"] = False  # EXEC permission restored
+    mon.run_once()
+
+    keys = notifier.event_keys()
+    assert keys.count("resolve:gluetun-unprobeable") == 1, keys
+    assert fake.restarted == [], "recovery of the probe path must not trigger a restart"


### PR DESCRIPTION
Closes #137.

**TL;DR — when the gateway probe's `exec` couldn't run, we counted it as a site connectivity failure and restarted gluetun in a loop it could never fix. Now it's treated as *unevaluated*: a distinct alert, alerts held, nothing touched. Also fixes a fake-green in the post-restart re-verify.**

## The bug
`docker exec` into gluetun fails (proxy `EXEC=0`, proxy down, container gone, no `wget`) → `probe_site` returns `ok=False` → nothing special-cased it → every site "fails" → threshold breach → **restart gluetun**. The restart can't restore an EXEC permission, so the loop repeats ~every 60s, knocking over every dependent, indefinitely.

Proven with the repo's own fakes: **4 loops with exec denied → 2 gluetun restarts.**

The tell that it was an oversight: the **dependent** path already handled the identical failure correctly (`InterfaceStatus.UNKNOWN` → unevaluated → left alone). Pure asymmetry.

## The fix
- **`SiteResult.exec_failed`** — "the probe never ran" becomes an explicit signal, not a magic `exit_code == -1`.
- **Unevaluated, not failed** — an exec-failed probe records no poll, touches no failure counter, and can never gate a restart.
- **`check_gluetun_sites` → `GatewayCheck(breached, unprobeable)`** so callers structurally cannot conflate *"nothing failed"* with *"nothing was measured."*
- **All probes failed to run** → raise `gluetun-unprobeable` (`attention`, naming the likely causes), `mark_incomplete()` so active alerts hold rather than false-resolve, restart nothing.
- **The subtler trap, also fixed:** an unprobeable **post-restart re-verify** returned an empty breach list and was read as `gluetun-recovered` — a fake-green. It now holds the triggering sites and reports recovery as *unverified*.

> **Tenet 1:** *"a watchdog that damages the system it guards is worse than one that does nothing."*
> **Tenet 7 corollary:** *"the watchdog never becomes the outage."*

## Verification
Re-ran the issue's exact proof against the fix:
```
  gluetun restarts:  0   <-- was 2
  dependent touched: removed=[] created=[]
  alerts:            ['gluetun-unprobeable']
  false 'recovered'? False
```

**5 regression tests**, each verified **RED against the unfixed code and GREEN after** (stash-and-run):
- the exec-failed signal itself
- unprobeable gateway → 0 restarts, dependents untouched, announced once
- **unprobeable re-verify → does not claim recovery** (the fake-green)
- partial exec failure → the unprobeable site never accrues a counter, so it can't breach
- the alert resolves exactly once when probing works again

## Docs
README now states the guarantee where the proxy permissions are documented: *"if the monitor cannot probe, it does nothing"* — plus why `POST=1` is unavoidable (per the #29 experiments). This is the behavior `docs/COMPATIBILITY.md` will lean on.

Full suite + ruff + mypy green.