### PR TITLE
docs: ADR-0017 (the monitor is incurious) + the capability contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,8 @@ The full per-loop state machine (22 nodes) is in
 [ADR-0006](docs/adr/0006-per-dependent-viability-testing.md); the
 restart-vs-recreate decision is [ADR-0004](docs/adr/0004-dependent-aware-health.md).
 
+The monitor is deliberately **incurious** — it never learns what you route through the tunnel or what your containers are for, only that they have a shape it can measure ([ADR-0017](docs/adr/0017-incurious-monitor.md)). A dependent is *defined* as any container sharing Gluetun's network namespace; nothing else about it matters. What each capability your container ships unlocks — and what a `FROM scratch` container still gets — is written down in **[docs/COMPATIBILITY.md](docs/COMPATIBILITY.md)**. Nothing there is a requirement to be met; it's an interface, and the monitor tells you which layer it's operating at rather than pretending.
+
 ## Upgrading from v1 (v1 is end-of-life)
 
 **v1 (the original bash implementation, image tag `:1`) is end-of-life.** v2 is

--- a/docs/COMPATIBILITY.md
+++ b/docs/COMPATIBILITY.md
@@ -1,0 +1,112 @@
+# Compatibility — what the monitor needs to see
+
+gluetun-monitor is deliberately **incurious** ([ADR-0017](adr/0017-incurious-monitor.md)). It does not know or care *what* you route through the tunnel, *which* containers you run, or *what* traffic flows through them. It cares only that they have a shape it can measure health against.
+
+This page states that shape exactly. It is not a bar to clear. It is an **interface**: provide more of it and you unlock deeper validation, provide none of it and you still get watched. Nothing on this page is "unsupported" — a `FROM scratch` container behind the tunnel is a first-class citizen of the parts of it the monitor can reach.
+
+---
+
+## What a dependent *is*
+
+The entire definition:
+
+```
+HostConfig.NetworkMode == "container:<gluetun>"
+```
+
+A dependent is any container sharing gluetun's network namespace. That's it. Not its image, not its name, not its purpose. The monitor matches the container-name form, the full-id form, and the short-id prefix, so however you wrote it in your compose file, it is found.
+
+Everything downstream follows from that one structural fact: because a dependent shares gluetun's already-proven egress, the only fault that can be *uniquely its own* is its DNS resolver. That is why the checks below look the way they do.
+
+---
+
+## What you get for what you provide
+
+Each capability your container ships unlocks a deeper layer of validation. None of them are required.
+
+| Your container provides | The monitor can | What you get |
+|---|---|---|
+| *nothing* (`FROM scratch`) | read `HostConfig.NetworkMode` via the Docker API | **Strand detection.** If gluetun is *recreated* (new container id), your netns parent is dead and you are cut off. The monitor sees the id has moved and recreates you. Works on a single static binary. |
+| **+ a shell** | `ls /sys/class/net` | **Direct interface check.** The monitor sees your actual interfaces — `eth0`/`tun0` (live) versus loopback-only (stranded) — and detects a strand without inferring it from container ids. |
+| **+ any one of `wget`, `getent`, `ping`** | resolve a hostname from inside your container | **Full L7 viability.** The monitor validates *your own resolver* — the one fault that is uniquely yours. This is the deepest check available. |
+
+**First-class = a shell + any one of those three tools.** No particular distro. No particular `wget`.
+
+### `wget` flavor does not matter
+
+Probe results are classified on the **HTTP response**, never on `wget`'s exit code. GNU `wget` reports HTTP errors as exit 6/8; BusyBox `wget` returns exit 1 for the same responses. Keying on "did a server answer?" makes both correct, and makes a harmless `404` from a BusyBox dependent read as the success it is. Bring whichever you have.
+
+### The DNS cascade
+
+The resolver check tries, in order, `wget` → `getent hosts` → `ping`, stopping at the first tool that actually exists. If none of them do, the verdict is **`UNVALIDATED`** — and the monitor says so out loud and falls back to the interface check. It does not guess.
+
+---
+
+## When the monitor can't tell, it says so
+
+This is the load-bearing promise, and it is worth stating plainly because it is what makes the ladder above safe to stand on:
+
+- A dependent whose interfaces can't be read is `UNKNOWN` → **unevaluated**. Its alerts are *held*, not resolved, and it is **not remediated**. *"I wasn't sure, so I left it alone and said so."*
+- A dependent with no usable DNS tool is `UNVALIDATED` → the monitor reports it and relies on the interface check rather than inventing a verdict.
+- If the **gateway** itself can't be probed — no `EXEC` permission, an unreachable proxy, a missing `wget` — the monitor raises a distinct `cannot probe` alert, holds every active alert, and **restarts nothing**. A restart cannot restore an EXEC permission, and a watchdog that damages the system it guards is worse than one that does nothing ([#137](https://github.com/csmarshall/gluetun-monitor/issues/137)).
+
+The monitor never reports healthy on absence of evidence. Fail loud; never fake-green.
+
+---
+
+## Making a container first-class
+
+If you are building or choosing an image to run behind the tunnel and want the deepest validation, ship:
+
+1. **A shell** — so `ls /sys/class/net` can run. Any `sh` will do.
+2. **One DNS tool** — `wget`, `getent`, or `ping`. Most base images already have at least one; BusyBox alone satisfies it.
+
+That is the whole checklist. If you can't (distroless, scratch, a hardened runtime), you lose the deeper checks and keep strand detection — and the monitor will tell you which layer it's operating at, every loop, rather than pretending.
+
+---
+
+## The gateway
+
+gluetun is the only gateway that is tested, but the coupling is **structural, not brand-specific**. A gateway must be:
+
+- **exec-able**, with a shell and a `wget` on `PATH` (any flavor), and readable interfaces at `/sys/class/net`
+- reachable through the Docker API with `CONTAINERS`, `POST`, and `EXEC` (see below)
+
+Note the honest caveat: gluetun installs GNU `wget` deliberately, but that is an *implementation detail* of its image rather than a documented guarantee. Whether it forms part of gluetun's supported surface is [an open question upstream](https://github.com/passteque/gluetun/discussions/3387). The monitor is built not to depend on the answer — it requires *a* `wget`, doesn't care which, and if one ever vanishes it reports rather than restarts.
+
+The **only** gluetun-specific code in the project is `endpoint.py`, which greps gluetun's own logs for the exit IP, country, and WireGuard server to print the `[ENDPOINT]` line. That is cosmetic reporting about *the subject under test*, not part of any health decision — no restart, no remediation, no alert depends on it. It is therefore a documented **extension point**: point the monitor at a different VPN gateway that satisfies the structural contract above and health monitoring works unchanged; teach `endpoint.py` that gateway's log format and you get the endpoint line too.
+
+---
+
+## Docker API surface
+
+The monitor needs three capabilities, and no more. With the recommended [socket proxy](../README.md#docker-socket-proxy):
+
+| Setting | Required for |
+|---|---|
+| `CONTAINERS=1` | list, inspect, and read container logs; create the replacement when recreating a stranded dependent |
+| `POST=1` | restart / remove / start containers (the recreate path rides the same flag) |
+| `EXEC=1` | run the connectivity and interface probes inside gluetun and the dependents |
+
+`POST=1` is unavoidable, not laziness: tecnativa's `POST` is a *binary* switch over the container API. With `POST=0` the `EXEC` and `ALLOW_RESTARTS` carve-outs are inert — neither probing nor restarting works — and with `POST=1` the whole container write surface is open, including create and remove. There is no configuration that grants exec and restart while denying recreate. This was established empirically rather than assumed ([#29](https://github.com/csmarshall/gluetun-monitor/issues/29)).
+
+Nothing else is enabled: no `IMAGES`, `NETWORKS`, `SERVICES`, `SWARM`, or `SYSTEM`.
+
+---
+
+## Platforms
+
+Published for `linux/amd64`, `linux/arm64`, and `linux/arm/v7`. Containers are assumed to be Linux — the monitor relies on network-namespace semantics and `/sys/class/net`.
+
+---
+
+## What the monitor will never ask of you
+
+Because it is incurious, there are whole categories of requirement it does not have and will not grow ([ADR-0017](adr/0017-incurious-monitor.md)):
+
+- It never inspects your traffic, nor knows what you use the tunnel for.
+- It has no per-service knowledge. There is no code path that behaves differently because a container is a torrent client, an indexer, or a media server — and there never will be.
+- It has no VPN-provider-specific logic.
+- It does not phone home. There is no telemetry, opt-in or otherwise, and no code to audit for it.
+
+Your test sites are opaque reachability oracles: the monitor cares *only* whether something answered, never what it said or who it belongs to.

--- a/docs/COMPATIBILITY.md
+++ b/docs/COMPATIBILITY.md
@@ -105,7 +105,7 @@ Published for `linux/amd64`, `linux/arm64`, and `linux/arm/v7`. Containers are a
 Because it is incurious, there are whole categories of requirement it does not have and will not grow ([ADR-0017](adr/0017-incurious-monitor.md)):
 
 - It never inspects your traffic, nor knows what you use the tunnel for.
-- It has no per-service knowledge. There is no code path that behaves differently because a container is a torrent client, an indexer, or a media server — and there never will be.
+- It has no per-service knowledge. Containers are simply dependents that require network connectivity through gluetun; no code path behaves differently based on what any of them is — and none ever will.
 - It has no VPN-provider-specific logic.
 - It does not phone home. There is no telemetry, opt-in or otherwise, and no code to audit for it.
 

--- a/docs/adr/0017-incurious-monitor.md
+++ b/docs/adr/0017-incurious-monitor.md
@@ -1,0 +1,52 @@
+# ADR-0017: The monitor is incurious — it validates structure, not content
+
+- **Status:** Accepted
+- **Date:** 2026-07-08
+- **Relates to:** ADR-0001 (test from inside the namespace), ADR-0004/0006 (dependent-aware health), ADR-0002 (socket proxy); Tenets 1, 2, 3, 6, 7, 9; issues #36 (foreclosed by this record), #29, #137
+- **Contract:** [`docs/COMPATIBILITY.md`](../COMPATIBILITY.md)
+
+## Context
+
+The monitor has always behaved this way; it had simply never said so. A dependent is discovered by *who shares gluetun's network namespace*, never by image or name (Tenet 6). A test site is a reachability oracle — a server answered, therefore egress works — and explicitly *not* something whose health we care about (Tenet 3). The `|role=critical|advisory` distinction added in ADR-0015 is structural ("does this site gate a restart?") rather than semantic ("what kind of site is this?"). Nowhere in the codebase is there a branch that behaves differently because a container happens to be a torrent client, an indexer, or a media server.
+
+Leaving that boundary unstated cost us three things.
+
+First, it left the question of **telemetry** permanently open. An issue proposing opt-in, anonymous adoption analytics (version and platform only, modelled on Home Assistant's) sat in the backlog as a plausible "maybe," because nothing in the project's stated principles ruled it in or out.
+
+Second, and more damaging, it left users **no published statement of what shape their containers must have**. The monitor's actual requirements — a shell for `ls /sys/class/net`, some tool among `wget`/`getent`/`ping` for the resolver check, a `wget` of any flavor in the gateway — were implicit in the code, discoverable only by reading it or by watching the monitor quietly degrade. Someone running a distroless container had no way to learn what they would and would not get.
+
+Third, that same silence let a real bug hide. Establishing whether we could even *publish* "the gateway must provide a `wget`" meant asking what happens when it doesn't — which surfaced #137: a gateway probe whose `exec` could not run was being counted as a *site connectivity failure*, breaching the threshold and restarting the tunnel in a loop that no restart could ever fix. The dependent path had always handled the identical failure correctly, treating an unreadable container as *unevaluated* and leaving it alone. The asymmetry survived precisely because no one had written down what the monitor is entitled to know, and what it must do when it knows nothing.
+
+## Decision
+
+**The monitor validates structure, not content — neither yours nor ours.**
+
+It observes only the structural facts it needs to judge health: that a container shares gluetun's network namespace, that it has interfaces other than loopback, that its resolver can resolve a name, that some server answered a request made from inside the tunnel. It does not know, record, or act upon what you route through the tunnel, which containers you run, what they are for, or what traffic passes between them. Its test sites are opaque oracles: whether something answered, never what it said.
+
+Three consequences follow, and are adopted as part of this decision.
+
+**We owe users an explicit, published contract.** If the monitor asks only for a shape, that shape must be written down. [`COMPATIBILITY.md`](../COMPATIBILITY.md) states it as an *interface rather than a bar*: nothing is unsupported, each capability a container provides unlocks a deeper layer of validation, and a `FROM scratch` binary still gets strand detection. The contract is reference material and will evolve as fallbacks are added; it lives beside this record rather than inside it, so a new degradation path does not require amending an architecture decision.
+
+**When the monitor cannot tell, it must say so and act on nothing.** An unreadable dependent is unevaluated: its alerts are held, not resolved, and it is not remediated. An unprobeable gateway raises a distinct alert and restarts nothing — a restart cannot restore an `EXEC` permission, and a watchdog that damages the system it guards is worse than one that does nothing (Tenet 1; the corollary in Tenet 7). Honest degradation is the price of asking for so little, and it is what makes the ladder in the contract safe to stand on.
+
+**Therefore, no telemetry.** This is not a separate values statement; it is entailed. A monitor whose domain explicitly excludes knowing anything about your setup has no business reporting on it. The proposal in #36 is *foreclosed* by this record rather than rejected on its own merits, and the reasoning generalises: for a tool whose entire purpose is guarding a privacy boundary, phoning home is a contradiction users should not have to audit away. "There is no beacon code" is a categorically stronger guarantee than "the beacon defaults to off," because the latter is a thing every user must read, trust, and keep trusting across releases.
+
+Adoption and efficacy are therefore judged from **coarse public signals that require no trust from anyone**: registry pull counts and the shape of the issue tracker. These are genuinely imprecise — pulls include CI, mirrors, and bots rather than unique users, and a quiet tracker means "no bugs" exactly as plausibly as it means "no users." We accept that imprecision deliberately. The trade being made is coarse public signals over precise private ones, and it is not close.
+
+### What this record does *not* claim
+
+It does not claim total blindness. `endpoint.py` reads gluetun's own logs to report the exit IP, country, and WireGuard server on the `[ENDPOINT]` line. That is observation of *the subject under test* — the tunnel whose health is the entire point — and no restart, remediation, or alert depends on it. Stating this plainly is the difference between a boundary and a slogan.
+
+Nor does it forswear coupling to gluetun. We are named after it and we grep its log format. That coupling is to the **gateway**, not to the operator's setup, and it is confined to exactly one cosmetic module — which makes `endpoint.py` a documented extension point rather than an accident: another VPN gateway satisfying the structural contract is monitored correctly today, and merely reports an unknown endpoint until someone teaches that module its log format.
+
+## Consequences
+
+A class of features is now foreclosed, and can be closed on sight rather than re-litigated: adoption analytics of any kind (#36); content- or traffic-aware probing; per-service health logic ("restart a media server differently"); VPN-provider-specific integrations. Each would require the monitor to know what something *is*, which it has decided not to.
+
+The degradation ladder stops being an apology and becomes a feature. Because the monitor asks so little, it can state exactly what a `FROM scratch` container gets, and mean it. The honest `UNKNOWN` and `UNVALIDATED` verdicts are not gaps in coverage; they are the contract working.
+
+Future design gains a cheap test. Any proposal can be held against the boundary — *does this require knowing what the user runs, or only its shape?* — and #137 shows the cost of not having had one: a documentation question about `wget` uncovered a tunnel-churning restart loop and a fake-green in the post-restart re-verify, both of which had hidden in the space where the boundary should have been written down.
+
+What we give up is real. We will never know how many people run this, on what, or whether a release broke them, except insofar as they tell us. That is the intended shape of the trade, and the alternative — auditing our own beacon on behalf of users who chose a privacy tool — costs more than the data is worth.
+
+One question remains open upstream: whether `wget`'s presence in the gluetun image is part of its supported surface or an internal implementation detail ([passteque/gluetun#3387](https://github.com/passteque/gluetun/discussions/3387)). The answer changes one sentence of the contract and nothing in this decision, because the monitor already requires only *a* `wget`, does not depend on its flavor, and reports rather than restarts when it is absent.

--- a/docs/adr/0017-incurious-monitor.md
+++ b/docs/adr/0017-incurious-monitor.md
@@ -7,7 +7,7 @@
 
 ## Context
 
-The monitor has always behaved this way; it had simply never said so. A dependent is discovered by *who shares gluetun's network namespace*, never by image or name (Tenet 6). A test site is a reachability oracle — a server answered, therefore egress works — and explicitly *not* something whose health we care about (Tenet 3). The `|role=critical|advisory` distinction added in ADR-0015 is structural ("does this site gate a restart?") rather than semantic ("what kind of site is this?"). Nowhere in the codebase is there a branch that behaves differently because a container happens to be a torrent client, an indexer, or a media server.
+The monitor has always behaved this way; it had simply never said so. A dependent is discovered by *who shares gluetun's network namespace*, never by image or name (Tenet 6). A test site is a reachability oracle — a server answered, therefore egress works — and explicitly *not* something whose health we care about (Tenet 3). The `|role=critical|advisory` distinction added in ADR-0015 is structural ("does this site gate a restart?") rather than semantic ("what kind of site is this?"). Containers are simply dependents that require network connectivity through gluetun; nowhere in the codebase is there a branch that behaves differently based on what one of them is.
 
 Leaving that boundary unstated cost us three things.
 
@@ -41,7 +41,7 @@ Nor does it forswear coupling to gluetun. We are named after it and we grep its 
 
 ## Consequences
 
-A class of features is now foreclosed, and can be closed on sight rather than re-litigated: adoption analytics of any kind (#36); content- or traffic-aware probing; per-service health logic ("restart a media server differently"); VPN-provider-specific integrations. Each would require the monitor to know what something *is*, which it has decided not to.
+A class of features is now foreclosed, and can be closed on sight rather than re-litigated: adoption analytics of any kind (#36); content- or traffic-aware probing; per-service health logic (treating one dependent differently from another based on what it is); VPN-provider-specific integrations. Each would require the monitor to know what something *is*, which it has decided not to.
 
 The degradation ladder stops being an apology and becomes a feature. Because the monitor asks so little, it can state exactly what a `FROM scratch` container gets, and mean it. The honest `UNKNOWN` and `UNVALIDATED` verdicts are not gaps in coverage; they are the contract working.
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -45,3 +45,4 @@ Format: [`_template.md`](_template.md). Status ∈ Proposed | Accepted | Superse
 | [0014](0014-durable-dependent-memory.md) | Durable dependent memory: persisted gluetun id history + known dependents; adopt-or-warn orphan scan (dead parent in history = provably ours) | Accepted |
 | [0015](0015-per-site-role.md) | Per-site role (`\|role=critical\|advisory`, default critical) — advisory sites are probed but never gate a restart; explicit operator opt-out, not auto-quarantine | Accepted |
 | [0016](0016-wedge-escalation-and-backoff.md) | Escalate a wedged dependent — distinct alert + runbook, capped remediation backoff (#98); a bounded Tenet-9 carve-out for a provably-futile repeat | Accepted |
+| [0017](0017-incurious-monitor.md) | The monitor is incurious — validates *structure*, not content (neither yours nor ours): a published capability contract, honest degradation, and therefore no telemetry (#36 foreclosed) | Accepted |


### PR DESCRIPTION
Closes #36.

**TL;DR — states the boundary the monitor has always honoured but never wrote down: it validates *structure*, not content. Publishes the capability contract users were missing, and forecloses telemetry as a consequence rather than a separate values statement.**

## Why now
Leaving the boundary unstated cost three things:
1. **#36 (analytics) sat open as a plausible "maybe"** — nothing in the stated principles ruled it in or out.
2. **Users had no published statement of what shape their containers must have.** The real requirements (a shell for `ls /sys/class/net`; any one of `wget`/`getent`/`ping`; a `wget` of any flavor in the gateway) were implicit in the code — discoverable only by reading it, or by watching the monitor quietly degrade.
3. **#137 hid in that gap.** Establishing whether we could even *publish* "the gateway must provide a `wget`" meant asking what happens when it doesn't — which surfaced a gateway `exec` failure being counted as a connectivity failure, restarting the tunnel in a loop no restart could fix, plus a fake-green in the post-restart re-verify. The dependent path had always handled the identical failure correctly. That asymmetry survived precisely because nobody had written down what the monitor is entitled to know, and what it must do when it knows nothing.

## `docs/COMPATIBILITY.md` — an interface, not a bar
Deliberately **inclusive**. Nothing is "unsupported"; each capability a container ships unlocks a deeper layer:

| Provide | Get |
|---|---|
| *nothing* (`FROM scratch`) | strand detection (netns id moved → recreate) |
| + a shell | direct interface check (`eth0/tun0` vs loopback-only) |
| + any of `wget`/`getent`/`ping` | full L7 viability (your own resolver — the one fault uniquely yours) |

**First-class = a shell + one DNS tool.** `wget` flavor is irrelevant (classification is HTTP-response-first, so GNU and BusyBox behave identically — which is why #28's `gm-probe` was never needed). And when the monitor can't tell, it says so and acts on nothing.

It also states the **gateway** contract and names `endpoint.py` as a documented **extension point** rather than an accident: it's the only gluetun-specific code, it's cosmetic (the `[ENDPOINT]` line), and no health decision depends on it.

## ADR-0017 — the decision
The monitor observes only structure. Three things follow, adopted as part of the decision:
- **We owe a published contract** → `COMPATIBILITY.md` (reference material, lives beside the ADR so a new fallback doesn't require amending an architecture record).
- **When it can't tell, it says so and acts on nothing** — honest degradation is the price of asking so little.
- **Therefore no telemetry.** Entailed, not asserted: a monitor whose domain excludes knowing about your setup has no business reporting on it. For a privacy tool, *"there is no beacon code"* is categorically stronger than *"the beacon defaults off,"* because the latter is something every user must read, trust, and keep trusting. Adoption is judged from **coarse public signals** (registry pull counts, the issue tracker) — genuinely imprecise, and accepted deliberately.

**Honest carve-out, stated rather than hidden:** `endpoint.py` reads gluetun's own logs for the exit IP/country. That observes *the subject under test*. Saying so is the difference between a boundary and a slogan.

**Deliberately vague about what you run.** Containers are described only as *dependents that require network connectivity through gluetun*. Enumerating use-cases would itself be the opinion this record exists to disclaim.

Docs only — no release. All relative links verified to resolve.