### PR TITLE
fix: never count an unprobeable dependent as healthy (#147)

### DIFF
--- a/README.md
+++ b/README.md
@@ -778,7 +778,7 @@ line looks. Each level adds its own row to everything above it (ADR-0011):
 
 | `NOTIFY_LEVEL` | You get | Events |
 |---|---|---|
-| **`attention`** *(default)* | only when **you** must act/decide | recovery/remediation failed, refused to start, **cannot probe the gateway**, **flaky-site advisory**, **dependent-flapping advisory** |
+| **`attention`** *(default)* | only when **you** must act/decide | recovery/remediation failed, refused to start, **cannot probe the gateway**, **cannot probe a dependent**, **flaky-site advisory**, **dependent-flapping advisory** |
 | `recovery` | + self-healed incidents | gluetun recovered, dependent remediated |
 | `activity` | + non-fault changes | `sites.conf` reloaded, **advisory site unreachable / recovered** |
 | `all` | + the firehose | per-loop checks, restart play-by-play |
@@ -1184,6 +1184,8 @@ The recommended deployment uses a [Docker socket proxy](https://github.com/Tecna
 All three are required. `POST=1` in particular is unavoidable: tecnativa's `POST` is a *binary* switch for the container API — with `POST=0`, the `EXEC` and `ALLOW_RESTARTS` carve-outs are inert, so neither probing nor restarting works (verified; see [#29](https://github.com/csmarshall/gluetun-monitor/issues/29)).
 
 **If the monitor cannot probe, it does nothing.** Should `EXEC` be missing, the proxy become unreachable, or Gluetun stop shipping a usable `wget`, the site probes cannot *run* — which says nothing about the tunnel. Rather than mistake that for a connectivity failure and restart Gluetun (a restart cannot restore an EXEC permission), the monitor raises a distinct `attention` alert — *"cannot probe `<gluetun>`"* — holds its existing alerts, touches nothing, and never claims recovery it could not verify ([#137](https://github.com/csmarshall/gluetun-monitor/issues/137)).
+
+**The same holds for a dependent it cannot see into** — and "cannot see into" includes a container that is *crash-looping*, because Docker reports one as `Running: true` throughout (`Running` means the daemon considers it alive, not that it works). Such a dependent is never counted as healthy and never remediated: restarting a container that is already restarting fixes nothing, and would bounce the network namespace its siblings share. It is reported instead — excluded from the healthy count but never hidden from the total (`dependents: 3/4 ok (1 unprobeable)`), and escalated to a *"cannot probe `<dependent>`"* `attention` alert if it stays unprobeable, which resolves itself the moment the container answers again ([#147](https://github.com/csmarshall/gluetun-monitor/issues/147)). A dependent *stranded* by a Gluetun recreate also crash-loops — its restart policy keeps starting it onto a dead namespace — so the strand check runs first and still heals it; only a container dying of its own accord is left alone.
 
 On `wget` specifically: Gluetun installs GNU `wget` deliberately (it's an explicit `apk add` in its Dockerfile), but that is an *implementation detail* rather than a documented guarantee — whether its presence is part of Gluetun's supported surface is [an open question upstream](https://github.com/passteque/gluetun/discussions/3387). The monitor is built not to care: probes are classified on the **HTTP response**, not on `wget`'s exit code, so GNU and BusyBox `wget` behave identically — and if it ever disappears entirely, the paragraph above applies. We report; we do not restart.
 

--- a/docs/adr/0004-dependent-aware-health.md
+++ b/docs/adr/0004-dependent-aware-health.md
@@ -133,3 +133,46 @@ must therefore be evaluated **per dependent**, not as a single global flag.
   dependent that fails it is routed back into this ADR's recovery branch.
 - Supersedes the implicit assumption — present in the original design — that a
   healthy gluetun implies a healthy stack.
+
+## Amendments
+
+### #147 — a crash-looping dependent is *unknown*, and a strand outranks it
+
+Docker reports a container that is crash-looping as `State.Running: true`, with
+`State.Status: "restarting"`. `Running` means "the daemon considers this alive",
+which includes the gaps between a dying container's respawns; it is not a claim
+of health. A dependent that had died 8,548 times therefore read as running, and
+because every `docker exec` into it failed, the interface check returned UNKNOWN
+and the loop left it *unevaluated* — correctly, per #137: never act on a signal
+you cannot attribute. But the tally then counted it as healthy, and nothing ever
+escalated it. The stack reported `dependents: 4/4 ok` for ten days over a
+container that had not worked once.
+
+Three rules follow, and they interact:
+
+1. **`ContainerInfo.running` keeps Docker's meaning; the crash-loop is carried by
+   an explicit `restarting` field.** Both constructors (`from_inspect`, which
+   reads the `Running` bool, and `from_list_entry`, which reads the state string)
+   populate it, so a container's aliveness cannot flip depending on which API
+   call discovered it — they previously disagreed in exactly this case.
+   Narrowing `running` to exclude `restarting` looks obviously correct and is a
+   trap: `running` gates the recreate verdict above, and **a stranded dependent
+   crash-loops too** — its restart policy keeps starting it onto a dead netns, so
+   `Status` is `restarting` for precisely the containers this ADR exists to
+   rescue. Redefining it would have routed them away from the strand branch.
+
+2. **The strand verdict wins.** The `NetworkMode`-vs-current-id comparison runs
+   *before* the crash-loop check, because a strand is the actionable diagnosis
+   and healing it is the point. Only a container dying for reasons of its own
+   falls through to "crash-looping".
+
+3. **A crash-looper is reported, never remediated.** Restarting a container that
+   is already restarting fixes nothing, and bounces the netns its siblings share
+   — the watchdog becoming the outage (Tenets 1 and 7). It is left unevaluated:
+   excluded from the healthy count, never hidden from the total
+   (`dependents: 3/4 ok (1 unprobeable)` — shrinking that to `3/3` would be a
+   fake-green by omission), and escalated by a `dependent-unprobeable` alert once
+   it stays unprobeable beyond a threshold sized to absorb a remediation restart.
+   Without that alert an unprobeable dependent is silent by construction: it
+   accrues no failure count, so it can never trip `dependent-unhealthy`.
+   Lifecycle per ADR-0012 — it resolves itself once the container is probeable.

--- a/docs/adr/0011-notification-tiers-and-rollup.md
+++ b/docs/adr/0011-notification-tiers-and-rollup.md
@@ -100,7 +100,7 @@ later, with no contract change.
 **The pipeline** — why grouping is intrinsic (the rollup substrate):
 
 ```mermaid
-flowchart LR
+flowchart TD
     EV[problems + point events this loop] --> LC{lifecycle: new / repeat / resolve?}
     LC -->|suppressed| X[dropped]
     LC -->|emit| TF{tier within NOTIFY_LEVEL?}

--- a/docs/adr/0012-alert-lifecycle.md
+++ b/docs/adr/0012-alert-lifecycle.md
@@ -88,3 +88,15 @@ edge/repeat/resolve logic is here, which keeps both pieces simple and testable.
   and a dependent the loop couldn't evaluate holds its alert via `AlertState.hold`
   instead of resolving it (#112). Both apply the incomplete-loop principle
   (silence ≠ recovery) at per-subject granularity.
+- **#147 — an un-evaluatable subject needs an alert of its own.** Holding a
+  dependent's alert (above) keeps the lifecycle from *lying* about it, but a
+  dependent that was never unhealthy in the first place has no alert to hold: it
+  accrues no failure count, so it can never trip `dependent-unhealthy`, and it
+  falls silent by construction. `dependent-unprobeable` closes that gap — an
+  `attention` alert raised once a dependent stays unprobeable past a threshold
+  (sized to absorb a remediation restart, which briefly makes one unprobeable by
+  the monitor's own hand). It needs no explicit resolve: it stops being reported
+  the loop the dependent answers again, and the edge-triggered lifecycle above
+  does the rest. Mirrors `gluetun-unprobeable` (#137) on the dependent side; the
+  reasoning about *what* is unprobeable, and why a crash-looper is reported
+  rather than restarted, is in ADR-0004's amendments.

--- a/gluetun_monitor/docker_client.py
+++ b/gluetun_monitor/docker_client.py
@@ -33,7 +33,15 @@ class ContainerInfo:
     name: str
     network_mode: str
     running: bool
+    """The daemon considers this container ALIVE — which includes the gaps between a
+    crash-looping container's restarts. It is *not* a claim of health: a container that
+    has died 8,000 times still reports ``Running=true`` while ``Status="restarting"``.
+    Ask ``restarting`` before reading this as "fine" (#147)."""
     health: str
+    restarting: bool = False
+    """``State.Status == "restarting"`` — the container is crash-looping. Docker keeps
+    ``Running`` true throughout, so this is the ONLY field that distinguishes a healthy
+    container from one dying on a loop. Both constructors carry it, so the two agree."""
     raw: dict[str, Any] = field(default_factory=dict)
 
     @classmethod
@@ -48,6 +56,7 @@ class ContainerInfo:
             network_mode=str(host_config.get("NetworkMode", "")),
             running=bool(state.get("Running", False)),
             health=str(health_obj.get("Status", "unknown")) if health_obj else "unknown",
+            restarting=str(state.get("Status", "")).lower() == "restarting",
             raw=raw,
         )
 
@@ -61,15 +70,24 @@ class ContainerInfo:
         an inspect per container. ``health`` is left ``"unknown"`` and ``raw`` is the
         list entry (NOT a full inspect), so any caller needing ``Config``/``Mounts``
         must still ``inspect()``.
+
+        ``/containers/json`` returns crash-looping containers (``State="restarting"``)
+        alongside healthy ones, so ``running`` counts them as alive — matching what
+        inspect's ``State.Running`` bool reports for the same container. The two
+        constructors must agree, or a container's aliveness would flip depending on
+        which call the monitor happened to learn about it from (#147). The crash-loop
+        itself is carried, in both, by ``restarting``.
         """
         names = entry.get("Names") or []
         host_config = entry.get("HostConfig", {}) or {}
+        state = str(entry.get("State", "")).lower()
         return cls(
             id=entry.get("Id", ""),
             name=str(names[0]).lstrip("/") if names else "",
             network_mode=str(host_config.get("NetworkMode", "")),
-            running=str(entry.get("State", "")).lower() == "running",
+            running=state in ("running", "restarting"),
             health="unknown",
+            restarting=state == "restarting",
             raw=entry,
         )
 

--- a/gluetun_monitor/monitor.py
+++ b/gluetun_monitor/monitor.py
@@ -57,6 +57,13 @@ if TYPE_CHECKING:
 
 Sleep = Callable[[float], None]
 
+# Consecutive loops a dependent may stay unprobeable before the monitor says so out loud
+# (#147). Not a tunable: it is a floor on "long enough that this is not just a restart".
+# A remediation restart leaves a dependent unprobeable for a loop or two, which is the
+# monitor's own doing and not worth paging about; anything past that is a container we
+# genuinely cannot see, and silence there is how one crash-looped for ten days unnoticed.
+_UNPROBEABLE_ALERT_LOOPS = 5
+
 
 @dataclass(frozen=True, slots=True)
 class GatewayCheck:
@@ -85,6 +92,7 @@ class DependentProbe:
     viability_ok: bool | None  # None = not tested (no pool / not live / unvalidatable)
     reason: str
     dns_unvalidated: bool = False  # True = no usable DNS tool in the container
+    restarting: bool = False  # True = crash-looping: alive per Docker, healthy per nobody
     interfaces: str = "?"  # the dependent's net interfaces, for DEBUG visibility
 
 
@@ -171,6 +179,10 @@ class Monitor:
         self._unrecovered_sites: set[str] = set()
         self.site_failures = Counter()
         self.dependent_failures = Counter()
+        # Consecutive loops each dependent has been UNPROBEABLE (#147) — tracked apart from
+        # dependent_failures because "I couldn't tell" is not "it failed": this counter never
+        # drives remediation, only the dependent-unprobeable alert.
+        self.dependent_unprobeable = Counter()
         # Last-seen full specs (url -> SiteSpec), so a live edit is detected on ANY
         # config change — not just add/remove, but a site's role/timeout/tries too.
         self._last_specs: dict[str, SiteSpec] | None = None
@@ -588,6 +600,18 @@ class Monitor:
                     "inspect: netns id moved (gluetun recreated), container not exec'able",
                     interfaces=ifs,
                 )
+            # Crash-looping (#147). Checked AFTER the strand verdict above, because a
+            # stranded dependent also crash-loops (its restart policy keeps starting it
+            # onto a dead netns) and healing that strand is the whole point — the strand
+            # is the actionable diagnosis, so it wins. What's left here is a container
+            # dying for reasons of its own. Docker reports it Running the whole time, so
+            # without this it looks alive and probes silently fail forever. We can't fix
+            # it (restarting a container that is *already* restarting is pure churn —
+            # Tenets 1 and 7), so we say so instead of acting: unevaluated, and loud.
+            if info is not None and info.restarting:
+                return DependentProbe(dep, InterfaceStatus.UNKNOWN, True, None,
+                                      "container is restarting (crash-looping)",
+                                      interfaces=ifs, restarting=True)
             return DependentProbe(dep, status, running, None, "link check unavailable",
                                   interfaces=ifs)
 
@@ -737,7 +761,9 @@ class Monitor:
         for gone in self._managed_dependents - set(dependents):
             self._forget(f"dependent-unhealthy:{gone}")
             self._forget(f"dependent-wedged:{gone}")
+            self._forget(f"dependent-unprobeable:{gone}")
             self._wedges.pop(gone, None)
+            self.dependent_unprobeable.reset(gone)
         self._managed_dependents = set(dependents)
         if not dependents:
             return
@@ -785,7 +811,11 @@ class Monitor:
                 continue
             if probe.status is InterfaceStatus.UNKNOWN:
                 self.log.debug(f"[{tag}] {probe.reason} (running={probe.running})")
-                if not probe.running:
+                if probe.restarting:
+                    # Crash-looping: restarting it again fixes nothing and churns the
+                    # netns its siblings share. Not judged, not touched — escalated below.
+                    unevaluated.add(dep)
+                elif not probe.running:
                     to_remediate.append((dep, "not running (link check unavailable)"))
                 else:
                     unevaluated.add(dep)  # running but interfaces unreadable — not judged
@@ -820,14 +850,45 @@ class Monitor:
                 self.log.debug(f"[{tag}] reach fail: {probe.reason} [{count}/{threshold}]")
 
         # INFO heartbeat for the dependent phase (mirrors the gateway summary).
-        healthy = len(probes) - len(to_remediate)
+        # A dependent we could not evaluate is neither ok nor failing — it is UNKNOWN, and
+        # counting it as healthy reported a container that had crash-looped thousands of
+        # times as "4/4 ok" (#147). Exclude it from the healthy count, but NEVER from the
+        # denominator: shrinking N/M to hide it would just be a fake-green by omission.
+        # "I couldn't tell" gets said out loud (Tenet 7).
+        healthy = len(probes) - len(to_remediate) - len(unevaluated)
+        unprobed = f" ({len(unevaluated)} unprobeable)" if unevaluated else ""
         if to_remediate:
             self.log.info(
-                f"dependents: {healthy}/{len(probes)} ok — "
+                f"dependents: {healthy}/{len(probes)} ok{unprobed} — "
                 f"remediating: {', '.join(dep for dep, _ in to_remediate)}"
             )
         else:
-            self.log.info(f"dependents: {healthy}/{len(probes)} ok")
+            self.log.info(f"dependents: {healthy}/{len(probes)} ok{unprobed}")
+
+        # A dependent that STAYS unprobeable escalates (#147). Left alone it is neither
+        # healthy nor failing: it accrues no failure count (correctly — #137: never act on
+        # a signal we cannot attribute), so it never trips dependent-unhealthy, and it would
+        # sit in limbo silently forever. On the host that prompted this, a crash-looping
+        # dependent was unprobeable for TEN DAYS and nothing ever said so. Mirrors the
+        # gateway's `gluetun-unprobeable`. Thresholded because a remediation restart makes a
+        # dependent briefly unprobeable — that is the monitor's own doing, not an incident.
+        for dep in unevaluated:
+            streak = self.dependent_unprobeable.fail(dep)
+            if streak >= _UNPROBEABLE_ALERT_LOOPS:
+                self._problem(
+                    f"dependent-unprobeable:{dep}",
+                    "attention",
+                    f"cannot probe dependent: {dep}",
+                    f"{dep} has been unprobeable for {streak} consecutive loops — its health "
+                    f"is UNKNOWN, and it is NOT being remediated (acting on a signal we can't "
+                    f"attribute would risk restarting a healthy container). Check whether it "
+                    f"is crash-looping, is stuck, or lacks the tools to probe with.",
+                )
+        # Probeable again: drop the streak. The alert stops being reported, so the
+        # lifecycle resolves it (ADR-0012) — no explicit resolve call needed.
+        for probe in probes:
+            if probe.name not in unevaluated:
+                self.dependent_unprobeable.reset(probe.name)
 
         # A dependent the loop couldn't evaluate wasn't proven healthy — hold any
         # active alert so it doesn't false-resolve mid-incident (e.g. all sites went

--- a/tests/fakes.py
+++ b/tests/fakes.py
@@ -46,12 +46,23 @@ def make_inspect(
     network_mode: str = "",
     running: bool = True,
     health: str | None = "healthy",
+    status: str | None = None,
     mounts: list[dict[str, Any]] | None = None,
     config: dict[str, Any] | None = None,
     host_config: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
-    """Build a docker-inspect-shaped dict."""
-    state: dict[str, Any] = {"Running": running}
+    """Build a docker-inspect-shaped dict.
+
+    Real Docker ALWAYS sets ``State.Status``, and reports ``Running=true`` while
+    ``Status == "restarting"`` — the crash-loop case that produced the #147 fake-green.
+    So the fake carries both: ``status`` defaults to the value implied by ``running``,
+    and a test can pass ``status="restarting"`` (with ``running=True``) to reproduce a
+    crash-looping container faithfully.
+    """
+    state: dict[str, Any] = {
+        "Running": running,
+        "Status": status if status is not None else ("running" if running else "exited"),
+    }
     if health is not None:
         state["Health"] = {"Status": health}
     full_host_config = {"NetworkMode": network_mode}

--- a/tests/test_dependent_unprobeable.py
+++ b/tests/test_dependent_unprobeable.py
@@ -152,6 +152,28 @@ def test_persistent_unprobeable_dependent_escalates_once(tmp_path: Path) -> None
     assert "dependent-unprobeable:sonarr" not in keys, "the healthy one stays quiet"
 
 
+def test_unprobeable_alert_repeats_like_any_other(tmp_path: Path) -> None:
+    """A container stuck for ten days must keep nagging, not announce once and go quiet.
+
+    It gets this for free — the alert is raised through the same `_problem()` entry point
+    as everything else, so the ADR-0012 machinery (edge-trigger → remind every
+    NOTIFY_REPEAT_INTERVAL loops while active → resolve) applies with no special-casing.
+    Pinned because "stuck" is exactly the state where a fire-once alert would be useless.
+    """
+    notifier = FakeNotifier()
+    mon, _ = _monitor(tmp_path, notifier, io.StringIO())
+    mon.alerts._repeat = 3  # NOTIFY_REPEAT_INTERVAL
+
+    for _ in range(_UNPROBEABLE_ALERT_LOOPS + 9):
+        mon.run_once()
+
+    events = [e for e in notifier.events if e.key == "dependent-unprobeable:flaresolverr"]
+    assert len(events) > 1, "an ongoing problem must nag, not fire once and fall silent"
+    assert not events[0].title.startswith("still active"), "the first one is the edge"
+    assert all(e.title.startswith("still active") for e in events[1:]), "the rest are reminders"
+    assert all(e.tier == "attention" for e in events)
+
+
 def test_a_brief_unprobeable_blip_does_not_alert(tmp_path: Path) -> None:
     """A remediation restart leaves a dependent unprobeable for a loop or two. That is
     the monitor's own doing, not an incident — the threshold exists to absorb it."""

--- a/tests/test_dependent_unprobeable.py
+++ b/tests/test_dependent_unprobeable.py
@@ -1,0 +1,196 @@
+"""#147: a dependent the monitor cannot probe is UNKNOWN — never "ok", never silent.
+
+Docker reports a crash-looping container as ``State.Running: true`` (with
+``State.Status: "restarting"``), so a dependent that had died 8,548 times still looked
+alive. Exec into it always failed, which correctly left it *unevaluated* — the #137
+discipline: never act on a signal you can't attribute. But the heartbeat computed
+``healthy = total - failing``, so "couldn't tell" quietly became "fine", and nothing
+escalated an unevaluated dependent. The result was ``dependents: 4/4 ok`` printed every
+30s for TEN DAYS over a container that had not worked once in that window — the exact
+fake-green Tenet 7 exists to forbid.
+
+These tests pin all three halves: the state model (``restarting`` is carried, and both
+ContainerInfo constructors agree on it), the arithmetic (unevaluated is subtracted from
+the numerator and NEVER hidden from the denominator), and the escalation (a dependent
+that stays unprobeable gets said out loud — without ever being restarted, because
+restarting a container that is already restarting is churn we can't fix).
+"""
+
+from __future__ import annotations
+
+import io
+import random
+from pathlib import Path
+
+from gluetun_monitor.config import Config
+from gluetun_monitor.docker_client import ContainerInfo, ExecResult
+from gluetun_monitor.logging_setup import Logger
+from gluetun_monitor.monitor import _UNPROBEABLE_ALERT_LOOPS, Monitor
+from gluetun_monitor.site_stats import SiteStatsStore
+
+from .fakes import FakeDockerClient, FakeNotifier, make_inspect
+
+GLUETUN_ID = "a" * 64
+FLARE_ID = "f" * 64
+SITE = "https://a.example"
+
+# What the daemon actually says when you exec into a crash-looping container.
+_RESTARTING = "Container is restarting, wait until the container is running"
+
+
+def _monitor(
+    tmp_path: Path, notifier: FakeNotifier, log: io.StringIO
+) -> tuple[Monitor, FakeDockerClient]:
+    """gluetun + two dependents: one healthy, one crash-looping."""
+    conf = tmp_path / "sites.conf"
+    conf.write_text(f"{SITE}\n")
+    fake = FakeDockerClient()
+    fake.add_container("gluetun", id=GLUETUN_ID, health="healthy")
+    fake.add_container("sonarr", network_mode=f"container:{GLUETUN_ID}")
+    # Alive per Docker, healthy per nobody: Running=true AND Status=restarting.
+    fake.add_container(
+        "flaresolverr", id=FLARE_ID, network_mode=f"container:{GLUETUN_ID}",
+        running=True, status="restarting", health="unhealthy",
+    )
+
+    def handler(name: str, cmd: list[str]) -> ExecResult:
+        if name == "flaresolverr":
+            raise RuntimeError(_RESTARTING)  # every exec into it fails, every loop
+        if cmd[:1] == ["ls"]:
+            return ExecResult(0, "eth0 lo tun0\n")
+        if cmd[:1] in (["nslookup"], ["getent"]):
+            return ExecResult(0, "1.1.1.1\n")
+        return ExecResult(0, "  HTTP/1.1 200 OK\n")
+
+    fake.on_exec = handler
+    mon = Monitor(
+        fake,
+        Config(config_file=str(conf), gluetun_container="gluetun",
+               fail_threshold=2, dns_wait_timeout=0, advisory_min_restarts=999),
+        Logger(log_file=None, stream=log),
+        rng=random.Random(0), sleep=lambda _s: None,
+        stats=SiteStatsStore(None), notifier=notifier,
+    )
+    return mon, fake
+
+
+# ----- the state model: Docker's `Running` is not a health claim -----
+
+
+def test_inspect_carries_the_crash_loop() -> None:
+    """`Running` stays what Docker means by it (alive); `restarting` carries the truth."""
+    info = ContainerInfo.from_inspect(
+        make_inspect("flaresolverr", id=FLARE_ID, running=True, status="restarting")
+    )
+    assert info.running is True, "Docker really does report a crash-looper as Running"
+    assert info.restarting is True, "...so `restarting` is the only field that catches it"
+
+
+def test_both_constructors_agree_on_a_crash_looper() -> None:
+    """A container's aliveness must not depend on which API call discovered it.
+
+    `/containers/json` lists restarting containers too. Before #147 the list path read
+    them as not-running while the inspect path read them as running — the same container,
+    two verdicts, decided by which code got there first.
+    """
+    listed = ContainerInfo.from_list_entry(
+        {"Id": FLARE_ID, "Names": ["/flaresolverr"], "State": "restarting", "HostConfig": {}}
+    )
+    inspected = ContainerInfo.from_inspect(
+        make_inspect("flaresolverr", id=FLARE_ID, running=True, status="restarting")
+    )
+    assert (listed.running, listed.restarting) == (inspected.running, inspected.restarting)
+    assert listed.restarting is True
+
+
+# ----- the arithmetic: unevaluated is not healthy, and is never hidden -----
+
+
+def test_crash_looping_dependent_is_not_counted_healthy(tmp_path: Path) -> None:
+    """The core regression (RED pre-fix: printed `dependents: 2/2 ok`).
+
+    The unprobeable dependent leaves the numerator, stays in the denominator, and is
+    named — shrinking the total to `1/1 ok` would just be a fake-green by omission.
+    """
+    log = io.StringIO()
+    mon, _ = _monitor(tmp_path, FakeNotifier(), log)
+
+    mon.run_once()
+
+    out = log.getvalue()
+    assert "dependents: 1/2 ok (1 unprobeable)" in out, out
+    assert "2/2 ok" not in out, f"fake-green! {out}"
+
+
+def test_crash_looping_dependent_is_never_restarted(tmp_path: Path) -> None:
+    """Restarting a container that is ALREADY restarting fixes nothing and bounces the
+    netns its siblings share — the watchdog becoming the outage (Tenets 1 and 7)."""
+    log = io.StringIO()
+    mon, fake = _monitor(tmp_path, FakeNotifier(), log)
+
+    for _ in range(_UNPROBEABLE_ALERT_LOOPS + 3):
+        mon.run_once()
+
+    assert fake.restarted == [], "a crash-looper must be reported, not churned"
+    assert (fake.removed, fake.created) == ([], []), "and certainly not recreated"
+
+
+# ----- the escalation: silence is the bug -----
+
+
+def test_persistent_unprobeable_dependent_escalates_once(tmp_path: Path) -> None:
+    """Ten days of invisibility must not be quiet. Edge-triggered: announced once."""
+    notifier = FakeNotifier()
+    mon, _ = _monitor(tmp_path, notifier, io.StringIO())
+
+    for _ in range(_UNPROBEABLE_ALERT_LOOPS + 2):
+        mon.run_once()
+
+    keys = notifier.event_keys()
+    assert keys.count("dependent-unprobeable:flaresolverr") == 1, keys
+    assert "dependent-unhealthy:flaresolverr" not in keys, "unknown is not failing (#137)"
+    assert "dependent-unprobeable:sonarr" not in keys, "the healthy one stays quiet"
+
+
+def test_a_brief_unprobeable_blip_does_not_alert(tmp_path: Path) -> None:
+    """A remediation restart leaves a dependent unprobeable for a loop or two. That is
+    the monitor's own doing, not an incident — the threshold exists to absorb it."""
+    notifier = FakeNotifier()
+    mon, _ = _monitor(tmp_path, notifier, io.StringIO())
+
+    for _ in range(_UNPROBEABLE_ALERT_LOOPS - 1):
+        mon.run_once()
+
+    assert "dependent-unprobeable:flaresolverr" not in notifier.event_keys()
+
+
+def test_unprobeable_resolves_when_the_dependent_comes_back(tmp_path: Path) -> None:
+    """Lifecycle (ADR-0012): the alert clears itself once the container is probeable —
+    exactly once, and without a restart, since nothing needed remediating."""
+    notifier = FakeNotifier()
+    log = io.StringIO()
+    mon, fake = _monitor(tmp_path, notifier, log)
+
+    for _ in range(_UNPROBEABLE_ALERT_LOOPS):
+        mon.run_once()
+    assert "dependent-unprobeable:flaresolverr" in notifier.event_keys()
+
+    # Operator fixes the container: it stops crash-looping and starts answering execs.
+    fake._store[FLARE_ID]["State"]["Status"] = "running"
+
+    def probeable(name: str, cmd: list[str]) -> ExecResult:
+        if cmd[:1] == ["ls"]:
+            return ExecResult(0, "eth0 lo tun0\n")
+        if cmd[:1] in (["nslookup"], ["getent"]):
+            return ExecResult(0, "1.1.1.1\n")
+        return ExecResult(0, "  HTTP/1.1 200 OK\n")
+
+    fake.on_exec = probeable
+    log.truncate(0)
+    log.seek(0)
+    mon.run_once()
+
+    keys = notifier.event_keys()
+    assert keys.count("resolve:dependent-unprobeable:flaresolverr") == 1, keys
+    assert fake.restarted == [], "recovery of the probe path must not trigger a restart"
+    assert "dependents: 2/2 ok" in log.getvalue(), "and it counts as healthy again"


### PR DESCRIPTION
## TL;DR

A crash-looping dependent was reported as `dependents: 4/4 ok` — every 30 seconds, for **ten days**, over a container that had not worked once in that window. Three defects fed one fake-green. This fixes all three, and adds the alert that would have caught it on day one.

Closes #147.

## What went wrong

Docker reports a container that has died 8,548 times as `State.Running: true`, with `State.Status: "restarting"`. `Running` means *"the daemon considers this alive"* — including the gaps between a crash-looper's respawns. It is not a health claim.

Exec into that container always failed, which correctly left it **unevaluated** — per #137, never act on a signal you cannot attribute. But two things then went wrong at once:

1. The heartbeat computed `healthy = total − failing`, so *"couldn't tell"* silently became *"fine"*.
2. Nothing escalated an unevaluated dependent. It accrues no failure count (correctly), so it never trips `dependent-unhealthy` — and nothing else was watching. Limbo, silently, forever.

## The state machine

```mermaid
stateDiagram-v2
    direction TB
    [*] --> Probe: each loop

    Probe --> Stranded: lo-only / netns id moved
    Probe --> Live: interfaces readable
    Probe --> Unprobeable: exec fails

    Stranded --> Remediate: restart / recreate
    Live --> Failing: viability fails
    Live --> Healthy: viability ok
    Failing --> Remediate: after FAIL_THRESHOLD

    Unprobeable --> Unprobeable: streak++ (never remediated)
    Unprobeable --> Alert: streak ≥ 5
    Unprobeable --> Healthy: probeable again → resolve
    Alert --> Healthy: probeable again → resolve

    Remediate --> [*]
    Healthy --> [*]

    note right of Unprobeable
        BEFORE: counted as healthy (fake-green),
        no alert, no escalation — forever.
        AFTER: out of the numerator,
        still in the denominator, and loud.
    end note
```

## The fix

**1. `ContainerInfo` carries `restarting`, and both constructors agree on it.**

They previously disagreed: `from_inspect` read the `Running` bool (→ running), `from_list_entry` read the state string (→ not running). The same container got opposite verdicts depending on which API call happened to discover it.

`running` deliberately keeps Docker's meaning rather than being redefined to exclude `restarting`. It gates the stranded-container RECREATE path (#20/#97) — and a stranded dependent *also* crash-loops, because its restart policy keeps starting it onto a dead netns. Narrowing `running` would have quietly broken strand healing, which is the product's core value.

**2. The heartbeat refuses to guess.**

```
dependents: 3/4 ok (1 unprobeable)
```

Unevaluated leaves the numerator and **never** leaves the denominator. Shrinking the total to `3/3 ok` would just be a fake-green wearing a disguise. The gateway path got this discipline in #137; the dependent path never did.

**3. `dependent-unprobeable:<dep>` — the missing escalation.**

A dependent unprobeable for **5 consecutive loops** raises an `attention` alert, auto-resolving through the ADR-0012 lifecycle the moment it is probeable again. Five rather than two because a remediation restart leaves a dependent briefly unprobeable — that is the monitor's own doing and not worth paging about.

A crash-looper is **never restarted**. Restarting a container that is *already* restarting fixes nothing and bounces the netns its siblings share — the watchdog becoming the outage (Tenets 1 and 7). We say it out loud instead of acting on it. That check sits *after* the strand verdict, so a genuine strand is still healed rather than merely reported.

## Verification

`tests/test_dependent_unprobeable.py` — 7 tests, verified RED against pristine sources. The regression test caught the exact production string:

```
assert 'dependents: 1/2 ok (1 unprobeable)' in ...
E   assert ... in '... [INFO] dependents: 2/2 ok\n'
```

Full suite: **593 passed, 1 skipped** (live-daemon test; no docker group). `ruff check` and `mypy` clean.
