### PR TITLE
fix(ci): bump pip-tools 7.5.3 → 7.6.1 for pip 26 compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,7 +128,7 @@ jobs:
         # Python version, invocation — is stripped), so it fails on real dependency
         # drift, not cosmetic header text.
         run: |
-          pip install pip-tools==7.5.3
+          pip install pip-tools==7.6.1
           cp requirements.lock /tmp/committed.lock
           pip-compile --quiet --generate-hashes --output-file=requirements.lock pyproject.toml
           if ! diff -u <(grep -v '^#' /tmp/committed.lock) <(grep -v '^#' requirements.lock); then

--- a/scripts/regen-lock.sh
+++ b/scripts/regen-lock.sh
@@ -12,7 +12,7 @@
 set -euo pipefail
 unset TMOUT
 
-PIP_TOOLS_VERSION="7.5.3"   # keep in lock-step with .github/workflows/ci.yml lock-audit
+PIP_TOOLS_VERSION="7.6.1"   # keep in lock-step with .github/workflows/ci.yml lock-audit
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$REPO_ROOT"
 


### PR DESCRIPTION
## What's broken

The **lock-audit** job (`requirements.lock faithful to the runtime Python`) is failing on **every branch, including `main`** — not just on open PRs. It has nothing to do with the changes in the PRs it's blocking.

```
ImportError: cannot import name 'stdlib_pkgs'
  from 'pip._internal.utils.compat'
```

## Why

The job pins pip-tools but installs **whatever pip the runner ships**, which is now **pip 26.2.1**:

```
Requirement already satisfied: pip>=22.2 ... (26.2.1)
```

pip-tools 7.5.3 imports `stdlib_pkgs` in `piptools/sync.py`. pip removed that name from its private `pip._internal` API. Because pip-tools reaches into a private API, a floating pip can break a pinned pip-tools at any time — which is exactly what happened.

The import is reached even though the job only runs `pip-compile`: click's config-file validation (`override_defaults_from_config_file` → `_validate_config`) imports the sync CLI, so the job dies before compiling anything.

## Verification

Reproduced against this repo's own `pyproject.toml`, then confirmed the fix:

| Combination | Result |
|---|---|
| pip-tools **7.5.3** + pip 26.2.1 | the exact CI `ImportError` |
| pip-tools **7.6.1** + pip 26.2.1 | `pip-compile` succeeds |

Then ran the repo's own `./scripts/regen-lock.sh` under 7.6.1 (in `python:3.14-slim`, as the script does) and compared using CI's exact comparison:

```
Regenerating requirements.lock in python:3.14-slim (pip-tools==7.6.1)...
→ requirements.lock byte-identical to the committed one
→ diff -u <(grep -v '^#' committed) <(grep -v '^#' fresh)  →  PASS
```

So this is a **pure toolchain fix** — no lock churn, no dependency movement.

## Both pins move together

The two pins are explicitly meant to stay in lock-step, and the comment in `regen-lock.sh` says so:

- `.github/workflows/ci.yml:131` — the lock-audit
- `scripts/regen-lock.sh:15` — `PIP_TOOLS_VERSION`

Bumping only one would validate the lock with a different resolver than generated it — the precise drift that comment guards against.

## Note for the next bump

7.6.1 emits:

> `--strip-extras` is becoming the default in version 8.0.0

So a future 8.x bump **will** change lock output and will need a real `regen-lock.sh` run plus a committed lock change. Worth knowing before that one looks like a no-op too.

## Unblocks

#167 (`chore(main): release 2.6.8`) is otherwise clean — every other check passes; this was its only red.