### PR TITLE
fix(tunables): gate suggestions on recent evidence; drop dead histogram.merge (#25)

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@ docker compose up -d
 | `STATS_FILE` | `/logs/site-stats.json` | Where persistent per-site stats are written (best-effort, atomic; survives restarts). See [Site stats & flaky-site advisory](#site-stats--flaky-site-advisory) |
 | `STATS_RETENTION_DAYS` | `90` | Drop a site's stats if it hasn't been tested (e.g. removed from `sites.conf`) for this many days; `0` keeps them forever |
 | `MONITOR_STATE_FILE` | `/logs/monitor-state.json` | Durable dependent memory: gluetun's container-id history + known dependent names, so dependents stranded by a gluetun recreate stay visible (and healable) across monitor restarts. Best-effort, atomic |
-| `ADVISORY_WINDOW` | `86400` | Window (seconds) for the flaky-site advisory |
+| `ADVISORY_WINDOW` | `86400` | Window (seconds) for the flaky-site advisory — and the recency window for `--suggest-tunables` (a site with no failure inside it yields no advice) |
 | `ADVISORY_MIN_RESTARTS` | `5` | Minimum gluetun restarts in the window before an advisory can fire |
 | `ADVISORY_DOMINANCE` | `0.5` | Fraction of those restarts one site must cause to be flagged flaky |
 | `DEPENDENT_ADVISORY_WINDOW` | `86400` | Window (seconds) for the dependent-flapping advisory |
@@ -476,7 +476,9 @@ role included: `… all sites use TIMEOUT=10s, WGET_TRIES=1, role=critical`.
 You don't have to guess. The monitor already records how every site behaves
 (latency percentiles, failure categories, restart effectiveness — see
 [Site stats & flaky-site advisory](#site-stats--flaky-site-advisory))
-and can read that history back as concrete recommendations:
+and can read that history back as concrete recommendations.
+
+Those stats are *lifetime* counters, which is what makes the advice well-evidenced — and what would otherwise make it immortal. So suggestions are gated on **recent evidence**: a site with no failure inside `ADVISORY_WINDOW` (24h) yields nothing, however damning its lifetime totals. Advice about an episode from last month is noise, not diagnosis.
 
 ```bash
 docker exec gluetun-monitor gluetun-monitor --suggest-tunables

--- a/gluetun_monitor/cli.py
+++ b/gluetun_monitor/cli.py
@@ -206,6 +206,11 @@ def _run_suggest_tunables(config: Config, logger: Logger) -> int:
     suggestions = suggest_tunables(
         store.sites, global_timeout=config.timeout, global_tries=config.wget_tries,
         specs=specs,  # judge each site against its EFFECTIVE knobs (#77)
+        # This is the path that surfaced stale advice: unlike the advisory hint, it is
+        # invoked on demand against the whole sidecar, so a site healthy for a month
+        # would still be "diagnosed" from its immortal lifetime counters (#25).
+        now=store.now(),
+        stale_after_seconds=config.advisory_window,
     )
     print("gluetun-monitor — per-URL tunable suggestions")
     print(

--- a/gluetun_monitor/histogram.py
+++ b/gluetun_monitor/histogram.py
@@ -11,9 +11,10 @@ a factor gamma = (1+a)/(1-a), and each bucket is represented by a single value.
 That makes every reported percentile **within `a` (relative) of the true value** —
 the DDSketch property (Dunning/Ertl). For latencies spanning ~1 ms to ~100 s at
 a = 5%, that's only a few dozen populated buckets per site (a sparse
-``{bucket: count}`` dict), it survives restarts, and it's **mergeable** (bucket
-counts simply add). Exact ``count``/``sum``/``min``/``max`` are tracked alongside,
-so only the percentiles are approximate.
+``{bucket: count}`` dict) and it survives restarts. Exact ``count``/``sum``/``min``/
+``max`` are tracked alongside, so only the percentiles are approximate — note that
+``min``/``max`` are therefore exact order statistics held *outside* the buckets, which
+is why no bucket-level transform (decay, merge) can affect them (#25).
 """
 
 from __future__ import annotations
@@ -93,22 +94,6 @@ class LatencyHistogram:
             "p90": self.quantile(0.90),
             "p99": self.quantile(0.99),
         }
-
-    def merge(self, other: LatencyHistogram) -> None:
-        """Fold ``other`` into this one (the mergeable property — counts add).
-
-        Retained deliberately (no production caller yet): merging is the defining
-        operation of this DDSketch-style sketch, and the recency-weighted all-time
-        view (#25) folds per-period histograms through it.
-        """
-        if other.count == 0:
-            return
-        for key, cnt in other.buckets.items():
-            self.buckets[key] = self.buckets.get(key, 0) + cnt
-        self.min_ms = other.min_ms if self.count == 0 else min(self.min_ms, other.min_ms)
-        self.max_ms = max(self.max_ms, other.max_ms)
-        self.count += other.count
-        self.sum_ms += other.sum_ms
 
     def to_dict(self) -> dict[str, object]:
         """JSON-friendly form (bucket keys as strings, since JSON object keys are)."""

--- a/gluetun_monitor/monitor.py
+++ b/gluetun_monitor/monitor.py
@@ -1358,6 +1358,12 @@ class Monitor:
             {site: st}, global_timeout=self.config.timeout,
             global_tries=self.config.wget_tries,
             specs=self._specs,  # judge against the site's EFFECTIVE knobs (#77)
+            # Recency gate (#25). A no-op on this path by construction — the hint only
+            # rides an ACTIVE flaky-site advisory, so the site is failing now — but
+            # passing it keeps the one window (ADVISORY_WINDOW) authoritative for both
+            # "is this site currently a problem?" and "is advice about it still current?"
+            now=self.stats.now(),
+            stale_after_seconds=self.config.advisory_window,
         )
         if sugg and sugg[0].config_line:
             return (f" The stats suggest `{sugg[0].config_line}` — run "

--- a/gluetun_monitor/site_stats.py
+++ b/gluetun_monitor/site_stats.py
@@ -217,6 +217,13 @@ class SiteStatsStore:
             cat = categorize_failure(reason)
             st.failure_reasons[cat] = st.failure_reasons.get(cat, 0) + 1
 
+    def now(self) -> float:
+        """The store's current time. Public so callers that need to reason about the
+        age of a persisted timestamp (e.g. the tunable-suggestion recency gate, #25)
+        share this store's clock — including the fake one injected by tests.
+        """
+        return self._clock()
+
     def record_restart(self, site: str) -> None:
         """Record that ``site`` triggered a gluetun restart (attribution)."""
         now = self._clock()

--- a/gluetun_monitor/tunables.py
+++ b/gluetun_monitor/tunables.py
@@ -33,6 +33,12 @@ _SLOW_LATENCY_FRACTION = 0.7
 # a one-off blip (a single slow read on an otherwise-fast site isn't worth pinning
 # a higher per-URL timeout that would only delay detecting a real outage).
 _MIN_TIMEOUT_FAILURES = 3
+# Suggestions are computed from LIFETIME counters (a site's failure_reasons,
+# restarts_triggered and restart_effectiveness never reset), which is what makes them
+# well-evidenced — and what would otherwise make them immortal: a site that misbehaved
+# once, months ago, would qualify forever. Gate on recent evidence instead: no failure
+# inside this window means nothing to tune, whatever the lifetime totals say (#25).
+_DEFAULT_STALE_AFTER_SECONDS = 86400  # 24h; callers pass ADVISORY_WINDOW
 # Headroom (seconds) added above the slowest observed *successful* response when
 # suggesting a new timeout — enough that the occasional slow read still lands.
 _TIMEOUT_HEADROOM_S = 5
@@ -162,7 +168,9 @@ def suggest_tunables(
     *,
     global_timeout: int,
     global_tries: int,
+    now: float,
     specs: dict[str, SiteSpec] | None = None,
+    stale_after_seconds: int = _DEFAULT_STALE_AFTER_SECONDS,
 ) -> list[Suggestion]:
     """Per-URL tunable suggestions across all sites, ranked by restarts triggered.
 
@@ -172,10 +180,22 @@ def suggest_tunables(
     (or missing a URL) means the site inherits the globals, as before.
     Returns only sites worth acting on (healthy sites yield nothing), most-impactful
     first so the operator fixes the biggest restart driver before the long tail.
+
+    ``now`` is required rather than read from the clock so this stays a pure function
+    (and so a caller can never silently skip the recency gate below). A site whose last
+    failure predates ``stale_after_seconds`` is not worth tuning however damning its
+    lifetime counters are — it is healthy *now*, and advice about a month-old episode
+    is noise (#25).
     """
     specs = specs or {}
     out = []
     for url, st in sites.items():
+        # Recency gate (#25). The gates in _suggest_one all read lifetime-monotone
+        # counters, so without this a site that timed out once, long ago, would draw a
+        # "widen the timeout" suggestion forever. `last_failure is None` means it has
+        # never failed — nothing to tune, and its failure counters are empty anyway.
+        if st.last_failure is None or (now - st.last_failure) > stale_after_seconds:
+            continue
         spec = specs.get(url)
         # An advisory site never gates a restart (#110), so "widen its timeout to
         # avoid restarts" is meaningless advice — skip it rather than recommend a

--- a/tests/test_histogram.py
+++ b/tests/test_histogram.py
@@ -2,7 +2,7 @@
 
 Why: it backs the all-time latency view. These tests pin the accuracy guarantee
 (every percentile within ALPHA relative error), the exact count/avg/min/max,
-monotonic percentiles, mergeability, JSON round-trip, and graceful handling of
+monotonic percentiles, JSON round-trip, and graceful handling of
 empty/garbage input (it feeds the best-effort stats sidecar).
 """
 
@@ -71,29 +71,6 @@ def test_bounded_bucket_count() -> None:
     for _ in range(50_000):
         h.add(rng.randint(50, 10_000))
     assert len(h.buckets) < 120  # ~log_gamma(10000/50) buckets, not 50k samples
-
-
-def test_merge_is_additive() -> None:
-    a = LatencyHistogram()
-    b = LatencyHistogram()
-    for v in (100, 200, 300):
-        a.add(v)
-    for v in (400, 500, 600):
-        b.add(v)
-    combined = LatencyHistogram()
-    for v in (100, 200, 300, 400, 500, 600):
-        combined.add(v)
-    a.merge(b)
-    assert a.count == combined.count == 6
-    assert a.min_ms == 100 and a.max_ms == 600
-    assert a.summary() == combined.summary()
-
-
-def test_merge_empty_noop() -> None:
-    a = LatencyHistogram()
-    a.add(100)
-    a.merge(LatencyHistogram())
-    assert a.count == 1
 
 
 def test_json_round_trip() -> None:

--- a/tests/test_timeout_ceiling.py
+++ b/tests/test_timeout_ceiling.py
@@ -120,8 +120,14 @@ def test_loop_raises_the_ceiling_on_sites_reload(tmp_path: Path) -> None:
 # ----- tunables judge each site against its EFFECTIVE knobs -----
 
 
+# #25: suggestions are gated on recent evidence, so a fixture's site must look
+# like it failed recently. Overridable per-test via _stat(last_failure=...).
+_NOW = 1000.0
+
+
 def _stat(**kw: object) -> SiteStat:
     st = SiteStat(first_seen=0.0)
+    st.last_failure = _NOW  # fresh by default (#25 recency gate)
     for key, value in kw.items():
         setattr(st, key, value)
     return st
@@ -144,7 +150,7 @@ def test_no_resuggestion_at_or_below_the_existing_override() -> None:
     st = _slow_stat(13000)  # would suggest 20 against the 10s global
     specs = {"https://slow": SiteSpec("https://slow", timeout=30)}
     assert suggest_tunables(
-        {"https://slow": st}, global_timeout=10, global_tries=1, specs=specs
+        {"https://slow": st}, global_timeout=10, global_tries=1, now=_NOW, specs=specs
     ) == []
 
 
@@ -154,7 +160,7 @@ def test_overridden_site_still_gets_a_wider_suggestion_when_warranted() -> None:
     st = _slow_stat(40000)  # suggest round_up_5(40+5) = 45 > effective 30
     specs = {"https://slow": SiteSpec("https://slow", timeout=30, tries=2)}
     (s,) = suggest_tunables(
-        {"https://slow": st}, global_timeout=10, global_tries=1, specs=specs
+        {"https://slow": st}, global_timeout=10, global_tries=1, now=_NOW, specs=specs
     )
     assert s.config_line == "https://slow|timeout=45|tries=2"
 
@@ -162,7 +168,7 @@ def test_overridden_site_still_gets_a_wider_suggestion_when_warranted() -> None:
 def test_timeout_suggestions_are_capped_at_the_parse_maximum() -> None:
     """Never emit a paste-ready line parse_entry would reject."""
     st = _slow_stat(400_000)  # would suggest 405s uncapped
-    (s,) = suggest_tunables({"https://glacial": st}, global_timeout=10, global_tries=1)
+    (s,) = suggest_tunables({"https://glacial": st}, global_timeout=10, global_tries=1, now=_NOW)
     assert s.config_line == f"https://glacial|timeout={MAX_URL_TIMEOUT}"
 
 
@@ -176,7 +182,7 @@ def test_tries_override_suppresses_the_retry_suggestion() -> None:
     )
     specs = {"https://blippy": SiteSpec("https://blippy", tries=2)}
     assert suggest_tunables(
-        {"https://blippy": st}, global_timeout=10, global_tries=1, specs=specs
+        {"https://blippy": st}, global_timeout=10, global_tries=1, now=_NOW, specs=specs
     ) == []
 
 
@@ -188,6 +194,6 @@ def test_tries_suggestion_preserves_an_existing_timeout_override() -> None:
     )
     specs = {"https://blippy": SiteSpec("https://blippy", timeout=25)}
     (s,) = suggest_tunables(
-        {"https://blippy": st}, global_timeout=10, global_tries=1, specs=specs
+        {"https://blippy": st}, global_timeout=10, global_tries=1, now=_NOW, specs=specs
     )
     assert s.config_line == "https://blippy|timeout=25|tries=2"

--- a/tests/test_tunables.py
+++ b/tests/test_tunables.py
@@ -12,16 +12,21 @@ from __future__ import annotations
 from gluetun_monitor.site_stats import SiteStat
 from gluetun_monitor.tunables import suggest_tunables
 
+# #25: suggestions are gated on recent evidence, so a fixture's site must look
+# like it failed recently. Overridable per-test via _stat(last_failure=...).
+_NOW = 1000.0
+
 
 def _stat(**kw: object) -> SiteStat:
     st = SiteStat(first_seen=0.0)
+    st.last_failure = _NOW  # fresh by default (#25 recency gate)
     for key, value in kw.items():
         setattr(st, key, value)
     return st
 
 
 def _suggest(sites: dict[str, SiteStat], *, timeout: int = 10, tries: int = 1):
-    return suggest_tunables(sites, global_timeout=timeout, global_tries=tries)
+    return suggest_tunables(sites, global_timeout=timeout, global_tries=tries, now=_NOW)
 
 
 def test_slow_but_alive_gets_a_timeout_bump() -> None:
@@ -113,7 +118,59 @@ def test_advisory_site_gets_no_suggestion() -> None:
     url = "https://slow"
     st = _stat(total_polls=100, total_failures=5, failure_reasons={"timeout": 5},
                restarts_triggered=10, restarts_cleared=4, recent_latencies=[1500, 1800, 13000])
-    assert suggest_tunables({url: st}, global_timeout=10, global_tries=1,
+    assert suggest_tunables({url: st}, global_timeout=10, global_tries=1, now=_NOW,
                             specs={url: SiteSpec(url, role="critical")})           # critical -> suggests
-    assert suggest_tunables({url: st}, global_timeout=10, global_tries=1,
+    assert suggest_tunables({url: st}, global_timeout=10, global_tries=1, now=_NOW,
                             specs={url: SiteSpec(url, role="advisory")}) == []      # advisory -> skipped
+
+
+# ----- #25: suggestions are gated on recent evidence -----
+
+
+def _damning() -> SiteStat:
+    """Lifetime counters that qualify for a timeout bump: a pattern of read-timeouts
+    plus a success near the ceiling. Recency is what the tests below vary."""
+    return _stat(
+        total_polls=100, total_failures=5, failure_reasons={"timeout": 5},
+        restarts_triggered=10, restarts_cleared=4, longest_fail_streak=3,
+        recent_latencies=[1500, 1800, 13000],
+    )
+
+
+def test_stale_site_yields_no_suggestion_however_damning_its_lifetime_counters() -> None:
+    """The core #25 regression: every gate reads a lifetime-monotone counter, so a site
+    that misbehaved a month ago and has been healthy since used to qualify forever."""
+    st = _damning()
+    st.last_failure = _NOW - 90_000  # 25h ago, outside the 24h window
+    assert suggest_tunables({"https://slow": st}, global_timeout=10, global_tries=1,
+                            now=_NOW, stale_after_seconds=86_400) == []
+
+
+def test_recent_failure_still_yields_the_suggestion() -> None:
+    """The gate suppresses stale advice, not useful advice."""
+    st = _damning()
+    st.last_failure = _NOW - 3_600  # an hour ago — still a live problem
+    (s,) = suggest_tunables({"https://slow": st}, global_timeout=10, global_tries=1,
+                            now=_NOW, stale_after_seconds=86_400)
+    assert s.kind == "timeout"
+
+
+def test_never_failed_site_yields_no_suggestion() -> None:
+    """`last_failure is None` — nothing has ever gone wrong, so there is nothing to tune
+    (its failure counters are empty anyway; the gate just says so explicitly)."""
+    st = _damning()
+    st.last_failure = None
+    assert suggest_tunables({"https://slow": st}, global_timeout=10, global_tries=1,
+                            now=_NOW, stale_after_seconds=86_400) == []
+
+
+def test_recency_window_boundary_is_inclusive() -> None:
+    """A failure exactly at the window edge still counts; one second older does not."""
+    at_edge = _damning()
+    at_edge.last_failure = _NOW - 86_400
+    past_edge = _damning()
+    past_edge.last_failure = _NOW - 86_401
+    assert suggest_tunables({"https://slow": at_edge}, global_timeout=10, global_tries=1,
+                            now=_NOW, stale_after_seconds=86_400)
+    assert suggest_tunables({"https://slow": past_edge}, global_timeout=10, global_tries=1,
+                            now=_NOW, stale_after_seconds=86_400) == []


### PR DESCRIPTION
Closes #25.

**TL;DR — tunable suggestions never expired. Every gate reads a lifetime-monotone counter, so a site that timed out once a month ago and has been healthy ever since permanently qualified for a "widen the timeout" suggestion. Now gated on recent evidence.**

## Behavioral proof

Against the **old** code, a site whose last failure was **25 hours** ago:

| | suggestion |
|---|---|
| without the gate | `https://slow.example\|timeout=20` ← the bug |
| with the gate | `NONE` |

## The bug

```python
timeouts = st.failure_reasons.get("timeout", 0)                       # never resets
if timeouts >= _MIN_TIMEOUT_FAILURES and max_ms >= timeout*1000*0.7   # both monotone
...
eff is not None and eff < 0.5 and st.restarts_triggered >= _INVESTIGATE_MIN_RESTARTS
```

Lifetime counters are what make the advice *well-evidenced* — and what made it *immortal*.

The alert path was safe only by accident: the hint rides an **active** flaky-site advisory, which is windowed, so its subject is failing *now* by construction. It was **`--suggest-tunables`** — invoked on demand against the whole sidecar — that surfaced stale advice.

## The fix

`SiteStat.last_failure` already existed, is a timestamp, and is already persisted. **No new data structure, no decay bookkeeping, no new knob.**

- `suggest_tunables` gains a **required** `now` (keeps it a pure function, and makes it impossible to *silently* skip the gate) plus `stale_after_seconds`, and skips any site whose `last_failure` is absent or older than the window.
- Both callers pass `ADVISORY_WINDOW`, so one window is authoritative for both *"is this site a problem now?"* and *"is advice about it still current?"*
- `SiteStatsStore.now()` exposes the store's clock, so tests' injected fake clock flows through.

## Deliberately unchanged: the estimator still anchors on `max`

Costs are **asymmetric** — under-suggesting a timeout keeps bouncing the tunnel and churning every dependent; over-suggesting merely makes a *failing* probe take a few more seconds. So it must cover the **worst legitimate success**, not a percentile (`p99` would set a timeout that still times out on the site's genuinely slow-but-alive responses).

And `max` cannot run away: latency is recorded **only on a successful poll**, so `max_ms <= effective timeout`, making the suggestion a bounded, converging ratchet (10s → 15s → 20s, only while it keeps timing out at the current width).

Not switched to the recent ring's max either — 200 samples ≈ **1.7h**, so a site slow once every few hours would drop its slow success out of the window and we'd systematically *under*-suggest, erring in the expensive direction.

## Also: `histogram.merge()` removed

It was kept in #91 on the explicit rationale that #25's recency-weighted view would consume it. That view isn't being built — bucket decay cannot touch `min`/`max`, which are exact scalars held *outside* the buckets, so it would change **zero** decisions (the full evidence is on #25). `merge()` is therefore dead code, and its keep-comment was a lie. Removed, with its two tests.

## Tests
4 new: stale site yields nothing however damning its lifetime counters; a recent failure still yields the suggestion; `last_failure is None` yields nothing; the window boundary is inclusive. Existing fixtures updated to model reality (a site with failures has a `last_failure`).

Full suite + ruff + mypy green.