### PR TITLE
fix: drop a remembered dependent when its NetworkMode no longer shares gluetun's netns

### DIFF
--- a/gluetun_monitor/monitor.py
+++ b/gluetun_monitor/monitor.py
@@ -719,7 +719,8 @@ class Monitor:
 
     def _resolve_dependents(self) -> list[str]:
         """Current dependent set: discovery (or manual list) unioned with the
-        remembered set, pruned to containers that still exist, minus EXCLUDE.
+        remembered set, pruned to containers that still exist AND still plausibly
+        share gluetun's netns, minus EXCLUDE.
 
         A name that came from an explicit ``DEPENDENT_CONTAINERS`` list but does
         not exist is a likely misconfiguration — warn loudly (deduped) rather
@@ -740,14 +741,26 @@ class Monitor:
         self._known_dependents.update(
             name for name, exists in present.items() if exists and not is_parked_name(name)
         )
-        # Prune the remembered set to containers that still exist. Reuse the
-        # existence we already learned for the current names; only inspect a
-        # remembered name we haven't already checked this loop (e.g. one stranded
-        # by a gluetun recreate, so current-id discovery no longer surfaces it).
+        # Prune the remembered set to containers that still exist AND whose
+        # NetworkMode still looks like it could share gluetun's netns. Reuse the
+        # existence we already learned for the current names (those came from
+        # live discovery, so they're container-mode by construction — no need to
+        # re-inspect). For a remembered name NOT in this loop's discovery, only
+        # existing is not enough: it may be legitimately stranded on a stale
+        # gluetun id (keep — the id-continuity case this memory exists for), or
+        # it may have been reconfigured (e.g. its compose file dropped
+        # ``network_mode: container:gluetun`` entirely) to plain bridge/host/no
+        # networking at all, in which case it is simply no longer a dependent and
+        # must be dropped even though the container itself is still alive under
+        # the same name — the previous check ("does inspect() return non-None")
+        # could never tell these two cases apart, so a container that outlived
+        # its gluetun dependency stayed phantom-managed forever.
         existence = dict(present)
         for d in self._known_dependents:
-            if d not in existence:
-                existence[d] = self.client.inspect(d) is not None
+            if d in existence:
+                continue
+            info = self.client.inspect(d)
+            existence[d] = info is not None and info.network_mode.startswith("container:")
         self._known_dependents = {d for d in self._known_dependents if existence.get(d, False)}
         # Mirror the pruned remembered set into the durable memory (#97) so a
         # monitor restart resumes with exactly what this instance knew.

--- a/tests/test_resolve_dependents.py
+++ b/tests/test_resolve_dependents.py
@@ -61,3 +61,31 @@ def test_remembered_but_gone_dependent_is_pruned() -> None:
 
     fake.remove("dep", volumes=False)  # disappears
     assert mon._resolve_dependents() == []  # pruned from the remembered set
+
+
+def test_remembered_dependent_reconfigured_off_gluetun_is_pruned() -> None:
+    """A remembered name whose container was recreated under plain bridge
+    networking (compose dropped ``network_mode: container:gluetun`` entirely) is
+    no longer a dependent, even though it still exists under the same name.
+
+    Existence alone can't distinguish this from the legitimate stale-id-stranded
+    case the remembered set exists for (ADR-0014) — only the current NetworkMode
+    can. Without this check the name would be phantom-managed forever, since
+    nothing else ever removes a name from ``known_dependents`` except the
+    container disappearing outright. Auto-discovery (the real deployment's mode)
+    is what actually exercises this: a manual ``DEPENDENT_CONTAINERS`` list is
+    taken at face value regardless of NetworkMode, by design.
+    """
+    fake = _CountingClient()
+    fake.add_container("gluetun", id=GLUETUN_ID)
+    fake.add_container("dep", network_mode=f"container:{GLUETUN_ID}")
+    mon = _mon(fake)  # default dependent_containers="auto"
+    assert mon._resolve_dependents() == ["dep"]  # dep now remembered
+
+    # Simulate a real recreate: old container gone, new one under the same name
+    # with unrelated (non-container-mode) networking. Auto-discovery no longer
+    # finds it (NetworkMode doesn't match gluetun), so this only reaches the
+    # remembered-set prune path being tested here.
+    fake.remove("dep", volumes=False)
+    fake.add_container("dep", network_mode="bridge")
+    assert mon._resolve_dependents() == []  # no longer a dependent, though it exists


### PR DESCRIPTION
## Description

\`_resolve_dependents()\` pruned the \`known_dependents\` remembered set (ADR-0004/0014) only by container existence, never by whether the container's current \`NetworkMode\` still plausibly shares gluetun's network namespace. That check exists to survive a dependent stranded on a *stale gluetun id* after a recreate (an id-continuity problem) — it was never meant to handle a dependent being *deliberately reconfigured* (e.g. its own compose file dropping \`network_mode: container:gluetun\` entirely) to stop being a dependent at all.

Once a name landed in \`known_dependents\`, nothing except the container disappearing outright ever removed it. So a container that legitimately moved off gluetun's netns stayed phantom-managed forever: probed every loop, "remediated" (restarted) on any transient blip, and eventually flagged WEDGED — despite being perfectly healthy on its own new network.

**Fix:** a remembered name not covered by this loop's live discovery is now kept only if it still exists **and** its \`NetworkMode\` still starts with \`container:\` — preserving every legitimate keep case (current-gluetun-id, historical-id-stranded, unknown name-form) while dropping anything reconfigured to plain bridge/host/other networking.

Reproduced live on my own deployment: pulling \`jackett\` out of a gluetun-shared netns (moving it to its own bridge network, since it turned out gluetun's AirVPN exit IP was being blocked by two of its indexer targets) left it in \`known_dependents\` indefinitely, with the monitor trying to restart it every loop until it hit the WEDGED escalation.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [x] I have tested my changes locally
- [x] I have added tests that prove my fix works
- [x] My changes don't add any new dependencies
- [x] Full suite passes: 598 passed, 1 skipped (real-Docker-socket test, environment-gated)
- [x] \`ruff check\` and \`mypy\` (strict) both clean

## Testing

Added \`test_remembered_dependent_reconfigured_off_gluetun_is_pruned\` in \`tests/test_resolve_dependents.py\`, modeled on the existing \`test_remembered_but_gone_dependent_is_pruned\` in the same file. It simulates a real recreate (remove + re-add under the same name with \`network_mode="bridge"\`) via auto-discovery — the manual \`DEPENDENT_CONTAINERS\` path takes names at face value regardless of \`NetworkMode\` by design, so it wouldn't exercise this bug.

Also manually reproduced and verified the fix operationally against the live incident (state-file hand-edit + monitor restart cleared the phantom \`jackett\` entry immediately) before writing the code fix, to confirm the diagnosis before touching source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MFS6Haqvdjr1ocM5eGW9zz